### PR TITLE
Improve copying of custom cells and editors with custom swing components to plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 - *com.mbeddr.mpsutil.grammarcells* The default transformation text for optional cells was improved.
 - *de.itemis.mps.linenumbers* Line numbers should show again on first editor opening. They were disabled for VCS editor components.
 - *de.itemis.mps.linenumbers* Line numbers are now rendered center-aligned in the left column.
+- Copying of custom cells and editors with custom swing components to plain text was improved.
 
 ## July 2025
 

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
@@ -2787,7 +2787,7 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="10diQxZUlIo" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>
@@ -3173,7 +3173,7 @@
                       </node>
                     </node>
                     <node concept="2AHcQZ" id="10diQxZY6ZC" role="2AJF6D">
-                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                     </node>
                   </node>
                 </node>

--- a/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
+++ b/code/blutil/languages/com.mbeddr.mpsutil.blutil/languageModels/editor.mps
@@ -35,12 +35,13 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
     <import index="g3l6" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.model(MPS.Core/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="uddc" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.transformation(MPS.Editor/)" implicit="true" />
     <import index="tpch" ref="r:00000000-0000-4000-0000-011c8959028d(jetbrains.mps.lang.structure.editor)" implicit="true" />
     <import index="p15z" ref="63e0e566-5131-447e-90e3-12ea330e1a00/r:ac36bf27-36e9-407d-ba8e-953c68088e41(com.mbeddr.mpsutil.blutil/com.mbeddr.mpsutil.blutil.behavior)" implicit="true" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -2766,6 +2767,29 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3clFb_" id="10diQxZUlIi" role="jymVt">
+                    <property role="TrG5h" value="renderText" />
+                    <node concept="3Tm1VV" id="10diQxZUlIj" role="1B3o_S" />
+                    <node concept="3uibUv" id="10diQxZUlIl" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="10diQxZUlIn" role="3clF47">
+                      <node concept="3clFbF" id="10diQxZVm_j" role="3cqZAp">
+                        <node concept="2ShNRf" id="10diQxZUJWi" role="3clFbG">
+                          <node concept="1pGfFk" id="10diQxZUKSD" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="10diQxZVngQ" role="37wK5m">
+                              <property role="Xl_RC" value="]" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="10diQxZUlIo" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -3127,6 +3151,29 @@
                           <property role="3clFbU" value="true" />
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="10diQxZY6Zw" role="jymVt">
+                    <property role="TrG5h" value="renderText" />
+                    <node concept="3Tm1VV" id="10diQxZY6Zx" role="1B3o_S" />
+                    <node concept="3uibUv" id="10diQxZY6Zy" role="3clF45">
+                      <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                    </node>
+                    <node concept="3clFbS" id="10diQxZY6Zz" role="3clF47">
+                      <node concept="3clFbF" id="10diQxZY6Z$" role="3cqZAp">
+                        <node concept="2ShNRf" id="10diQxZY6Z_" role="3clFbG">
+                          <node concept="1pGfFk" id="10diQxZY6ZA" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                            <node concept="Xl_RD" id="10diQxZY6ZB" role="37wK5m">
+                              <property role="Xl_RC" value="[" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="10diQxZY6ZC" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" />
                     </node>
                   </node>
                 </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -3456,6 +3456,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="inTShh7EvG" role="3bR37C">
+          <node concept="3bR9La" id="inTShh7EvH" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2Xjt3l57bIF" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
@@ -19,7 +19,8 @@
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="gsia" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.event(JDK/)" />
     <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
-    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" implicit="true" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -34,11 +35,18 @@
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -53,6 +61,12 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
@@ -66,6 +80,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -88,6 +105,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -107,6 +125,7 @@
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -128,11 +147,19 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
         <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
@@ -144,6 +171,9 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
+        <property id="1200397540847" name="charConstant" index="1XhdNS" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
@@ -589,12 +619,63 @@
         <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
       </node>
       <node concept="3clFbS" id="2qBpcrwlhaA" role="3clF47">
+        <node concept="3cpWs8" id="10diQy0kYvH" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0kYvI" role="3cpWs9">
+            <property role="TrG5h" value="withOfOneDash" />
+            <node concept="10Oyi0" id="10diQy0kYcZ" role="1tU5fm" />
+            <node concept="2OqwBi" id="10diQy0kYvJ" role="33vP2m">
+              <node concept="2OqwBi" id="10diQy0kYvK" role="2Oq$k0">
+                <node concept="1rXfSq" id="10diQy0kYvL" role="2Oq$k0">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+                <node concept="liA8E" id="10diQy0kYvM" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                </node>
+              </node>
+              <node concept="liA8E" id="10diQy0kYvN" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getWidth(char,int)" resolve="getWidth" />
+                <node concept="1Xhbcc" id="10diQy0kYvO" role="37wK5m">
+                  <property role="1XhdNS" value="-" />
+                </node>
+                <node concept="3cmrfG" id="10diQy0kYvP" role="37wK5m">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0l4Q9" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0l4Qc" role="3cpWs9">
+            <property role="TrG5h" value="numberOfDashes" />
+            <node concept="10Oyi0" id="10diQy0l4Q7" role="1tU5fm" />
+            <node concept="FJ1c_" id="10diQy0l9nA" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0l9Vp" role="3uHU7w">
+                <ref role="3cqZAo" node="10diQy0kYvI" resolve="withOfOneDash" />
+              </node>
+              <node concept="1rXfSq" id="10diQy0l6Z$" role="3uHU7B">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getWidth()" resolve="getWidth" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs6" id="2qBpcrwljpM" role="3cqZAp">
           <node concept="2ShNRf" id="2qBpcrwljvh" role="3cqZAk">
             <node concept="1pGfFk" id="2qBpcrwlDsE" role="2ShVmc">
               <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
-              <node concept="Xl_RD" id="2qBpcrwlE3f" role="37wK5m">
-                <property role="Xl_RC" value="------------------------------" />
+              <node concept="2OqwBi" id="10diQy0lfWg" role="37wK5m">
+                <node concept="2YIFZM" id="10diQy0lc0B" role="2Oq$k0">
+                  <ref role="37wK5l" to="wyt6:~String.valueOf(char)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                  <node concept="1Xhbcc" id="10diQy0lcx$" role="37wK5m">
+                    <property role="1XhdNS" value="-" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="10diQy0lh$J" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.repeat(int)" resolve="repeat" />
+                  <node concept="37vLTw" id="10diQy0li9I" role="37wK5m">
+                    <ref role="3cqZAo" node="10diQy0l4Qc" resolve="numberOfDashes" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -1427,14 +1508,164 @@
         <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
       </node>
       <node concept="3clFbS" id="7d0q5VH9zS8" role="3clF47">
-        <node concept="3cpWs6" id="7d0q5VH9zS9" role="3cqZAp">
-          <node concept="2ShNRf" id="7d0q5VH9zSa" role="3cqZAk">
-            <node concept="1pGfFk" id="7d0q5VH9zSb" role="2ShVmc">
-              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
-              <node concept="Xl_RD" id="7d0q5VH9zSc" role="37wK5m">
-                <property role="Xl_RC" value="|" />
+        <node concept="3cpWs8" id="10diQy0mxks" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0mxkr" role="3cpWs9">
+            <property role="TrG5h" value="settings" />
+            <node concept="3uibUv" id="10diQy0mxkt" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorSettings" resolve="EditorSettings" />
+            </node>
+            <node concept="2YIFZM" id="10diQy0mxY7" role="33vP2m">
+              <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+              <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0mHsb" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0mHsc" role="3cpWs9">
+            <property role="TrG5h" value="editorComponentSettings" />
+            <node concept="3uibUv" id="10diQy0mGZP" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorComponentSettings" resolve="EditorComponentSettings" />
+            </node>
+            <node concept="2OqwBi" id="10diQy0mHsd" role="33vP2m">
+              <node concept="1rXfSq" id="10diQy0mHse" role="2Oq$k0">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+              </node>
+              <node concept="liA8E" id="10diQy0mHsf" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0mRiS" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0mRiT" role="3cpWs9">
+            <property role="TrG5h" value="fontMetrics" />
+            <node concept="3uibUv" id="10diQy0mQT_" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorFontMetrics" resolve="EditorFontMetrics" />
+            </node>
+            <node concept="2OqwBi" id="10diQy0mRiU" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0mRiV" role="2Oq$k0">
+                <ref role="3cqZAo" node="10diQy0mHsc" resolve="editorComponentSettings" />
+              </node>
+              <node concept="liA8E" id="10diQy0mRiW" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorFontMetricsProvider.getFontMetrics(java.lang.String,int,int)" resolve="getFontMetrics" />
+                <node concept="2OqwBi" id="10diQy0mRiX" role="37wK5m">
+                  <node concept="37vLTw" id="10diQy0mRiY" role="2Oq$k0">
+                    <ref role="3cqZAo" node="10diQy0mxkr" resolve="settings" />
+                  </node>
+                  <node concept="liA8E" id="10diQy0mRiZ" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~EditorSettings.getFontFamily()" resolve="getFontFamily" />
+                  </node>
+                </node>
+                <node concept="10M0yZ" id="10diQy0mRj0" role="37wK5m">
+                  <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
+                  <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
+                </node>
+                <node concept="2OqwBi" id="10diQy0mRj1" role="37wK5m">
+                  <node concept="37vLTw" id="10diQy0mRj2" role="2Oq$k0">
+                    <ref role="3cqZAo" node="10diQy0mHsc" resolve="editorComponentSettings" />
+                  </node>
+                  <node concept="liA8E" id="10diQy0mRj3" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getFontSize()" resolve="getFontSize" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0lnXf" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0lnXg" role="3cpWs9">
+            <property role="TrG5h" value="heightOfOneDash" />
+            <node concept="10Oyi0" id="10diQy0lnXh" role="1tU5fm" />
+            <node concept="2OqwBi" id="10diQy0mUcq" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0mT_B" role="2Oq$k0">
+                <ref role="3cqZAo" node="10diQy0mRiT" resolve="fontMetrics" />
+              </node>
+              <node concept="liA8E" id="10diQy0mUXf" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorFontMetrics.getHeight()" resolve="getHeight" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="10diQy0mtgp" role="3cqZAp" />
+        <node concept="3cpWs8" id="10diQy0luMT" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0luMU" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="10diQy0luMV" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+            </node>
+            <node concept="2ShNRf" id="10diQy0lw_b" role="33vP2m">
+              <node concept="1pGfFk" id="10diQy0lx$d" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0lnXp" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0lnXq" role="3cpWs9">
+            <property role="TrG5h" value="numberOfDashes" />
+            <node concept="10Oyi0" id="10diQy0lnXr" role="1tU5fm" />
+            <node concept="FJ1c_" id="10diQy0lnXs" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0lnXt" role="3uHU7w">
+                <ref role="3cqZAo" node="10diQy0lnXg" resolve="withOfOneDash" />
+              </node>
+              <node concept="2OqwBi" id="10diQy0miNB" role="3uHU7B">
+                <node concept="1rXfSq" id="10diQy0lnXu" role="2Oq$k0">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getParent()" resolve="getParent" />
+                </node>
+                <node concept="liA8E" id="10diQy0mkDD" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getHeight()" resolve="getHeight" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="10diQy0lz3I" role="3cqZAp">
+          <node concept="3clFbS" id="10diQy0lz3K" role="2LFqv$">
+            <node concept="3clFbF" id="10diQy0lJHX" role="3cqZAp">
+              <node concept="2OqwBi" id="10diQy0lKka" role="3clFbG">
+                <node concept="37vLTw" id="10diQy0lJHV" role="2Oq$k0">
+                  <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="10diQy0lKZ9" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                  <node concept="2ShNRf" id="10diQy0lLKP" role="37wK5m">
+                    <node concept="1pGfFk" id="10diQy0lMBr" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                      <node concept="Xl_RD" id="10diQy0lNgy" role="37wK5m">
+                        <property role="Xl_RC" value="|" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="10diQy0lz3L" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="10diQy0lzA3" role="1tU5fm" />
+            <node concept="3cmrfG" id="10diQy0l_q4" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="10diQy0lGqq" role="1Dwp0S">
+            <node concept="37vLTw" id="10diQy0lIaP" role="3uHU7w">
+              <ref role="3cqZAo" node="10diQy0lnXq" resolve="numberOfDashes" />
+            </node>
+            <node concept="37vLTw" id="10diQy0lDd5" role="3uHU7B">
+              <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="10diQy0lJ5Q" role="1Dwrff">
+            <node concept="37vLTw" id="10diQy0lJ5S" role="2$L3a6">
+              <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="10diQy0lOt1" role="3cqZAp">
+          <node concept="37vLTw" id="10diQy0lOsZ" role="3clFbG">
+            <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
           </node>
         </node>
       </node>

--- a/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
+++ b/code/celllayout/solutions/de.slisson.mps.editor.celllayout.runtime/models/de/itemis/mps/editor/celllayout/runtime/cells.mps
@@ -1607,7 +1607,7 @@
             <node concept="10Oyi0" id="10diQy0lnXr" role="1tU5fm" />
             <node concept="FJ1c_" id="10diQy0lnXs" role="33vP2m">
               <node concept="37vLTw" id="10diQy0lnXt" role="3uHU7w">
-                <ref role="3cqZAo" node="10diQy0lnXg" resolve="withOfOneDash" />
+                <ref role="3cqZAo" node="10diQy0lnXg" resolve="heightOfOneDash" />
               </node>
               <node concept="2OqwBi" id="10diQy0miNB" role="3uHU7B">
                 <node concept="1rXfSq" id="10diQy0lnXu" role="2Oq$k0">

--- a/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
+++ b/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
@@ -518,7 +518,7 @@
                                 </node>
                               </node>
                               <node concept="2AHcQZ" id="inTShirt9p" role="2AJF6D">
-                                <ref role="2AI5Lk" to="wyt6:~Override" />
+                                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                               </node>
                             </node>
                           </node>
@@ -1314,7 +1314,7 @@
                                       </node>
                                     </node>
                                     <node concept="2AHcQZ" id="inTShipgu2" role="2AJF6D">
-                                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                                     </node>
                                   </node>
                                 </node>
@@ -1850,7 +1850,7 @@
                           </node>
                         </node>
                         <node concept="2AHcQZ" id="inTShimTVn" role="2AJF6D">
-                          <ref role="2AI5Lk" to="wyt6:~Override" />
+                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                         </node>
                       </node>
                     </node>

--- a/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
+++ b/code/compare/languages/com.mbeddr.mpsutil.compare/languageModels/editor.mps
@@ -31,6 +31,7 @@
     <import index="qjvf" ref="r:82cadfba-0fcc-402e-8eaa-37395d383fb6(com.mbeddr.mpsutil.compare.behavior)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tpc5" ref="r:00000000-0000-4000-0000-011c89590299(jetbrains.mps.lang.editor.editor)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -227,7 +228,6 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -243,6 +243,11 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
@@ -484,8 +489,39 @@
                         <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
                       </node>
                       <node concept="2ShNRf" id="6Od11GY5Tpi" role="33vP2m">
-                        <node concept="1pGfFk" id="6Od11GY5Tph" role="2ShVmc">
-                          <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;()" resolve="JBCheckBox" />
+                        <node concept="YeOm9" id="inTShirt1e" role="2ShVmc">
+                          <node concept="1Y3b0j" id="inTShirt1h" role="YeSDq">
+                            <property role="2bfB8j" value="true" />
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;()" resolve="JBCheckBox" />
+                            <ref role="1Y3XeK" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
+                            <node concept="3Tm1VV" id="inTShirt1i" role="1B3o_S" />
+                            <node concept="3clFb_" id="inTShirt96" role="jymVt">
+                              <property role="TrG5h" value="toString" />
+                              <node concept="3Tm1VV" id="inTShirt97" role="1B3o_S" />
+                              <node concept="3uibUv" id="inTShirt99" role="3clF45">
+                                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                              </node>
+                              <node concept="3clFbS" id="inTShirt9o" role="3clF47">
+                                <node concept="3clFbF" id="inTShirB9b" role="3cqZAp">
+                                  <node concept="3K4zz7" id="inTShirB9c" role="3clFbG">
+                                    <node concept="Xl_RD" id="inTShirB9d" role="3K4E3e">
+                                      <property role="Xl_RC" value="☒" />
+                                    </node>
+                                    <node concept="Xl_RD" id="inTShirB9e" role="3K4GZi">
+                                      <property role="Xl_RC" value="☐" />
+                                    </node>
+                                    <node concept="1rXfSq" id="inTShirB9f" role="3K4Cdx">
+                                      <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2AHcQZ" id="inTShirt9p" role="2AJF6D">
+                                <ref role="2AI5Lk" to="wyt6:~Override" />
+                              </node>
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1254,11 +1290,33 @@
                               <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
                             </node>
                             <node concept="2ShNRf" id="5gDLJkKJbYs" role="33vP2m">
-                              <node concept="1pGfFk" id="5gDLJkKJbYt" role="2ShVmc">
-                                <property role="373rjd" value="true" />
-                                <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
-                                <node concept="Xl_RD" id="5gDLJkKJbYu" role="37wK5m">
-                                  <property role="Xl_RC" value="..." />
+                              <node concept="YeOm9" id="inTShipeXm" role="2ShVmc">
+                                <node concept="1Y3b0j" id="inTShipeXp" role="YeSDq">
+                                  <property role="2bfB8j" value="true" />
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="dxuu:~JButton.&lt;init&gt;(java.lang.String)" resolve="JButton" />
+                                  <ref role="1Y3XeK" to="dxuu:~JButton" resolve="JButton" />
+                                  <node concept="3Tm1VV" id="inTShipeXq" role="1B3o_S" />
+                                  <node concept="Xl_RD" id="5gDLJkKJbYu" role="37wK5m">
+                                    <property role="Xl_RC" value="..." />
+                                  </node>
+                                  <node concept="3clFb_" id="inTShipgtN" role="jymVt">
+                                    <property role="TrG5h" value="toString" />
+                                    <node concept="3Tm1VV" id="inTShipgtO" role="1B3o_S" />
+                                    <node concept="3uibUv" id="inTShipgtQ" role="3clF45">
+                                      <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                                    </node>
+                                    <node concept="3clFbS" id="inTShipgu1" role="3clF47">
+                                      <node concept="3clFbF" id="inTShipkd8" role="3cqZAp">
+                                        <node concept="Xl_RD" id="inTShipkd7" role="3clFbG">
+                                          <property role="Xl_RC" value="path chooser" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2AHcQZ" id="inTShipgu2" role="2AJF6D">
+                                      <ref role="2AI5Lk" to="wyt6:~Override" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -1763,8 +1821,39 @@
                   <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
                 </node>
                 <node concept="2ShNRf" id="H43MYuWsRg" role="33vP2m">
-                  <node concept="1pGfFk" id="H43MYuWsRh" role="2ShVmc">
-                    <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;()" resolve="JBCheckBox" />
+                  <node concept="YeOm9" id="inTShimTNc" role="2ShVmc">
+                    <node concept="1Y3b0j" id="inTShimTNf" role="YeSDq">
+                      <property role="2bfB8j" value="true" />
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;()" resolve="JBCheckBox" />
+                      <ref role="1Y3XeK" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
+                      <node concept="3Tm1VV" id="inTShimTNg" role="1B3o_S" />
+                      <node concept="3clFb_" id="inTShimTV4" role="jymVt">
+                        <property role="TrG5h" value="toString" />
+                        <node concept="3Tm1VV" id="inTShimTV5" role="1B3o_S" />
+                        <node concept="3uibUv" id="inTShimTV7" role="3clF45">
+                          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                        </node>
+                        <node concept="3clFbS" id="inTShimTVm" role="3clF47">
+                          <node concept="3clFbF" id="inTShinabz" role="3cqZAp">
+                            <node concept="3K4zz7" id="inTShinnFu" role="3clFbG">
+                              <node concept="Xl_RD" id="inTShinouV" role="3K4E3e">
+                                <property role="Xl_RC" value="☒" />
+                              </node>
+                              <node concept="Xl_RD" id="inTShinwLr" role="3K4GZi">
+                                <property role="Xl_RC" value="☐" />
+                              </node>
+                              <node concept="1rXfSq" id="inTShioCJs" role="3K4Cdx">
+                                <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2AHcQZ" id="inTShimTVn" role="2AJF6D">
+                          <ref role="2AI5Lk" to="wyt6:~Override" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/de.itemis.mps.editor.diagram.demo.activity.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/de.itemis.mps.editor.diagram.demo.activity.mpl
@@ -18,6 +18,7 @@
     <dependency reexport="false">fa13cc63-c476-4d46-9c96-d53670abe7bc(de.itemis.mps.editor.diagram)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:3bdedd09-792a-4e15-a4db-83970df3ee86:de.itemis.mps.editor.collapsible" version="0" />
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="1" />
     <language slang="l:21063c66-85ba-4e98-839b-036445b17ae2:de.itemis.mps.editor.layout" version="0" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demo.activity/languageModels/editor.mps
@@ -6,6 +6,7 @@
     <use id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram" version="1" />
     <use id="3bdedd09-792a-4e15-a4db-83970df3ee86" name="de.itemis.mps.editor.collapsible" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -276,6 +277,9 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
     <language id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram">
       <concept id="6554619383003875357" name="de.itemis.mps.editor.diagram.structure.InlineEditorComponent" flags="ig" index="238au4" />
       <concept id="8433227566817223068" name="de.itemis.mps.editor.diagram.structure.LayeredLayoutAlgorithm" flags="ng" index="39fpm">
@@ -487,9 +491,7 @@
         </node>
         <node concept="2iRfu4" id="4XPshStfHp1" role="2iSdaV" />
       </node>
-      <node concept="3F0ifn" id="4XPshStfJuE" role="3EZMnx">
-        <property role="3F0ifm" value="---------------------------------------------" />
-      </node>
+      <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
       <node concept="3F2HdR" id="4XPshStfHpD" role="3EZMnx">
         <ref role="1NtTu8" to="vux5:4XPshStfHmi" resolve="content" />
         <node concept="2iRkQZ" id="4XPshStfHpF" role="2czzBx" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/de.itemis.mps.editor.diagram.demoentities.mpl
@@ -20,6 +20,7 @@
     <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="1" />
     <language slang="l:21063c66-85ba-4e98-839b-036445b17ae2:de.itemis.mps.editor.layout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
+++ b/code/diagram/languages/de.itemis.mps.editor.diagram.demoentities/languageModels/editor.mps
@@ -5,6 +5,7 @@
     <use id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram" version="1" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -219,6 +220,9 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
       <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
+    </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
     </language>
     <language id="fa13cc63-c476-4d46-9c96-d53670abe7bc" name="de.itemis.mps.editor.diagram">
       <concept id="6554619383003875357" name="de.itemis.mps.editor.diagram.structure.InlineEditorComponent" flags="ig" index="238au4" />
@@ -1052,12 +1056,7 @@
       <node concept="3F0A7n" id="4_qW8fWM_h9" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
-      <node concept="3F0ifn" id="4_qW8fWM_hf" role="3EZMnx">
-        <property role="3F0ifm" value="---" />
-        <node concept="VPxyj" id="4_qW8fWPjHz" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-      </node>
+      <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
       <node concept="3F2HdR" id="4_qW8fWM_hm" role="3EZMnx">
         <ref role="1NtTu8" to="g93z:4_qW8fWLenL" resolve="attributes" />
         <node concept="2iRkQZ" id="4_qW8fWM_hn" role="2czzBx" />

--- a/code/hacks/languages/de.itemis.mps.nativelibs/de.itemis.mps.nativelibs.mpl
+++ b/code/hacks/languages/de.itemis.mps.nativelibs/de.itemis.mps.nativelibs.mpl
@@ -55,6 +55,7 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/hacks/languages/de.itemis.mps.nativelibs/languageModels/editor.mps
+++ b/code/hacks/languages/de.itemis.mps.nativelibs/languageModels/editor.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
   </languages>
   <imports>
     <import index="9lvj" ref="r:96ef99ad-4777-4e07-b5ac-713fe7c8396a(de.itemis.mps.nativelibs.structure)" />
@@ -46,6 +47,10 @@
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828844315" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineColorStyle" flags="lg" index="2T_bXS" />
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
   </registry>
   <node concept="24kQdi" id="2H_mjOXpJcz">
     <ref role="1XX52x" to="9lvj:2H_mjOXpG70" resolve="NativeLibraries" />
@@ -53,9 +58,7 @@
       <node concept="3F0ifn" id="2H_mjOXpLb8" role="3EZMnx">
         <property role="3F0ifm" value="native libraries" />
       </node>
-      <node concept="3F0ifn" id="2H_mjOXpLbc" role="3EZMnx">
-        <property role="3F0ifm" value="----------------" />
-      </node>
+      <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
       <node concept="3F0ifn" id="2H_mjOXpLbn" role="3EZMnx">
         <node concept="VPM3Z" id="2H_mjOXpRtm" role="3F10Kt">
           <property role="VOm3f" value="false" />
@@ -84,9 +87,8 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3F0ifn" id="6r4GR4aevVR" role="3EZMnx">
-        <property role="3F0ifm" value="---------------------------------------" />
-        <node concept="VechU" id="6r4GR4aeG_H" role="3F10Kt">
+      <node concept="2T_mXK" id="inTShitOOX" role="3EZMnx">
+        <node concept="2T_bXS" id="inTShitOOY" role="3F10Kt">
           <property role="Vb096" value="fLJRk5A/lightGray" />
         </node>
       </node>

--- a/code/math/languages/de.itemis.mps.editor.math.demolang/languageModels/editor.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.demolang/languageModels/editor.mps
@@ -400,7 +400,7 @@
         <ref role="1NtTu8" to="96v7:73f6OzXxOZS" resolve="body" />
       </node>
       <node concept="1AGncr" id="4XhobVUfyBf" role="2dIXc_">
-        <ref role="1AGmCo" to="zva4:6vUATgmxhhb" resolve="ArrowLeft" />
+        <ref role="1AGmCo" to="zva4:6vUATgmxhhb" resolve="ArrowRight" />
       </node>
     </node>
   </node>

--- a/code/math/languages/de.itemis.mps.editor.math.notations/de.itemis.mps.editor.math.notations.mpl
+++ b/code/math/languages/de.itemis.mps.editor.math.notations/de.itemis.mps.editor.math.notations.mpl
@@ -108,6 +108,7 @@
     <dependency reexport="false">a9a7bf57-15e6-4d28-adc1-be146e415fe5(de.itemis.mps.editor.math.runtime)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/math/languages/de.itemis.mps.editor.math.notations/generator/template/main@generator.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.notations/generator/template/main@generator.mps
@@ -16,9 +16,11 @@
     <import index="diuo" ref="r:98c96203-129a-452b-86c3-5a06ed0a0d9e(de.itemis.mps.editor.math.notations.structure)" />
     <import index="zva4" ref="r:bd4abf95-b43c-45fd-92b4-452c4b7daf58(de.itemis.mps.editor.math.symbols)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -27,7 +29,7 @@
       </concept>
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
     </language>
@@ -79,6 +81,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -135,7 +140,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -152,7 +157,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
@@ -161,6 +166,7 @@
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -181,7 +187,7 @@
       </concept>
       <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
-      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ngI" index="v9R3L">
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
       </concept>
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
@@ -229,10 +235,12 @@
         <child id="175930839491748724" name="layoutFunction" index="2qw2Hu" />
         <child id="175930839491944693" name="paintFunction" index="2qxizv" />
         <child id="1330709772460755941" name="childCells" index="34RqEp" />
+        <child id="330987653115583073" name="renderTextFunction" index="1kqnR_" />
         <child id="9120555111513756053" name="symbols" index="1AH2$o" />
         <child id="9120555111509036276" name="sharedVariables" index="1Dj3hT" />
         <child id="8588142736409368490" name="initFunction" index="1F9M7V" />
       </concept>
+      <concept id="330987653115025311" name="de.itemis.mps.editor.math.structure.TextBuilderFunction" flags="ig" index="1kov0r" />
       <concept id="9120555111512623985" name="de.itemis.mps.editor.math.structure.UpdateDimensionFunction" flags="ig" index="1AxZfW" />
       <concept id="9120555111512624407" name="de.itemis.mps.editor.math.structure.Parameter_Dimension" flags="ng" index="1AxZmq" />
       <concept id="9120555111514385514" name="de.itemis.mps.editor.math.structure.MathSymbolReferenceExpression" flags="ng" index="1ACDjB">
@@ -246,6 +254,7 @@
         <child id="9120555111513755624" name="symbol" index="1AH3t_" />
       </concept>
       <concept id="9120555111528208049" name="de.itemis.mps.editor.math.structure.InlineMathSymbol" flags="ng" index="1B$qSW">
+        <child id="330987653119172907" name="renderTextFunction" index="1lCCqJ" />
         <child id="9120555111528208559" name="paintFunction" index="1B$q0y" />
         <child id="9120555111528208560" name="updateDimensionFunction" index="1B$q0X" />
       </concept>
@@ -313,7 +322,7 @@
         <property id="1757699476691236116" name="role_DebugInfo" index="2qtEX8" />
         <property id="1341860900488019036" name="linkId" index="P3scX" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -638,6 +647,21 @@
             </node>
           </node>
         </node>
+        <node concept="1kov0r" id="inTShhdTgA" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhdTgB" role="2VODD2">
+            <node concept="3clFbF" id="inTShhdTiO" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhdTiM" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhdTxJ" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhdTzR" role="37wK5m">
+                    <property role="Xl_RC" value="|" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="raruj" id="2_93Dm87xPe" role="lGtFl" />
       <node concept="3F0ifn" id="2_93Dm87xPf" role="1BQ6eu">
@@ -739,6 +763,21 @@
             </node>
           </node>
         </node>
+        <node concept="1kov0r" id="inTShhdTFW" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhdTFX" role="2VODD2">
+            <node concept="3clFbF" id="inTShhdTGI" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhdTGJ" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhdTGK" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhdTGL" role="37wK5m">
+                    <property role="Xl_RC" value="|" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1ZhdrF" id="3p9OysaldAu" role="lGtFl">
         <property role="2qtEX8" value="parentStyleClass" />
@@ -826,6 +865,21 @@
             </node>
           </node>
         </node>
+        <node concept="1kov0r" id="inTShhmbqN" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhmbqO" role="2VODD2">
+            <node concept="3clFbF" id="inTShhmbtv" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhmbtt" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhmb_k" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhmc7c" role="37wK5m">
+                    <property role="Xl_RC" value="{" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="raruj" id="2_93Dm840yB" role="lGtFl" />
       <node concept="3F0ifn" id="2_93Dm840yC" role="1BQ6eu">
@@ -885,6 +939,21 @@
                   <node concept="1AxZmq" id="2_93Dm84aFh" role="2Oq$k0" />
                   <node concept="2OwXpG" id="2_93Dm84aFi" role="2OqNvi">
                     <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1kov0r" id="inTShhmcfg" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhmcfh" role="2VODD2">
+            <node concept="3clFbF" id="inTShhmcgw" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhmcgx" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhmcgy" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhmcgz" role="37wK5m">
+                    <property role="Xl_RC" value="}" />
                   </node>
                 </node>
               </node>
@@ -1262,6 +1331,177 @@
                 </node>
                 <node concept="30H73N" id="3p9OysalmCl" role="2Oq$k0" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1kov0r" id="inTShhoC5P" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhoC5Q" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhoD6Y" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhoD6Z" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhoD70" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhtrer" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhtrv1" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtr$m" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtrKr" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtr$k" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtrV4" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtrXL" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtsf4" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtsf7" role="37wK5m">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtuf7" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtuic" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtutq" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtuia" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtuCP" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhoG7v" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhoEEC" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhoEz3" role="2Oq$k0">
+                      <ref role="34R20x" node="70CVChR5NPU" resolve="upper" />
+                    </node>
+                    <node concept="liA8E" id="inTShhoENs" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhoH5t" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtvFO" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtvK7" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtvK8" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtvK9" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtvKa" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtvKb" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtvKc" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtvKd" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtvKe" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhoH8m" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhoHgz" role="3clFbG">
+              <node concept="37vLTw" id="inTShhoH8k" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhoHtf" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhoHuP" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhoHBP" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhoHES" role="37wK5m">
+                      <property role="Xl_RC" value="/" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhoHOE" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtvUG" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtvUH" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtvUI" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtvUJ" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtvUK" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtvUL" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtvUM" role="37wK5m">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtvUN" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhoHSY" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhoI3a" role="3clFbG">
+              <node concept="37vLTw" id="inTShhoHSW" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhoId1" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhoJzp" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhoIqS" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhoIfe" role="2Oq$k0">
+                      <ref role="34R20x" node="70CVChR5NQ0" resolve="lower" />
+                    </node>
+                    <node concept="liA8E" id="inTShhoIAz" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhoKyO" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhoKLe" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtw1K" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtw1L" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtw1M" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtw1N" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtw1O" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtw1P" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtw1Q" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtw1R" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhoKD_" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhoKDz" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhoD6Z" resolve="builder" />
             </node>
           </node>
         </node>
@@ -2416,6 +2656,122 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShhrugN" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhrugO" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhrxE0" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhrxE1" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhrxE2" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhrxED" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhrxV0" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhwiCG" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhwiCI" role="3clFbx">
+              <node concept="3clFbF" id="inTShhryLk" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhryMb" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhryLi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhrxE1" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhryOo" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhrEUl" role="37wK5m">
+                      <node concept="2OqwBi" id="inTShhryWE" role="2Oq$k0">
+                        <node concept="34R21W" id="inTShhryPK" role="2Oq$k0">
+                          <ref role="34R20x" node="70CVChQO0aV" resolve="n" />
+                        </node>
+                        <node concept="liA8E" id="inTShhrEv8" role="2OqNvi">
+                          <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="inTShhrI9Q" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhrJjy" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="inTShhwiUM" role="3clFbw">
+              <node concept="10Nm6u" id="inTShhwj1d" role="3uHU7w" />
+              <node concept="34R21W" id="inTShhwiHf" role="3uHU7B">
+                <ref role="34R20x" node="70CVChQO0aV" resolve="n" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhrxXz" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhry6B" role="3clFbG">
+              <node concept="37vLTw" id="inTShhrxXx" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrxE1" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhryeI" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhrJFc" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhrJQ3" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhryfK" role="37wK5m">
+                      <property role="Xl_RC" value="√(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhrJZH" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhrK3x" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhrK3y" role="3clFbG">
+              <node concept="37vLTw" id="inTShhrK3z" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrxE1" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhrK3$" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhrK3_" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhrK3A" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhrK3B" role="2Oq$k0">
+                      <ref role="34R20x" node="70CVChQO0b5" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhrK3C" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhrK3D" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhrK3E" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShiJf8j" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShiJf8k" role="3clFbG">
+              <node concept="37vLTw" id="inTShiJf8l" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrxE1" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShiJf8m" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShiJf8n" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShiJf8o" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShiJf8p" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShiJf8q" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="7wCpClFsPS3">
@@ -2718,6 +3074,177 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShh1tsO" role="1kqnR_">
+        <node concept="3clFbS" id="inTShh1tsP" role="2VODD2">
+          <node concept="3cpWs8" id="inTShh1$pC" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShh1$pD" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShh1$oP" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhtV6l" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhtVmV" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtWt8" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtWC$" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtWt6" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtWOC" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtWOF" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtX6O" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtXap" role="37wK5m">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtXn9" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtVsg" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtVCl" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtVse" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtVMY" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShh1$pE" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShh1$pF" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShh1$pG" role="2Oq$k0">
+                      <ref role="34R20x" node="19RCnNmEI9D" resolve="base" />
+                    </node>
+                    <node concept="liA8E" id="inTShh1$pH" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShh1$pI" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtWkY" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtXr2" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtXr3" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtXr4" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtXr5" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtXr6" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtXr7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtXr8" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtXr9" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShh1yLy" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShh1$VJ" role="3clFbG">
+              <node concept="37vLTw" id="inTShh1$pJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShh1_4n" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShh1_5U" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShh1_nt" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShh1_nw" role="37wK5m">
+                      <property role="Xl_RC" value="^" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShh1_yB" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtX_B" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtX_C" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtX_D" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtX_E" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtX_F" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtX_G" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtX_H" role="37wK5m">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtX_I" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShh1_AP" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShh1_KY" role="3clFbG">
+              <node concept="37vLTw" id="inTShh1_AN" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShh1_UM" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShh1GRf" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShh1Efj" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShh1_WW" role="2Oq$k0">
+                      <ref role="34R20x" node="19RCnNmEIi7" resolve="exponent" />
+                    </node>
+                    <node concept="liA8E" id="inTShh1Eph" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShh1Jyk" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShh1JCW" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhtXPk" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhtXPl" role="3clFbG">
+              <node concept="37vLTw" id="inTShhtXPm" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhtXPn" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhtXPo" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhtXPp" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhtXPq" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhtXPr" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShh1JJP" role="3cqZAp">
+            <node concept="37vLTw" id="inTShh1JJN" role="3clFbG">
+              <ref role="3cqZAo" node="inTShh1$pD" resolve="builder" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="7wCpClFtaRO">
@@ -2885,6 +3412,21 @@
             </node>
           </node>
         </node>
+        <node concept="1kov0r" id="inTShhs$y9" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhs$ya" role="2VODD2">
+            <node concept="3clFbF" id="inTShhs$_z" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhs$_x" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhs$Ho" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhs$IJ" role="37wK5m">
+                    <property role="Xl_RC" value="[" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="raruj" id="2_93Dm84dMZ" role="lGtFl" />
       <node concept="3F0ifn" id="2_93Dm84dN0" role="1BQ6eu">
@@ -2985,6 +3527,21 @@
                   <node concept="1AxZmq" id="2_93Dm84kHd" role="2Oq$k0" />
                   <node concept="2OwXpG" id="2_93Dm84kHe" role="2OqNvi">
                     <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1kov0r" id="inTShhs$Rz" role="1lCCqJ">
+          <node concept="3clFbS" id="inTShhs$R$" role="2VODD2">
+            <node concept="3clFbF" id="inTShhs$RA" role="3cqZAp">
+              <node concept="2ShNRf" id="inTShhs$RB" role="3clFbG">
+                <node concept="1pGfFk" id="inTShhs$RC" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                  <node concept="Xl_RD" id="inTShhs$RD" role="37wK5m">
+                    <property role="Xl_RC" value="]" />
                   </node>
                 </node>
               </node>
@@ -4213,6 +4770,270 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShhqAbH" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhqAbI" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhqVWP" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhqVWQ" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhqVWR" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhqVWS" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhqVWT" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVWU" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVWV" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVWW" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVWX" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhqVWY" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhqVWZ" role="2Oq$k0">
+                    <ref role="1AC0ER" node="7UiI8Oob6Kh" resolve="loopSymbol" />
+                  </node>
+                  <node concept="liA8E" id="inTShhqVX0" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVX1" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVX2" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVX3" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVX4" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVX5" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhqVX6" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhqVX7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhqVX8" role="37wK5m">
+                      <property role="Xl_RC" value="_{" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVX9" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVXa" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVXb" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVXc" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVXd" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhqVXe" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhqVXf" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhqVXg" role="2Oq$k0">
+                      <ref role="34R20x" node="7UiI8OoQLnO" resolve="lower" />
+                    </node>
+                    <node concept="liA8E" id="inTShhqVXh" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhqVXi" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVXj" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhw6WL" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhw6WM" role="3clFbG">
+              <node concept="37vLTw" id="inTShhw6WN" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhw6WO" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhw6WP" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhw6WQ" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhw6WR" role="37wK5m">
+                      <property role="Xl_RC" value="}" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhw6WS" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVXk" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVXl" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVXm" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVXn" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhqVXo" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhqVXp" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhqVXq" role="37wK5m">
+                      <property role="Xl_RC" value="^{" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVXr" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVXs" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVXt" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVXu" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVXv" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhqVXw" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhqVXx" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhqVXy" role="2Oq$k0">
+                      <ref role="34R20x" node="7UiI8OoQLnP" resolve="upper" />
+                    </node>
+                    <node concept="liA8E" id="inTShhqVXz" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhqVX$" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVX_" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhw7uX" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhw7uY" role="3clFbG">
+              <node concept="37vLTw" id="inTShhw7uZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhw7v0" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhw7v1" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhw7v2" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhw7v3" role="37wK5m">
+                      <property role="Xl_RC" value="_}" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhw7v4" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhqVXA" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhqVXB" role="3clFbx">
+              <node concept="3clFbF" id="inTShhqVXC" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhqVXD" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhqVXE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhqVXF" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhqVXG" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhqVXH" role="2Oq$k0">
+                        <ref role="1AC0ER" node="7UiI8OotwKB" resolve="leftParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhqVXI" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhqVXJ" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJxdW" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJxKh" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJxKl" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJxlJ" role="3uHU7B">
+                  <ref role="1AC0ER" node="7UiI8OotwKB" resolve="leftParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhqVXK" role="3uHU7B">
+                <ref role="1DtDE4" node="QvUN5N1CtU" resolve="showParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhqVXL" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhqVXM" role="3clFbG">
+              <node concept="37vLTw" id="inTShhqVXN" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhqVXO" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhqVXP" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhqVXQ" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhqVXR" role="2Oq$k0">
+                      <ref role="34R20x" node="7UiI8OoQLnQ" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhqVXS" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhqVXT" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhqVXU" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhqVXV" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhqVXW" role="3clFbx">
+              <node concept="3clFbF" id="inTShhqVXX" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhqVXY" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhqVXZ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhqVY0" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhqVY1" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhqVY2" role="2Oq$k0">
+                        <ref role="1AC0ER" node="7UiI8Oot_EA" resolve="rightParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhqVY3" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhqVY4" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJxSy" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJy8q" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJy8u" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJy0l" role="3uHU7B">
+                  <ref role="1AC0ER" node="7UiI8Oot_EA" resolve="rightParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhqVY5" role="3uHU7B">
+                <ref role="1DtDE4" node="QvUN5N1CtU" resolve="showParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhroL2" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhroL0" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhqVWQ" resolve="builder" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="7UiI8Oph8NN">
@@ -4682,6 +5503,86 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShhdXe9" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhdXea" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhdYFw" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhdYFx" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhdYFy" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhdYG9" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhdYV6" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhdYZ3" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhdZ87" role="3clFbG">
+              <node concept="37vLTw" id="inTShhdYZ1" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhdYFx" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhdZge" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhdZz_" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhdZh5" role="2Oq$k0">
+                    <ref role="1AC0ER" node="7UiI8Opj55L" resolve="leftBracket" />
+                  </node>
+                  <node concept="liA8E" id="inTShhdZRy" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhe1ig" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhe1kO" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhe1ux" role="3clFbG">
+              <node concept="37vLTw" id="inTShhe1kM" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhdYFx" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhe1Bj" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhe3pF" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhe1MU" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhe1CP" role="2Oq$k0">
+                      <ref role="34R20x" node="7UiI8Opj0rJ" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhe1Wg" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhe6oy" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhe6un" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhe6zn" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhe6HZ" role="3clFbG">
+              <node concept="37vLTw" id="inTShhe6zl" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhdYFx" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhe6RZ" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhe7eN" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhe6UJ" role="2Oq$k0">
+                    <ref role="1AC0ER" node="7UiI8Opj6JV" resolve="rightBracket" />
+                  </node>
+                  <node concept="liA8E" id="inTShhe7yZ" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhebIe" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="73f6OzXu6FM">
@@ -4708,7 +5609,7 @@
       <node concept="1AH3oy" id="73f6OzXuBsh" role="1AH2$o">
         <property role="TrG5h" value="symbol" />
         <node concept="1AGncr" id="73f6OzXuBsi" role="1AH3t_">
-          <ref role="1AGmCo" to="zva4:6vUATgmxhhb" resolve="ArrowLeft" />
+          <ref role="1AGmCo" to="zva4:6vUATgmxhhb" resolve="ArrowRight" />
           <node concept="29HgVG" id="73f6OzXuBsj" role="lGtFl">
             <node concept="3NFfHV" id="73f6OzXuBsk" role="3NFExx">
               <node concept="3clFbS" id="73f6OzXuBsl" role="2VODD2">
@@ -4987,6 +5888,114 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShh4LZn" role="1kqnR_">
+        <node concept="3clFbS" id="inTShh4LZo" role="2VODD2">
+          <node concept="3cpWs8" id="inTShi38Ft" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShi38Fu" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShi38Fv" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShi3aUE" role="33vP2m">
+                <node concept="1pGfFk" id="inTShi3bbl" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShi3bgN" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShi3bsW" role="3clFbG">
+              <node concept="37vLTw" id="inTShi3bgL" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShi38Fu" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShi3bBD" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShi3bBG" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShi3bT4" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShi3bT7" role="37wK5m">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShi3ffl" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShi3gKl" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShi3gVr" role="3clFbG">
+              <node concept="37vLTw" id="inTShi3gKj" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShi38Fu" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShi3h6H" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShi391_" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShi391A" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShi391B" role="2Oq$k0">
+                      <ref role="34R20x" node="73f6OzXuBu2" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShi391C" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShi391D" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShi3ieR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShi3jEk" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShi3jEl" role="3clFbG">
+              <node concept="37vLTw" id="inTShi3jEm" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShi38Fu" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShi3jEn" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShi3jEo" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShi3jEp" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShi3jEq" role="37wK5m">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShi3jEr" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShi3jQ3" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShi3jQ4" role="3clFbG">
+              <node concept="37vLTw" id="inTShi3jQ5" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShi38Fu" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShi3jQ6" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShi3mkD" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShi3lYL" role="2Oq$k0">
+                    <ref role="1AC0ER" node="73f6OzXuBsh" resolve="symbol" />
+                  </node>
+                  <node concept="liA8E" id="inTShi3mDG" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShi3jQc" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShi3iSK" role="3cqZAp">
+            <node concept="37vLTw" id="inTShi3iSH" role="3clFbG">
+              <ref role="3cqZAo" node="inTShi38Fu" resolve="builder" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="4r1mNB_oBbJ">
@@ -5202,6 +6211,100 @@
                 </node>
                 <node concept="30H73N" id="3p9Oysalucc" role="2Oq$k0" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1kov0r" id="inTShhusof" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhusog" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhusSV" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhusSW" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhusSX" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2OqwBi" id="inTShhusSY" role="33vP2m">
+                <node concept="2OqwBi" id="inTShhusSZ" role="2Oq$k0">
+                  <node concept="34R21W" id="inTShhusT0" role="2Oq$k0">
+                    <ref role="34R20x" node="4r1mNB_oF0g" resolve="normal" />
+                  </node>
+                  <node concept="liA8E" id="inTShhusT1" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="inTShhusT2" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhusT3" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhusT4" role="3clFbG">
+              <node concept="37vLTw" id="inTShhusT5" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhusSW" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhusT6" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhusT7" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhusT8" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhusT9" role="37wK5m">
+                      <property role="Xl_RC" value="_{" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhusTa" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhusTb" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhusTc" role="3clFbG">
+              <node concept="37vLTw" id="inTShhusTd" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhusSW" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhusTe" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhusTf" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhusTg" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhusTh" role="2Oq$k0">
+                      <ref role="34R20x" node="4r1mNB_oF0p" resolve="subscript" />
+                    </node>
+                    <node concept="liA8E" id="inTShhusTi" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhusTj" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhusTk" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhusTl" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhusTm" role="3clFbG">
+              <node concept="37vLTw" id="inTShhusTn" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhusSW" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhusTo" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhusTp" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhusTq" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhusTr" role="37wK5m">
+                      <property role="Xl_RC" value="}" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhusTs" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhusTB" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhusTC" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhusSW" resolve="builder" />
             </node>
           </node>
         </node>
@@ -5617,6 +6720,124 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShhsC9m" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhsC9n" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhu9MP" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhu9MQ" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhu7nZ" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2OqwBi" id="inTShhu9MR" role="33vP2m">
+                <node concept="2OqwBi" id="inTShhu9MS" role="2Oq$k0">
+                  <node concept="34R21W" id="inTShhu9MT" role="2Oq$k0">
+                    <ref role="34R20x" node="4r1mNB_qxL5" resolve="normal" />
+                  </node>
+                  <node concept="liA8E" id="inTShhu9MU" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="inTShhu9MV" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhubjn" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhubsX" role="3clFbG">
+              <node concept="37vLTw" id="inTShhubjl" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhu9MQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhubA9" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhubBJ" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhubRV" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhubWx" role="37wK5m">
+                      <property role="Xl_RC" value="_{" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhuc8D" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhumcO" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhumcP" role="3clFbG">
+              <node concept="37vLTw" id="inTShhumcQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhu9MQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhumcR" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhumQD" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhumxE" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhumln" role="2Oq$k0">
+                      <ref role="34R20x" node="4r1mNB_qxLe" resolve="subscript" />
+                    </node>
+                    <node concept="liA8E" id="inTShhumHW" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhuotw" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhuo_Y" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhuci6" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhuci7" role="3clFbG">
+              <node concept="37vLTw" id="inTShhuci8" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhu9MQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhuci9" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhucia" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhucib" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhucic" role="37wK5m">
+                      <property role="Xl_RC" value="}" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhucid" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhuoE4" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhuoE5" role="3clFbG">
+              <node concept="37vLTw" id="inTShhuoE6" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhu9MQ" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhuoE7" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhuoE8" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhuoE9" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhuoEa" role="2Oq$k0">
+                      <ref role="34R20x" node="4r1mNB_qzah" resolve="argument" />
+                    </node>
+                    <node concept="liA8E" id="inTShhuoEb" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhuoEc" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhuoEd" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhu3xc" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhu9MW" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhu9MQ" resolve="renderText" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="4r1mNB_GT0M">
@@ -5697,6 +6918,21 @@
                       <property role="Xl_RC" value="d" />
                     </node>
                     <node concept="1D9iu6" id="4r1mNB_GX1f" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1kov0r" id="inTShhm$Iv" role="1lCCqJ">
+            <node concept="3clFbS" id="inTShhm$Iw" role="2VODD2">
+              <node concept="3clFbF" id="inTShhm$KV" role="3cqZAp">
+                <node concept="2ShNRf" id="inTShhm$KT" role="3clFbG">
+                  <node concept="1pGfFk" id="inTShhm$SK" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhm$SN" role="37wK5m">
+                      <property role="Xl_RC" value="d" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -7044,6 +8280,353 @@
           </node>
         </node>
       </node>
+      <node concept="1kov0r" id="inTShhm_mp" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhm_mq" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhmJdB" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhmJdC" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhmJdD" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhmJdM" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhmJsL" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhmJvk" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhmJCo" role="3clFbG">
+              <node concept="37vLTw" id="inTShhmJvi" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhmJKv" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhmKkE" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhmK3$" role="2Oq$k0">
+                    <ref role="1AC0ER" node="4r1mNB_GX0D" resolve="symbol" />
+                  </node>
+                  <node concept="liA8E" id="inTShhmKBo" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhmX0V" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhuMyl" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhuMyn" role="3clFbx">
+              <node concept="3clFbF" id="inTShhmX7e" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhmXiu" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhmX7c" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhmXrH" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2ShNRf" id="inTShhmXty" role="37wK5m">
+                      <node concept="1pGfFk" id="inTShhmXAL" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                        <node concept="Xl_RD" id="inTShhmXCT" role="37wK5m">
+                          <property role="Xl_RC" value="_{" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhmXM1" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="inTShhmXPB" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhmXPC" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhmXPD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhmXPE" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhn219" role="37wK5m">
+                      <node concept="2OqwBi" id="inTShhmYd7" role="2Oq$k0">
+                        <node concept="34R21W" id="inTShhmY2e" role="2Oq$k0">
+                          <ref role="34R20x" node="4r1mNB_GX1g" resolve="lower" />
+                        </node>
+                        <node concept="liA8E" id="inTShhmYSt" role="2OqNvi">
+                          <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="inTShhnaTi" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhmXPI" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="inTShhWX0v" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhWX0w" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhWX0x" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhWX0y" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2ShNRf" id="inTShhWX0z" role="37wK5m">
+                      <node concept="1pGfFk" id="inTShhWX0$" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                        <node concept="Xl_RD" id="inTShhWX0_" role="37wK5m">
+                          <property role="Xl_RC" value="}" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhWX0A" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="inTShhuNqk" role="3clFbw">
+              <node concept="10Nm6u" id="inTShhuN_C" role="3uHU7w" />
+              <node concept="34R21W" id="inTShhuMIM" role="3uHU7B">
+                <ref role="34R20x" node="4r1mNB_GX1g" resolve="lower" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhv6mg" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhv6mi" role="3clFbx">
+              <node concept="3clFbF" id="inTShhnaWA" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhnaWB" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhnaWC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhnaWD" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2ShNRf" id="inTShhnaWE" role="37wK5m">
+                      <node concept="1pGfFk" id="inTShhnaWF" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                        <node concept="Xl_RD" id="inTShhnaWG" role="37wK5m">
+                          <property role="Xl_RC" value="^{" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhnaWH" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="inTShhnbe6" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhnbe7" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhnbe8" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhnbe9" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhnbea" role="37wK5m">
+                      <node concept="2OqwBi" id="inTShhnbeb" role="2Oq$k0">
+                        <node concept="34R21W" id="inTShhnbec" role="2Oq$k0">
+                          <ref role="34R20x" node="4r1mNB_GX1p" resolve="upper" />
+                        </node>
+                        <node concept="liA8E" id="inTShhnbed" role="2OqNvi">
+                          <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="inTShhnbee" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhnbef" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="inTShhWX$2" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhWX$3" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhWX$4" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhWX$5" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2ShNRf" id="inTShhWX$6" role="37wK5m">
+                      <node concept="1pGfFk" id="inTShhWX$7" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                        <node concept="Xl_RD" id="inTShhWX$8" role="37wK5m">
+                          <property role="Xl_RC" value="}" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhWX$9" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="inTShhv6Mr" role="3clFbw">
+              <node concept="10Nm6u" id="inTShhv6Mv" role="3uHU7w" />
+              <node concept="34R21W" id="inTShhv6yH" role="3uHU7B">
+                <ref role="34R20x" node="4r1mNB_GX1p" resolve="upper" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhp7m_" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhp7mB" role="3clFbx">
+              <node concept="3clFbF" id="inTShhnsXW" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhnsXX" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhnsXY" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhnsXZ" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhnsY0" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhn_Pe" role="2Oq$k0">
+                        <ref role="1AC0ER" node="4r1mNB_GX10" resolve="leftParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhnsY4" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhnsY5" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJd2A" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJd_R" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJdHn" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJdaR" role="3uHU7B">
+                  <ref role="1AC0ER" node="4r1mNB_GX10" resolve="leftParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhp7Bn" role="3uHU7B">
+                <ref role="1DtDE4" node="QvUN5N4lP3" resolve="drawParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhnk2B" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhnk2C" role="3clFbG">
+              <node concept="37vLTw" id="inTShhnk2D" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhnk2E" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhnk2F" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhnk2G" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhnk2H" role="2Oq$k0">
+                      <ref role="34R20x" node="4r1mNB_GX1y" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhnk2I" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhnk2J" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhnk2K" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhpmuU" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhpmuW" role="3clFbx">
+              <node concept="3clFbF" id="inTShhnXq5" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhnXq6" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhnXq7" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhnXq8" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhnXq9" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhnXqa" role="2Oq$k0">
+                        <ref role="1AC0ER" node="4r1mNB_GX12" resolve="rightParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhnXqb" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhnXqc" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJdPM" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJeto" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJeHh" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJdY3" role="3uHU7B">
+                  <ref role="1AC0ER" node="4r1mNB_GX12" resolve="rightParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhpmFn" role="3uHU7B">
+                <ref role="1DtDE4" node="QvUN5N4lP3" resolve="drawParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhQ0ZD" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhQ0ZF" role="3clFbx">
+              <node concept="3clFbF" id="inTShho4$a" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShho4$b" role="3clFbG">
+                  <node concept="37vLTw" id="inTShho4$c" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShho4$d" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShho4$f" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhodp7" role="2Oq$k0">
+                        <ref role="1AC0ER" node="4r1mNB_GX14" resolve="dSymbol" />
+                      </node>
+                      <node concept="liA8E" id="inTShho4$h" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShho4$j" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="inTShhQ1AP" role="3clFbw">
+              <node concept="10Nm6u" id="inTShhQ1QT" role="3uHU7w" />
+              <node concept="1ACDjB" id="inTShhQ1bE" role="3uHU7B">
+                <ref role="1AC0ER" node="4r1mNB_GX14" resolve="dSymbol" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhvAaI" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhvAaK" role="3clFbx">
+              <node concept="3clFbF" id="inTShhoqiC" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhoqiD" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhoqiE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhoqiF" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhoqiG" role="37wK5m">
+                      <node concept="2OqwBi" id="inTShhoqiH" role="2Oq$k0">
+                        <node concept="34R21W" id="inTShhoz9a" role="2Oq$k0">
+                          <ref role="34R20x" node="4r1mNB_GX1F" resolve="variable" />
+                        </node>
+                        <node concept="liA8E" id="inTShhoqiJ" role="2OqNvi">
+                          <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="inTShhoqiK" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhoqiL" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="inTShhvAAT" role="3clFbw">
+              <node concept="10Nm6u" id="inTShhvAAX" role="3uHU7w" />
+              <node concept="34R21W" id="inTShhvAnb" role="3uHU7B">
+                <ref role="34R20x" node="4r1mNB_GX1F" resolve="variable" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhvSIe" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhvSIc" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhmJdC" resolve="builder" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13MO4I" id="3p9OysaCgJQ">
@@ -7354,6 +8937,86 @@
                   <ref role="3Tt5mk" to="tpc2:1cEk0X7fp1l" resolve="parentStyleClass" />
                 </node>
                 <node concept="30H73N" id="3p9OysaSl5W" role="2Oq$k0" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1kov0r" id="inTShhrUqF" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhrUqG" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhrWPb" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhrWPc" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhrWPd" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhrWPO" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhrX4L" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhrX7k" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhrXfm" role="3clFbG">
+              <node concept="37vLTw" id="inTShhrX7i" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrWPc" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhrXnt" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhrXFM" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhrXov" role="2Oq$k0">
+                    <ref role="1AC0ER" node="3p9OysaCj4o" resolve="leftBracket" />
+                  </node>
+                  <node concept="liA8E" id="inTShhrXYw" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhrY38" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhrY4I" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhrY4J" role="3clFbG">
+              <node concept="37vLTw" id="inTShhrY4K" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrWPc" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhrY4L" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhrYCK" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhrY4M" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhrYjx" role="2Oq$k0">
+                      <ref role="34R20x" node="3p9OysaCj6k" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhrY4O" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhrZWI" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhrY4P" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhrY84" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhrY85" role="3clFbG">
+              <node concept="37vLTw" id="inTShhrY86" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhrWPc" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhrY87" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhrY88" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhrY89" role="2Oq$k0">
+                    <ref role="1AC0ER" node="3p9OysaCj4x" resolve="rightBracket" />
+                  </node>
+                  <node concept="liA8E" id="inTShhrY8a" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhrY8b" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -8811,6 +10474,228 @@
                 </node>
                 <node concept="30H73N" id="3p9OysaSq2z" role="2Oq$k0" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1kov0r" id="inTShhskQm" role="1kqnR_">
+        <node concept="3clFbS" id="inTShhskQn" role="2VODD2">
+          <node concept="3cpWs8" id="inTShhspO7" role="3cqZAp">
+            <node concept="3cpWsn" id="inTShhspO8" role="3cpWs9">
+              <property role="TrG5h" value="builder" />
+              <node concept="3uibUv" id="inTShhspO9" role="1tU5fm">
+                <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+              </node>
+              <node concept="2ShNRf" id="inTShhspOa" role="33vP2m">
+                <node concept="1pGfFk" id="inTShhspOb" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspOc" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspOd" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspOe" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspOf" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhspOg" role="37wK5m">
+                  <node concept="1ACDjB" id="inTShhspOh" role="2Oq$k0">
+                    <ref role="1AC0ER" node="3p9OysaNjZK" resolve="loopSymbol" />
+                  </node>
+                  <node concept="liA8E" id="inTShhspOi" role="2OqNvi">
+                    <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspOj" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspOk" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspOl" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspOm" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspOn" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhspOo" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhspOp" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhspOq" role="37wK5m">
+                      <property role="Xl_RC" value="_" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspOr" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspOs" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspOt" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspOu" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspOv" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhspOw" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhspOx" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhspOy" role="2Oq$k0">
+                      <ref role="34R20x" node="3p9OysaNk0x" resolve="lower" />
+                    </node>
+                    <node concept="liA8E" id="inTShhspOz" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhspO$" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspO_" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspOA" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspOB" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspOC" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspOD" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2ShNRf" id="inTShhspOE" role="37wK5m">
+                  <node concept="1pGfFk" id="inTShhspOF" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                    <node concept="Xl_RD" id="inTShhspOG" role="37wK5m">
+                      <property role="Xl_RC" value="^" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspOH" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspOI" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspOJ" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspOK" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspOL" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhspOM" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhspON" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhspOO" role="2Oq$k0">
+                      <ref role="34R20x" node="3p9OysaNk0E" resolve="upper" />
+                    </node>
+                    <node concept="liA8E" id="inTShhspOP" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhspOQ" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspOR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhspOS" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhspOT" role="3clFbx">
+              <node concept="3clFbF" id="inTShhspOU" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhspOV" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhspOW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhspOX" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhspOY" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhspOZ" role="2Oq$k0">
+                        <ref role="1AC0ER" node="3p9OysaNjZT" resolve="leftParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhspP0" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhspP1" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJPhm" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJPP9" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJQ2U" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJPnZ" role="3uHU7B">
+                  <ref role="1AC0ER" node="3p9OysaNjZT" resolve="leftParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhspP2" role="3uHU7B">
+                <ref role="1DtDE4" node="3p9OysaNjZI" resolve="showParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspP3" role="3cqZAp">
+            <node concept="2OqwBi" id="inTShhspP4" role="3clFbG">
+              <node concept="37vLTw" id="inTShhspP5" role="2Oq$k0">
+                <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+              </node>
+              <node concept="liA8E" id="inTShhspP6" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                <node concept="2OqwBi" id="inTShhspP7" role="37wK5m">
+                  <node concept="2OqwBi" id="inTShhspP8" role="2Oq$k0">
+                    <node concept="34R21W" id="inTShhspP9" role="2Oq$k0">
+                      <ref role="34R20x" node="3p9OysaNk0N" resolve="body" />
+                    </node>
+                    <node concept="liA8E" id="inTShhspPa" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:43EHXy6GUHD" resolve="getEditorCell" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="inTShhspPb" role="2OqNvi">
+                    <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                  </node>
+                </node>
+                <node concept="3clFbT" id="inTShhspPc" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="inTShhspPd" role="3cqZAp">
+            <node concept="3clFbS" id="inTShhspPe" role="3clFbx">
+              <node concept="3clFbF" id="inTShhspPf" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShhspPg" role="3clFbG">
+                  <node concept="37vLTw" id="inTShhspPh" role="2Oq$k0">
+                    <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
+                  </node>
+                  <node concept="liA8E" id="inTShhspPi" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheRight(jetbrains.mps.openapi.editor.TextBuilder,boolean)" resolve="appendToTheRight" />
+                    <node concept="2OqwBi" id="inTShhspPj" role="37wK5m">
+                      <node concept="1ACDjB" id="inTShhspPk" role="2Oq$k0">
+                        <ref role="1AC0ER" node="3p9OysaNk0d" resolve="rightParenthesis" />
+                      </node>
+                      <node concept="liA8E" id="inTShhspPl" role="2OqNvi">
+                        <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="inTShhspPm" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="inTShhJRav" role="3clFbw">
+              <node concept="3y3z36" id="inTShhJRnN" role="3uHU7w">
+                <node concept="10Nm6u" id="inTShhJRuy" role="3uHU7w" />
+                <node concept="1ACDjB" id="inTShhJRh8" role="3uHU7B">
+                  <ref role="1AC0ER" node="3p9OysaNk0d" resolve="rightParenthesis" />
+                </node>
+              </node>
+              <node concept="1DtDwk" id="inTShhspPn" role="3uHU7B">
+                <ref role="1DtDE4" node="3p9OysaNjZI" resolve="showParentheses" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="inTShhspPo" role="3cqZAp">
+            <node concept="37vLTw" id="inTShhspPp" role="3clFbG">
+              <ref role="3cqZAo" node="inTShhspO8" resolve="builder" />
             </node>
           </node>
         </node>

--- a/code/math/languages/de.itemis.mps.editor.math.notations/generator/template/main@generator.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.notations/generator/template/main@generator.mps
@@ -29,7 +29,7 @@
       </concept>
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
     </language>
@@ -82,7 +82,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -140,7 +140,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -157,7 +157,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
@@ -187,7 +187,7 @@
       </concept>
       <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
-      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ng" index="v9R3L">
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ngI" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
       </concept>
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
@@ -322,7 +322,7 @@
         <property id="1757699476691236116" name="role_DebugInfo" index="2qtEX8" />
         <property id="1341860900488019036" name="linkId" index="P3scX" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -6833,7 +6833,7 @@
           </node>
           <node concept="3clFbF" id="inTShhu3xc" role="3cqZAp">
             <node concept="37vLTw" id="inTShhu9MW" role="3clFbG">
-              <ref role="3cqZAo" node="inTShhu9MQ" resolve="renderText" />
+              <ref role="3cqZAo" node="inTShhu9MQ" resolve="builder" />
             </node>
           </node>
         </node>

--- a/code/math/languages/de.itemis.mps.editor.math.notations/languageModels/editor.mps
+++ b/code/math/languages/de.itemis.mps.editor.math.notations/languageModels/editor.mps
@@ -5,6 +5,7 @@
   <languages>
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>

--- a/code/math/languages/de.itemis.mps.editor.math/generator/template/main@generator.mps
+++ b/code/math/languages/de.itemis.mps.editor.math/generator/template/main@generator.mps
@@ -71,6 +71,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -101,6 +102,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -166,6 +170,8 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
@@ -1555,6 +1561,7 @@
                         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                       </node>
                     </node>
+                    <node concept="2tJIrI" id="inTShgZIyQ" role="jymVt" />
                     <node concept="37vLTw" id="9L22Epakgt" role="37wK5m">
                       <ref role="3cqZAo" node="fXln3od" resolve="editorContext" />
                     </node>
@@ -1569,6 +1576,131 @@
                     </node>
                     <node concept="37vLTw" id="7UiI8OoI9PQ" role="37wK5m">
                       <ref role="3cqZAo" node="7UiI8OoFOQT" resolve="symbols" />
+                    </node>
+                    <node concept="3clFb_" id="inTShgZLy$" role="jymVt">
+                      <property role="TrG5h" value="renderText" />
+                      <node concept="3Tm1VV" id="inTShgZLy_" role="1B3o_S" />
+                      <node concept="3uibUv" id="inTShgZLyB" role="3clF45">
+                        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+                      </node>
+                      <node concept="3clFbS" id="inTShgZLyE" role="3clF47">
+                        <node concept="3cpWs8" id="inTShhi0Bz" role="3cqZAp">
+                          <node concept="3cpWsn" id="inTShhi0B$" role="3cpWs9">
+                            <property role="TrG5h" value="bounds" />
+                            <node concept="3uibUv" id="inTShhi0B_" role="1tU5fm">
+                              <ref role="3uigEE" to="fbzs:~Rectangle2D" resolve="Rectangle2D" />
+                            </node>
+                            <node concept="2ShNRf" id="inTShhi7Cf" role="33vP2m">
+                              <node concept="1pGfFk" id="inTShhicKB" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="fbzs:~Rectangle2D$Float.&lt;init&gt;(float,float,float,float)" resolve="Float" />
+                                <node concept="2OqwBi" id="inTShhimU4" role="37wK5m">
+                                  <node concept="Xjq3P" id="inTShhiiML" role="2Oq$k0" />
+                                  <node concept="liA8E" id="inTShhiriH" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getX()" resolve="getX" />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="inTShhiAsp" role="37wK5m">
+                                  <node concept="Xjq3P" id="inTShhizns" role="2Oq$k0" />
+                                  <node concept="liA8E" id="inTShhiEYJ" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="inTShhiKgb" role="37wK5m">
+                                  <node concept="Xjq3P" id="inTShhiIB5" role="2Oq$k0" />
+                                  <node concept="liA8E" id="inTShhiNgf" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getWidth()" resolve="getWidth" />
+                                  </node>
+                                </node>
+                                <node concept="2OqwBi" id="inTShhiW2r" role="37wK5m">
+                                  <node concept="Xjq3P" id="inTShhiTWG" role="2Oq$k0" />
+                                  <node concept="liA8E" id="inTShhiZ8W" role="2OqNvi">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getHeight()" resolve="getHeight" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="inTShh3kYs" role="3cqZAp">
+                          <node concept="3cpWsn" id="inTShh3kYv" role="3cpWs9">
+                            <property role="TrG5h" value="childCells" />
+                            <node concept="_YKpA" id="inTShh3kYo" role="1tU5fm">
+                              <node concept="3uibUv" id="inTShh3nzU" role="_ZDj9">
+                                <ref role="3uigEE" to="5nlq:9L22EoXDBp" resolve="MathLayoutableCell" />
+                              </node>
+                            </node>
+                            <node concept="1rXfSq" id="7sJd_4s315O" role="33vP2m">
+                              <ref role="37wK5l" to="5nlq:9L22Ep8vf3" resolve="getLayoutableChilds" />
+                              <node concept="3clFbT" id="7sJd_4s31bf" role="37wK5m">
+                                <property role="3clFbU" value="true" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="inTShhzopg" role="3cqZAp">
+                          <node concept="3cpWsn" id="inTShhzoph" role="3cpWs9">
+                            <property role="TrG5h" value="symbols" />
+                            <node concept="_YKpA" id="inTShhzmFq" role="1tU5fm">
+                              <node concept="3uibUv" id="inTShhzmFt" role="_ZDj9">
+                                <ref role="3uigEE" to="5nlq:7UiI8Oo6H1S" resolve="IMathSymbol" />
+                              </node>
+                            </node>
+                            <node concept="1rXfSq" id="inTShhzopi" role="33vP2m">
+                              <ref role="37wK5l" to="5nlq:7UiI8OoDnKR" resolve="getSymbols" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="inTShgZLyH" role="3cqZAp">
+                          <node concept="3nyPlj" id="inTShgZLyG" role="3clFbG">
+                            <ref role="37wK5l" to="g51k:~EditorCell_Collection.renderText()" resolve="renderText" />
+                          </node>
+                          <node concept="2b32R4" id="inTShh02_d" role="lGtFl">
+                            <node concept="3JmXsc" id="inTShh02_e" role="2P8S$">
+                              <node concept="3clFbS" id="inTShh02_f" role="2VODD2">
+                                <node concept="3clFbF" id="inTShh05Si" role="3cqZAp">
+                                  <node concept="2OqwBi" id="inTShh0nC4" role="3clFbG">
+                                    <node concept="2OqwBi" id="inTShh0cVc" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="inTShh08w_" role="2Oq$k0">
+                                        <node concept="30H73N" id="inTShh05Sh" role="2Oq$k0" />
+                                        <node concept="3TrEf2" id="inTShh0bgG" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="x4fh:inTShgZDDx" resolve="renderTextFunction" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="inTShh0kVl" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                                      </node>
+                                    </node>
+                                    <node concept="3Tsc0h" id="inTShh0qCk" role="2OqNvi">
+                                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="inTShgZLyF" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" />
+                      </node>
+                      <node concept="1W57fq" id="inTShh0vGW" role="lGtFl">
+                        <node concept="3IZrLx" id="inTShh0vGX" role="3IZSJc">
+                          <node concept="3clFbS" id="inTShh0vGY" role="2VODD2">
+                            <node concept="3clFbF" id="inTShh0yZF" role="3cqZAp">
+                              <node concept="2OqwBi" id="inTShh0$7X" role="3clFbG">
+                                <node concept="2OqwBi" id="inTShh0ztw" role="2Oq$k0">
+                                  <node concept="30H73N" id="inTShh0yZE" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="inTShh0zN3" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="x4fh:inTShgZDDx" resolve="renderTextFunction" />
+                                  </node>
+                                </node>
+                                <node concept="3x8VRR" id="inTShh0BOw" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2061,6 +2193,7 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="inTShgYxcw" role="jymVt" />
     <node concept="3Tm1VV" id="7UiI8Oog6sG" role="1B3o_S" />
     <node concept="n94m4" id="7UiI8Oog6sH" role="lGtFl">
       <ref role="n9lRv" to="x4fh:7UiI8OnHTLk" resolve="PredefinedMathSymbol" />
@@ -2078,6 +2211,75 @@
               <node concept="30H73N" id="7UiI8Oos31v" role="2Oq$k0" />
               <node concept="3TrcHB" id="7UiI8Oos3Gt" role="2OqNvi">
                 <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="inTShgYxq8" role="jymVt">
+      <property role="TrG5h" value="renderText" />
+      <node concept="3Tm1VV" id="inTShgYxqd" role="1B3o_S" />
+      <node concept="3uibUv" id="inTShgYxqe" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+      </node>
+      <node concept="3clFbS" id="inTShgYxqf" role="3clF47">
+        <node concept="3cpWs8" id="inTShhhvua" role="3cqZAp">
+          <node concept="3cpWsn" id="inTShhhvub" role="3cpWs9">
+            <property role="TrG5h" value="bounds" />
+            <node concept="3uibUv" id="inTShhhv5s" role="1tU5fm">
+              <ref role="3uigEE" to="fbzs:~Rectangle2D" resolve="Rectangle2D" />
+            </node>
+            <node concept="1rXfSq" id="inTShhhvuc" role="33vP2m">
+              <ref role="37wK5l" to="5nlq:7UiI8OooYkV" resolve="getBounds" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="inTShgYxqi" role="3cqZAp">
+          <node concept="3nyPlj" id="inTShgYxqh" role="3clFbG">
+            <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+          </node>
+          <node concept="2b32R4" id="inTShgYBlo" role="lGtFl">
+            <node concept="3JmXsc" id="inTShgYBlp" role="2P8S$">
+              <node concept="3clFbS" id="inTShgYBlq" role="2VODD2">
+                <node concept="3clFbF" id="inTShgYBS2" role="3cqZAp">
+                  <node concept="2OqwBi" id="inTShgYG_0" role="3clFbG">
+                    <node concept="2OqwBi" id="inTShgYFoP" role="2Oq$k0">
+                      <node concept="2OqwBi" id="inTShgYCLY" role="2Oq$k0">
+                        <node concept="30H73N" id="inTShgYBS1" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="inTShgYEmT" role="2OqNvi">
+                          <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="textFunction" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="inTShgYG6$" role="2OqNvi">
+                        <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                      </node>
+                    </node>
+                    <node concept="3Tsc0h" id="inTShgYHjl" role="2OqNvi">
+                      <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="inTShgYxqg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+      <node concept="1W57fq" id="inTShgYzTv" role="lGtFl">
+        <node concept="3IZrLx" id="inTShgYzTw" role="3IZSJc">
+          <node concept="3clFbS" id="inTShgYzTx" role="2VODD2">
+            <node concept="3clFbF" id="inTShgY$zp" role="3cqZAp">
+              <node concept="2OqwBi" id="inTShgY_YJ" role="3clFbG">
+                <node concept="2OqwBi" id="inTShgY$XK" role="2Oq$k0">
+                  <node concept="30H73N" id="inTShgY$zo" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="inTShgY_c4" role="2OqNvi">
+                    <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="textFunction" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="inTShgYAtd" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -2175,6 +2377,79 @@
                           </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2tJIrI" id="inTShhdm$t" role="jymVt" />
+          <node concept="3clFb_" id="inTShhdmLT" role="jymVt">
+            <property role="TrG5h" value="renderText" />
+            <node concept="3Tm1VV" id="inTShhdmLY" role="1B3o_S" />
+            <node concept="3uibUv" id="inTShhdmLZ" role="3clF45">
+              <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+            </node>
+            <node concept="3clFbS" id="inTShhdmM3" role="3clF47">
+              <node concept="3cpWs8" id="inTShhj5zd" role="3cqZAp">
+                <node concept="3cpWsn" id="inTShhj5ze" role="3cpWs9">
+                  <property role="TrG5h" value="bounds" />
+                  <node concept="3uibUv" id="inTShhj5r1" role="1tU5fm">
+                    <ref role="3uigEE" to="fbzs:~Rectangle2D" resolve="Rectangle2D" />
+                  </node>
+                  <node concept="2OqwBi" id="inTShhj5zf" role="33vP2m">
+                    <node concept="Xjq3P" id="inTShhj5zg" role="2Oq$k0" />
+                    <node concept="liA8E" id="inTShhj5zh" role="2OqNvi">
+                      <ref role="37wK5l" to="5nlq:7UiI8OooYkV" resolve="getBounds" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="inTShhdmM8" role="3cqZAp">
+                <node concept="3nyPlj" id="inTShhdmM7" role="3clFbG">
+                  <ref role="37wK5l" to="5nlq:inTShgXupP" resolve="renderText" />
+                </node>
+                <node concept="2b32R4" id="inTShhdo19" role="lGtFl">
+                  <node concept="3JmXsc" id="inTShhdo1a" role="2P8S$">
+                    <node concept="3clFbS" id="inTShhdo1b" role="2VODD2">
+                      <node concept="3clFbF" id="inTShhdoY4" role="3cqZAp">
+                        <node concept="2OqwBi" id="inTShhdryP" role="3clFbG">
+                          <node concept="2OqwBi" id="inTShhdqmM" role="2Oq$k0">
+                            <node concept="2OqwBi" id="inTShhdprc" role="2Oq$k0">
+                              <node concept="30H73N" id="inTShhdoY3" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="inTShhdpTa" role="2OqNvi">
+                                <ref role="3Tt5mk" to="x4fh:inTShhdm4F" resolve="renderTextFunction" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="inTShhdr4U" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                            </node>
+                          </node>
+                          <node concept="3Tsc0h" id="inTShhdsk_" role="2OqNvi">
+                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2AHcQZ" id="inTShhdmM4" role="2AJF6D">
+              <ref role="2AI5Lk" to="wyt6:~Override" />
+            </node>
+            <node concept="1W57fq" id="inTShhdtT5" role="lGtFl">
+              <node concept="3IZrLx" id="inTShhdtT6" role="3IZSJc">
+                <node concept="3clFbS" id="inTShhdtT7" role="2VODD2">
+                  <node concept="3clFbF" id="inTShhduJS" role="3cqZAp">
+                    <node concept="2OqwBi" id="inTShhdw8v" role="3clFbG">
+                      <node concept="2OqwBi" id="inTShhdvaf" role="2Oq$k0">
+                        <node concept="30H73N" id="inTShhduJR" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="inTShhdvoz" role="2OqNvi">
+                          <ref role="3Tt5mk" to="x4fh:inTShhdm4F" resolve="renderTextFunction" />
+                        </node>
+                      </node>
+                      <node concept="3x8VRR" id="inTShhdwQ8" role="2OqNvi" />
                     </node>
                   </node>
                 </node>

--- a/code/math/languages/de.itemis.mps.editor.math/generator/template/main@generator.mps
+++ b/code/math/languages/de.itemis.mps.editor.math/generator/template/main@generator.mps
@@ -1593,7 +1593,7 @@
                             <node concept="2ShNRf" id="inTShhi7Cf" role="33vP2m">
                               <node concept="1pGfFk" id="inTShhicKB" role="2ShVmc">
                                 <property role="373rjd" value="true" />
-                                <ref role="37wK5l" to="fbzs:~Rectangle2D$Float.&lt;init&gt;(float,float,float,float)" resolve="Float" />
+                                <ref role="37wK5l" to="fbzs:~Rectangle2D$Float.&lt;init&gt;(float,float,float,float)" resolve="Rectangle2D.Float" />
                                 <node concept="2OqwBi" id="inTShhimU4" role="37wK5m">
                                   <node concept="Xjq3P" id="inTShhiiML" role="2Oq$k0" />
                                   <node concept="liA8E" id="inTShhiriH" role="2OqNvi">
@@ -1682,7 +1682,7 @@
                         </node>
                       </node>
                       <node concept="2AHcQZ" id="inTShgZLyF" role="2AJF6D">
-                        <ref role="2AI5Lk" to="wyt6:~Override" />
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                       </node>
                       <node concept="1W57fq" id="inTShh0vGW" role="lGtFl">
                         <node concept="3IZrLx" id="inTShh0vGX" role="3IZSJc">
@@ -2248,7 +2248,7 @@
                       <node concept="2OqwBi" id="inTShgYCLY" role="2Oq$k0">
                         <node concept="30H73N" id="inTShgYBS1" role="2Oq$k0" />
                         <node concept="3TrEf2" id="inTShgYEmT" role="2OqNvi">
-                          <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="textFunction" />
+                          <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="renderTextFunction" />
                         </node>
                       </node>
                       <node concept="3TrEf2" id="inTShgYG6$" role="2OqNvi">
@@ -2266,7 +2266,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="inTShgYxqg" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
       <node concept="1W57fq" id="inTShgYzTv" role="lGtFl">
         <node concept="3IZrLx" id="inTShgYzTw" role="3IZSJc">
@@ -2276,7 +2276,7 @@
                 <node concept="2OqwBi" id="inTShgY$XK" role="2Oq$k0">
                   <node concept="30H73N" id="inTShgY$zo" role="2Oq$k0" />
                   <node concept="3TrEf2" id="inTShgY_c4" role="2OqNvi">
-                    <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="textFunction" />
+                    <ref role="3Tt5mk" to="x4fh:inTShgXvMi" resolve="renderTextFunction" />
                   </node>
                 </node>
                 <node concept="3x8VRR" id="inTShgYAtd" role="2OqNvi" />
@@ -2436,7 +2436,7 @@
               </node>
             </node>
             <node concept="2AHcQZ" id="inTShhdmM4" role="2AJF6D">
-              <ref role="2AI5Lk" to="wyt6:~Override" />
+              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
             </node>
             <node concept="1W57fq" id="inTShhdtT5" role="lGtFl">
               <node concept="3IZrLx" id="inTShhdtT6" role="3IZSJc">

--- a/code/math/languages/de.itemis.mps.editor.math/languageModels/behavior.mps
+++ b/code/math/languages/de.itemis.mps.editor.math/languageModels/behavior.mps
@@ -17,6 +17,7 @@
     <import index="x4fh" ref="r:6d7e624e-8f0d-49a1-aae8-a4cb94dbe189(de.itemis.mps.editor.math.structure)" />
     <import index="fbzs" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.geom(JDK/)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="tpcb" ref="r:00000000-0000-4000-0000-011c89590297(jetbrains.mps.lang.editor.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -1002,6 +1003,55 @@
           <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="inTShgXxxC">
+    <ref role="13h7C2" to="x4fh:inTShgXxuv" resolve="TextBuilderFunction" />
+    <node concept="13i0hz" id="inTShgXxxV" role="13h7CS">
+      <property role="TrG5h" value="getParameterConcepts" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:2xELmDxyi2v" resolve="getParameterConcepts" />
+      <node concept="3Tm1VV" id="inTShgXxxW" role="1B3o_S" />
+      <node concept="3clFbS" id="inTShgXxxX" role="3clF47">
+        <node concept="3clFbF" id="inTShhhs3U" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhhs3W" role="3clFbG">
+            <node concept="Tc6Ow" id="inTShhhs3X" role="2ShVmc">
+              <node concept="35c_gC" id="inTShhhs3Z" role="HW$Y0">
+                <ref role="35c_gD" to="x4fh:7UiI8OnHTWb" resolve="Parameter_Bounds" />
+              </node>
+              <node concept="3bZ5Sz" id="inTShhhs40" role="HW$YZ">
+                <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="inTShgXxy3" role="3clF45">
+        <node concept="3bZ5Sz" id="inTShgXxy4" role="_ZDj9">
+          <ref role="3bZ5Sy" to="tpee:g76ryKb" resolve="ConceptFunctionParameter" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="inTShgXxy5" role="13h7CS">
+      <property role="TrG5h" value="getExpectedReturnType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="tpek:hEwIGRD" resolve="getExpectedReturnType" />
+      <node concept="3Tm1VV" id="inTShgXxy6" role="1B3o_S" />
+      <node concept="3clFbS" id="inTShgXxy7" role="3clF47">
+        <node concept="3clFbF" id="inTShgZV5c" role="3cqZAp">
+          <node concept="2c44tf" id="inTShgZV5a" role="3clFbG">
+            <node concept="3uibUv" id="inTShgZV5M" role="2c44tc">
+              <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="inTShgXxyc" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="inTShgXxxD" role="13h7CW">
+      <node concept="3clFbS" id="inTShgXxxE" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/math/languages/de.itemis.mps.editor.math/languageModels/editor.mps
+++ b/code/math/languages/de.itemis.mps.editor.math/languageModels/editor.mps
@@ -272,6 +272,29 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
+        <node concept="3F0ifn" id="inTShh19s8" role="3EZMnx">
+          <node concept="ljvvj" id="inTShh19s9" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="pVoyu" id="inTShh19sa" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="VPM3Z" id="inTShh19sb" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="inTShh19sc" role="3EZMnx">
+          <property role="3F0ifm" value="rendered text" />
+          <node concept="lj46D" id="inTShh19sd" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="inTShh19se" role="3EZMnx">
+          <ref role="1NtTu8" to="x4fh:inTShgZDDx" resolve="renderTextFunction" />
+          <node concept="lj46D" id="inTShh19sf" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
         <node concept="3F0ifn" id="9L22EoX1YS" role="3EZMnx">
           <property role="3F0ifm" value="}" />
           <node concept="pVoyu" id="9L22EoX221" role="3F10Kt">
@@ -373,6 +396,26 @@
         <node concept="lj46D" id="7UiI8Oo5rm8" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+      </node>
+      <node concept="3F0ifn" id="inTShgYwsH" role="3EZMnx">
+        <node concept="ljvvj" id="inTShgYwsI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pVoyu" id="inTShgYwsJ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="VPM3Z" id="inTShgYwsK" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="inTShgYwsL" role="3EZMnx">
+        <property role="3F0ifm" value="rendered text:" />
+        <node concept="lj46D" id="inTShgYwsM" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="inTShgYwsO" role="3EZMnx">
+        <ref role="1NtTu8" to="x4fh:inTShgXvMi" resolve="renderTextFunction" />
       </node>
       <node concept="3F0ifn" id="7UiI8OnJHQ5" role="3EZMnx">
         <property role="3F0ifm" value="}" />
@@ -522,6 +565,26 @@
         <node concept="lj46D" id="7UiI8Op0LGj" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+      </node>
+      <node concept="3F0ifn" id="inTShhdm4G" role="3EZMnx">
+        <node concept="ljvvj" id="inTShhdm4H" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pVoyu" id="inTShhdm4I" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="VPM3Z" id="inTShhdm4J" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="inTShhdm4K" role="3EZMnx">
+        <property role="3F0ifm" value="rendered text:" />
+        <node concept="lj46D" id="inTShhdm4L" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="inTShhdm4Q" role="3EZMnx">
+        <ref role="1NtTu8" to="x4fh:inTShhdm4F" resolve="renderTextFunction" />
       </node>
       <node concept="3F0ifn" id="7UiI8Op0LGk" role="3EZMnx">
         <property role="3F0ifm" value="}" />

--- a/code/math/languages/de.itemis.mps.editor.math/languageModels/structure.mps
+++ b/code/math/languages/de.itemis.mps.editor.math/languageModels/structure.mps
@@ -98,6 +98,12 @@
       <property role="IQ2ns" value="8588142736409368490" />
       <ref role="20lvS9" node="7sJd_4s1VjR" resolve="InitFunction" />
     </node>
+    <node concept="1TJgyj" id="inTShgZDDx" role="1TKVEi">
+      <property role="IQ2ns" value="330987653115583073" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="renderTextFunction" />
+      <ref role="20lvS9" node="inTShgXxuv" resolve="TextBuilderFunction" />
+    </node>
     <node concept="PrWs8" id="19RCnNmEWth" role="PzmwI">
       <ref role="PrY4T" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
     </node>
@@ -188,6 +194,12 @@
       <property role="20kJfa" value="updateDimensionFunction" />
       <property role="IQ2ns" value="9120555111512650991" />
       <ref role="20lvS9" node="7UiI8Oo5kHL" resolve="UpdateDimensionFunction" />
+    </node>
+    <node concept="1TJgyj" id="inTShgXvMi" role="1TKVEi">
+      <property role="IQ2ns" value="330987653115018386" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="renderTextFunction" />
+      <ref role="20lvS9" node="inTShgXxuv" resolve="TextBuilderFunction" />
     </node>
     <node concept="PrWs8" id="7UiI8OnJHQt" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
@@ -319,6 +331,12 @@
       <property role="IQ2ns" value="9120555111528208560" />
       <ref role="20lvS9" node="7UiI8Oo5kHL" resolve="UpdateDimensionFunction" />
     </node>
+    <node concept="1TJgyj" id="inTShhdm4F" role="1TKVEi">
+      <property role="IQ2ns" value="330987653119172907" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="renderTextFunction" />
+      <ref role="20lvS9" node="inTShgXxuv" resolve="TextBuilderFunction" />
+    </node>
     <node concept="PrWs8" id="7UiI8Op0Lx9" role="PzmwI">
       <ref role="PrY4T" node="7UiI8Oo8WZA" resolve="IMathSymbol" />
     </node>
@@ -338,6 +356,11 @@
   <node concept="1TIwiD" id="7sJd_4s1VjR">
     <property role="TrG5h" value="InitFunction" />
     <property role="EcuMT" value="8588142736409343223" />
+    <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
+  </node>
+  <node concept="1TIwiD" id="inTShgXxuv">
+    <property role="TrG5h" value="TextBuilderFunction" />
+    <property role="EcuMT" value="330987653115025311" />
     <ref role="1TJDcQ" to="tpee:gyVMwX8" resolve="ConceptFunction" />
   </node>
 </model>

--- a/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.runtime/models/de/itemis/mps/editor/math/runtime.mps
@@ -56,6 +56,9 @@
       </concept>
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
       <concept id="1153422305557" name="jetbrains.mps.baseLanguage.structure.LessThanOrEqualsExpression" flags="nn" index="2dkUwp" />
+      <concept id="2323553266850475941" name="jetbrains.mps.baseLanguage.structure.IHasModifiers" flags="ngI" index="2frcj7">
+        <child id="2323553266850475953" name="modifiers" index="2frcjj" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
@@ -76,6 +79,7 @@
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
+      <concept id="4678410916365116210" name="jetbrains.mps.baseLanguage.structure.DefaultModifier" flags="ng" index="2JFqV2" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -144,6 +148,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -11304,6 +11311,24 @@
       <node concept="3cqZAl" id="4r1mNB_YJjG" role="3clF45" />
       <node concept="3Tm1VV" id="4r1mNB_YJjH" role="1B3o_S" />
       <node concept="3clFbS" id="4r1mNB_YJjI" role="3clF47" />
+    </node>
+    <node concept="3clFb_" id="inTShgXupP" role="jymVt">
+      <property role="TrG5h" value="renderText" />
+      <node concept="3clFbS" id="inTShgXupS" role="3clF47">
+        <node concept="3clFbF" id="inTShgXyjL" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShgXyjJ" role="3clFbG">
+            <node concept="1pGfFk" id="inTShgXQrf" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="inTShgXq_u" role="1B3o_S" />
+      <node concept="3uibUv" id="inTShgXsHV" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+      </node>
+      <node concept="2JFqV2" id="inTShh5Fds" role="2frcjj" />
     </node>
     <node concept="3Tm1VV" id="7UiI8Oo6H1T" role="1B3o_S" />
     <node concept="3uibUv" id="7UiI8OodCZO" role="3HQHJm">

--- a/code/math/solutions/de.itemis.mps.editor.math.symbols/de.itemis.mps.editor.math.symbols.msd
+++ b/code/math/solutions/de.itemis.mps.editor.math.symbols/de.itemis.mps.editor.math.symbols.msd
@@ -13,6 +13,7 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="true">a9a7bf57-15e6-4d28-adc1-be146e415fe5(de.itemis.mps.editor.math.runtime)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:766348f7-6a67-4b85-9323-384840132299:de.itemis.mps.editor.math" version="0" />
@@ -28,7 +29,13 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="a9a7bf57-15e6-4d28-adc1-be146e415fe5(de.itemis.mps.editor.math.runtime)" version="0" />
     <module reference="0fcee1cf-8f59-441b-b9c7-7ff7bdd6bc97(de.itemis.mps.editor.math.symbols)" version="0" />
   </dependencyVersions>

--- a/code/math/solutions/de.itemis.mps.editor.math.symbols/models/de/itemis/mps/editor/math/symbols.mps
+++ b/code/math/solutions/de.itemis.mps.editor.math.symbols/models/de/itemis/mps/editor/math/symbols.mps
@@ -11,6 +11,11 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="5nlq" ref="r:34f40b74-cb38-46ba-8e5b-13b443c803c4(de.itemis.mps.editor.math.runtime)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -23,6 +28,9 @@
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -56,6 +64,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -85,6 +96,9 @@
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -106,13 +120,26 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
+        <property id="1200397540847" name="charConstant" index="1XhdNS" />
+      </concept>
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
     <language id="766348f7-6a67-4b85-9323-384840132299" name="de.itemis.mps.editor.math">
       <concept id="175930839493260656" name="de.itemis.mps.editor.math.structure.Parameter_Graphics" flags="ng" index="2rujPq" />
+      <concept id="330987653115025311" name="de.itemis.mps.editor.math.structure.TextBuilderFunction" flags="ig" index="1kov0r" />
       <concept id="9120555111512623985" name="de.itemis.mps.editor.math.structure.UpdateDimensionFunction" flags="ig" index="1AxZfW" />
       <concept id="9120555111512624407" name="de.itemis.mps.editor.math.structure.Parameter_Dimension" flags="ng" index="1AxZmq" />
       <concept id="9120555111506484308" name="de.itemis.mps.editor.math.structure.PredefinedMathSymbol" flags="ng" index="1D9ijp">
+        <child id="330987653115018386" name="renderTextFunction" index="1koxGm" />
         <child id="9120555111512650991" name="updateDimensionFunction" index="1AxKLy" />
         <child id="9120555111506958622" name="paintFunction" index="1Db66j" />
       </concept>
@@ -126,7 +153,7 @@
     </language>
   </registry>
   <node concept="1D9ijp" id="6vUATgmxhhb">
-    <property role="TrG5h" value="ArrowLeft" />
+    <property role="TrG5h" value="ArrowRight" />
     <node concept="1D9ilv" id="6vUATgmxhhc" role="1Db66j">
       <node concept="3clFbS" id="6vUATgmxhhd" role="2VODD2">
         <node concept="3cpWs8" id="6vUATgmxhhe" role="3cqZAp">
@@ -367,6 +394,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShh7xqT" role="1koxGm">
+      <node concept="3clFbS" id="inTShh7xqU" role="2VODD2">
+        <node concept="3clFbF" id="inTShh7xt4" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShh7xt2" role="3clFbG">
+            <node concept="1pGfFk" id="inTShh7zPL" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShh7_tj" role="37wK5m">
+                <property role="Xl_RC" value="→" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="6vUATgmxhiS">
     <property role="TrG5h" value="HorizontalLine" />
@@ -422,6 +464,73 @@
               <node concept="1AxZmq" id="6vUATgmxhjj" role="2Oq$k0" />
               <node concept="2OwXpG" id="2LRHghwNKit" role="2OqNvi">
                 <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgTEo" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgTEp" role="2VODD2">
+        <node concept="3cpWs8" id="10diQy0kYvH" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0kYvI" role="3cpWs9">
+            <property role="TrG5h" value="withOfOneDash" />
+            <node concept="10Oyi0" id="10diQy0kYcZ" role="1tU5fm" />
+            <node concept="2OqwBi" id="inTShhhqZE" role="33vP2m">
+              <node concept="10M0yZ" id="inTShhhq_o" role="2Oq$k0">
+                <ref role="3cqZAo" to="exr9:~EditorComponentSettingsImpl.DEFAULT_SETTINGS" resolve="DEFAULT_SETTINGS" />
+                <ref role="1PxDUh" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+              </node>
+              <node concept="liA8E" id="inTShhhrrC" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getWidth(char,int)" resolve="getWidth" />
+                <node concept="1Xhbcc" id="inTShhhrub" role="37wK5m">
+                  <property role="1XhdNS" value="-" />
+                </node>
+                <node concept="3cmrfG" id="inTShhhrGy" role="37wK5m">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0l4Q9" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0l4Qc" role="3cpWs9">
+            <property role="TrG5h" value="numberOfDashes" />
+            <node concept="10Oyi0" id="10diQy0l4Q7" role="1tU5fm" />
+            <node concept="FJ1c_" id="10diQy0l9nA" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0l9Vp" role="3uHU7w">
+                <ref role="3cqZAo" node="10diQy0kYvI" resolve="withOfOneDash" />
+              </node>
+              <node concept="10QFUN" id="inTShhl$ey" role="3uHU7B">
+                <node concept="10Oyi0" id="inTShhl$x6" role="10QFUM" />
+                <node concept="2OqwBi" id="inTShhlxuD" role="10QFUP">
+                  <node concept="1D9iu6" id="inTShhlxad" role="2Oq$k0" />
+                  <node concept="liA8E" id="inTShhlxQ5" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getWidth()" resolve="getWidth" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="2qBpcrwljpM" role="3cqZAp">
+          <node concept="2ShNRf" id="2qBpcrwljvh" role="3cqZAk">
+            <node concept="1pGfFk" id="2qBpcrwlDsE" role="2ShVmc">
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="2OqwBi" id="10diQy0lfWg" role="37wK5m">
+                <node concept="2YIFZM" id="10diQy0lc0B" role="2Oq$k0">
+                  <ref role="37wK5l" to="wyt6:~String.valueOf(char)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                  <node concept="1Xhbcc" id="10diQy0lcx$" role="37wK5m">
+                    <property role="1XhdNS" value="-" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="10diQy0lh$J" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.repeat(int)" resolve="repeat" />
+                  <node concept="37vLTw" id="10diQy0li9I" role="37wK5m">
+                    <ref role="3cqZAo" node="10diQy0l4Qc" resolve="numberOfDashes" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -502,6 +611,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlD56" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlD57" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlD80" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlD81" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlD82" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlD83" role="37wK5m">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="6vUATgmxhjS">
     <property role="TrG5h" value="RightParenthesis" />
@@ -570,6 +694,21 @@
               <node concept="1AxZmq" id="6vUATgmxhkp" role="2Oq$k0" />
               <node concept="2OwXpG" id="6vUATgmxhkq" role="2OqNvi">
                 <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhlN9p" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlN9q" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlN9s" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlN9t" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlN9u" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlN9v" role="37wK5m">
+                <property role="Xl_RC" value=")" />
               </node>
             </node>
           </node>
@@ -896,6 +1035,21 @@
               </node>
               <node concept="3b6qkQ" id="6vUATgmxhkK" role="37wK5m">
                 <property role="$nhwW" value="0.7" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhlPyt" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlPyu" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlPCm" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlPCk" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlPMm" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlPXn" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
               </node>
             </node>
           </node>
@@ -1379,6 +1533,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlSeN" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlSeO" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlSmE" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlSmF" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlSmG" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlSmH" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="4r1mNB_E13K">
     <property role="TrG5h" value="BeautifulSumSymbol" />
@@ -1825,6 +1994,21 @@
               <node concept="1AxZmq" id="4r1mNB_GDBS" role="2Oq$k0" />
               <node concept="2OwXpG" id="4r1mNB_GEqS" role="2OqNvi">
                 <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgLhK" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgLhL" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgLrG" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgLrE" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgLzi" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgLzl" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
               </node>
             </node>
           </node>
@@ -2670,6 +2854,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgKbW" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgKbX" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgKp8" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgKp6" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgKB_" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgKCj" role="37wK5m">
+                <property role="Xl_RC" value="integral" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="4r1mNB_GoWK">
     <property role="TrG5h" value="FontIntegralSymbol" />
@@ -2709,6 +2908,21 @@
               </node>
               <node concept="3b6qkQ" id="7UiI8Op2iIr" role="37wK5m">
                 <property role="$nhwW" value="0.7" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgT9b" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgT9c" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgTbp" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgTbn" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgTiZ" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgTmw" role="37wK5m">
+                <property role="Xl_RC" value="integral" />
               </node>
             </node>
           </node>
@@ -3166,6 +3380,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgMiC" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgMiD" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgMsy" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgMsz" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgMs$" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgMs_" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="4r1mNB_NBod">
     <property role="TrG5h" value="BeautifulSumSymbol3" />
@@ -3617,6 +3846,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgN4y" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgN4z" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgN96" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgN97" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgN98" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgN99" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="4r1mNB_UBwx">
     <property role="TrG5h" value="ProductSymbol" />
@@ -3763,6 +4007,21 @@
               </node>
               <node concept="3b6qkQ" id="7UiI8Oph99D" role="37wK5m">
                 <property role="$nhwW" value="0.8" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhlMP2" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlMP3" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlMTh" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlMTf" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlN3h" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlN4C" role="37wK5m">
+                <property role="Xl_RC" value="prod" />
               </node>
             </node>
           </node>
@@ -4286,6 +4545,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlQZK" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlQZL" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlRr0" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlRr1" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlRr2" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlRr3" role="37wK5m">
+                <property role="Xl_RC" value="sum" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjbD">
     <property role="TrG5h" value="EmptySymbol" />
@@ -4303,6 +4577,21 @@
               <node concept="1AxZmq" id="3EpCmwwRjbM" role="2Oq$k0" />
               <node concept="2OwXpG" id="3EpCmwwRjbN" role="2OqNvi">
                 <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgP6q" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgP6r" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgP8r" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgP8p" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgPg1" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgPgJ" role="37wK5m">
+                <property role="Xl_RC" value="" />
               </node>
             </node>
           </node>
@@ -5139,6 +5428,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgQ76" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgQ77" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgQ$I" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgQ$G" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgQGk" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgQIt" role="37wK5m">
+                <property role="Xl_RC" value="ℯ" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjgo">
     <property role="TrG5h" value="FloorLeft" />
@@ -5267,6 +5571,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgRLS" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgRLT" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgSe2" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgSe0" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgSlC" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgSmm" role="37wK5m">
+                <property role="Xl_RC" value="⌊" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjhh">
     <property role="TrG5h" value="FloorRight" />
@@ -5389,6 +5708,21 @@
               <ref role="37wK5l" to="z60i:~Graphics2D.draw(java.awt.Shape)" resolve="draw" />
               <node concept="37vLTw" id="3EpCmwwRji9" role="37wK5m">
                 <ref role="3cqZAo" node="3EpCmwwRjhs" resolve="symbol" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgSMa" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgSMb" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgSR8" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgSR6" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgT5_" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgT5C" role="37wK5m">
+                <property role="Xl_RC" value="⌋" />
               </node>
             </node>
           </node>
@@ -6226,6 +6560,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlAzj" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlAzk" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlAMY" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlAMW" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlB$H" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlCxX" role="37wK5m">
+                <property role="Xl_RC" value="{" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjmX">
     <property role="TrG5h" value="LeftParenthesisThick" />
@@ -6599,6 +6948,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlEd_" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlEdA" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlEl1" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlEl2" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlEl3" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlEl4" role="37wK5m">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjp9">
     <property role="TrG5h" value="LeftSquareBracket" />
@@ -6748,6 +7112,21 @@
               <ref role="37wK5l" to="z60i:~Graphics2D.draw(java.awt.Shape)" resolve="draw" />
               <node concept="37vLTw" id="3EpCmwwRjqd" role="37wK5m">
                 <ref role="3cqZAo" node="3EpCmwwRjpk" resolve="symbol" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhlGoV" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlGoW" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlGoY" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlGoZ" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlGp0" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlGp1" role="37wK5m">
+                <property role="Xl_RC" value="[" />
               </node>
             </node>
           </node>
@@ -8143,6 +8522,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlHHS" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlHHT" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlI73" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlI71" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlIit" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlIiw" role="37wK5m">
+                <property role="Xl_RC" value="ln" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRjy9">
     <property role="TrG5h" value="RightParenthesisThick" />
@@ -8516,6 +8910,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlNLi" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlNLj" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlOl0" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlOl1" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlOl2" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlOl3" role="37wK5m">
+                <property role="Xl_RC" value=")" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRj$l">
     <property role="TrG5h" value="RightSquareBracket" />
@@ -8671,6 +9080,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhlOOM" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlOON" role="2VODD2">
+        <node concept="3clFbF" id="inTShhlOOP" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhlOOQ" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhlOOR" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhlOOS" role="37wK5m">
+                <property role="Xl_RC" value="]" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="3EpCmwwRj_q">
     <property role="TrG5h" value="VerticalLine" />
@@ -8728,6 +9152,157 @@
                 <ref role="2Oxat5" to="5nlq:7UiI8Oo4zw3" resolve="width" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhlZrL" role="1koxGm">
+      <node concept="3clFbS" id="inTShhlZrM" role="2VODD2">
+        <node concept="3cpWs8" id="10diQy0mxks" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0mxkr" role="3cpWs9">
+            <property role="TrG5h" value="settings" />
+            <node concept="3uibUv" id="10diQy0mxkt" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorSettings" resolve="EditorSettings" />
+            </node>
+            <node concept="2YIFZM" id="10diQy0mxY7" role="33vP2m">
+              <ref role="1Pybhc" to="exr9:~EditorSettings" resolve="EditorSettings" />
+              <ref role="37wK5l" to="exr9:~EditorSettings.getInstance()" resolve="getInstance" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0mRiS" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0mRiT" role="3cpWs9">
+            <property role="TrG5h" value="fontMetrics" />
+            <node concept="3uibUv" id="10diQy0mQT_" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorFontMetrics" resolve="EditorFontMetrics" />
+            </node>
+            <node concept="2OqwBi" id="10diQy0mRiU" role="33vP2m">
+              <node concept="liA8E" id="10diQy0mRiW" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorFontMetricsProvider.getFontMetrics(java.lang.String,int,int)" resolve="getFontMetrics" />
+                <node concept="2OqwBi" id="10diQy0mRiX" role="37wK5m">
+                  <node concept="37vLTw" id="10diQy0mRiY" role="2Oq$k0">
+                    <ref role="3cqZAo" node="10diQy0mxkr" resolve="settings" />
+                  </node>
+                  <node concept="liA8E" id="10diQy0mRiZ" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~EditorSettings.getFontFamily()" resolve="getFontFamily" />
+                  </node>
+                </node>
+                <node concept="10M0yZ" id="10diQy0mRj0" role="37wK5m">
+                  <ref role="3cqZAo" to="z60i:~Font.PLAIN" resolve="PLAIN" />
+                  <ref role="1PxDUh" to="z60i:~Font" resolve="Font" />
+                </node>
+                <node concept="2OqwBi" id="10diQy0mRj1" role="37wK5m">
+                  <node concept="liA8E" id="10diQy0mRj3" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorComponentSettings.getFontSize()" resolve="getFontSize" />
+                  </node>
+                  <node concept="10M0yZ" id="inTShhm0G0" role="2Oq$k0">
+                    <ref role="3cqZAo" to="exr9:~EditorComponentSettingsImpl.DEFAULT_SETTINGS" resolve="DEFAULT_SETTINGS" />
+                    <ref role="1PxDUh" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+                  </node>
+                </node>
+              </node>
+              <node concept="10M0yZ" id="inTShhlZM_" role="2Oq$k0">
+                <ref role="3cqZAo" to="exr9:~EditorComponentSettingsImpl.DEFAULT_SETTINGS" resolve="DEFAULT_SETTINGS" />
+                <ref role="1PxDUh" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0lnXf" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0lnXg" role="3cpWs9">
+            <property role="TrG5h" value="heightOfOneDash" />
+            <node concept="10Oyi0" id="10diQy0lnXh" role="1tU5fm" />
+            <node concept="2OqwBi" id="10diQy0mUcq" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0mT_B" role="2Oq$k0">
+                <ref role="3cqZAo" node="10diQy0mRiT" resolve="fontMetrics" />
+              </node>
+              <node concept="liA8E" id="10diQy0mUXf" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorFontMetrics.getHeight()" resolve="getHeight" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="10diQy0mtgp" role="3cqZAp" />
+        <node concept="3cpWs8" id="10diQy0luMT" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0luMU" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="10diQy0luMV" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+            </node>
+            <node concept="2ShNRf" id="10diQy0lw_b" role="33vP2m">
+              <node concept="1pGfFk" id="10diQy0lx$d" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="10diQy0lnXp" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0lnXq" role="3cpWs9">
+            <property role="TrG5h" value="numberOfDashes" />
+            <node concept="10Oyi0" id="10diQy0lnXr" role="1tU5fm" />
+            <node concept="FJ1c_" id="10diQy0lnXs" role="33vP2m">
+              <node concept="37vLTw" id="10diQy0lnXt" role="3uHU7w">
+                <ref role="3cqZAo" node="10diQy0lnXg" resolve="heightOfOneDash" />
+              </node>
+              <node concept="10QFUN" id="inTShhm2lZ" role="3uHU7B">
+                <node concept="10Oyi0" id="inTShhm2Ds" role="10QFUM" />
+                <node concept="2OqwBi" id="inTShhm1fD" role="10QFUP">
+                  <node concept="1D9iu6" id="inTShhm0Jy" role="2Oq$k0" />
+                  <node concept="liA8E" id="inTShhm1OH" role="2OqNvi">
+                    <ref role="37wK5l" to="fbzs:~RectangularShape.getHeight()" resolve="getHeight" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="10diQy0lz3I" role="3cqZAp">
+          <node concept="3clFbS" id="10diQy0lz3K" role="2LFqv$">
+            <node concept="3clFbF" id="10diQy0lJHX" role="3cqZAp">
+              <node concept="2OqwBi" id="10diQy0lKka" role="3clFbG">
+                <node concept="37vLTw" id="10diQy0lJHV" role="2Oq$k0">
+                  <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="10diQy0lKZ9" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                  <node concept="2ShNRf" id="10diQy0lLKP" role="37wK5m">
+                    <node concept="1pGfFk" id="10diQy0lMBr" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                      <node concept="Xl_RD" id="10diQy0lNgy" role="37wK5m">
+                        <property role="Xl_RC" value="|" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="10diQy0lz3L" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="10diQy0lzA3" role="1tU5fm" />
+            <node concept="3cmrfG" id="10diQy0l_q4" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="10diQy0lGqq" role="1Dwp0S">
+            <node concept="37vLTw" id="10diQy0lIaP" role="3uHU7w">
+              <ref role="3cqZAo" node="10diQy0lnXq" resolve="numberOfDashes" />
+            </node>
+            <node concept="37vLTw" id="10diQy0lDd5" role="3uHU7B">
+              <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="10diQy0lJ5Q" role="1Dwrff">
+            <node concept="37vLTw" id="10diQy0lJ5S" role="2$L3a6">
+              <ref role="3cqZAo" node="10diQy0lz3L" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="10diQy0lOt1" role="3cqZAp">
+          <node concept="37vLTw" id="10diQy0lOsZ" role="3clFbG">
+            <ref role="3cqZAo" node="10diQy0luMU" resolve="builder" />
           </node>
         </node>
       </node>
@@ -8860,6 +9435,21 @@
         </node>
       </node>
     </node>
+    <node concept="1kov0r" id="inTShhgOdw" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgOdx" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgOiu" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgOis" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgOq4" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgOqM" role="37wK5m">
+                <property role="Xl_RC" value="⌈" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1D9ijp" id="31wqjcz_2As">
     <property role="TrG5h" value="CeilingRight" />
@@ -8982,6 +9572,21 @@
               <ref role="37wK5l" to="z60i:~Graphics2D.draw(java.awt.Shape)" resolve="draw" />
               <node concept="37vLTw" id="31wqjcz_2Bk" role="37wK5m">
                 <ref role="3cqZAo" node="31wqjcz_2AB" resolve="symbol" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1kov0r" id="inTShhgOQA" role="1koxGm">
+      <node concept="3clFbS" id="inTShhgOQB" role="2VODD2">
+        <node concept="3clFbF" id="inTShhgOV$" role="3cqZAp">
+          <node concept="2ShNRf" id="inTShhgOVy" role="3clFbG">
+            <node concept="1pGfFk" id="inTShhgP3a" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="Xl_RD" id="inTShhgP3S" role="37wK5m">
+                <property role="Xl_RC" value="⌉" />
               </node>
             </node>
           </node>

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
@@ -937,9 +937,28 @@
         <ref role="3uigEE" to="hyam:~ActionListener" resolve="ActionListener" />
       </node>
     </node>
+    <node concept="2tJIrI" id="inTShidRm3" role="jymVt" />
+    <node concept="2tJIrI" id="inTShidRm4" role="jymVt" />
     <node concept="3Tm1VV" id="5K4KrT2v0$2" role="1B3o_S" />
     <node concept="3uibUv" id="5K4KrT2v0Bf" role="1zkMxy">
       <ref role="3uigEE" to="dxuu:~JButton" resolve="JButton" />
+    </node>
+    <node concept="3clFb_" id="inTShidRvo" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="inTShidRvp" role="1B3o_S" />
+      <node concept="3uibUv" id="inTShidRvr" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="inTShidRv_" role="3clF47">
+        <node concept="3clFbF" id="inTShidXhv" role="3cqZAp">
+          <node concept="1rXfSq" id="inTShidXhq" role="3clFbG">
+            <ref role="37wK5l" to="dxuu:~JComponent.getToolTipText()" resolve="getToolTipText" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="inTShidRvA" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="5BoAwgtOr7c">
@@ -3014,6 +3033,24 @@
       <node concept="3Tm1VV" id="7WXxMD90X8R" role="1B3o_S" />
       <node concept="3uibUv" id="7WXxMD911s2" role="3clF45">
         <ref role="3uigEE" node="7WXxMD8XJH0" resolve="PaginationSearchPanel.SearchOptionState" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="inTShidoGJ" role="jymVt" />
+    <node concept="3clFb_" id="inTShidhU8" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="inTShidhU9" role="1B3o_S" />
+      <node concept="3uibUv" id="inTShidhUa" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="inTShidhUb" role="3clF47">
+        <node concept="3clFbF" id="inTShidhUv" role="3cqZAp">
+          <node concept="Xl_RD" id="inTShidhUw" role="3clFbG">
+            <property role="Xl_RC" value="search panel" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="inTShidhUx" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
       </node>
     </node>
     <node concept="3Tm1VV" id="ZyH4gwmyfD" role="1B3o_S" />

--- a/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
+++ b/code/pagination/solutions/de.itemis.mps.editor.pagination.runtime/models/de.itemis.mps.editor.pagination.runtime.ui.mps
@@ -957,7 +957,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="inTShidRvA" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -3050,7 +3050,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="inTShidhUx" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3Tm1VV" id="ZyH4gwmyfD" role="1B3o_S" />

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/de.q60.mps.shadowmodels.examples.editor.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/de.q60.mps.shadowmodels.examples.editor.mpl
@@ -18,6 +18,7 @@
     <dependency reexport="false">9826ee01-d0ba-4048-a622-61eda9424397(de.q60.mps.shadowmodels.target.editor)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:bc963c22-d419-49b6-8543-ea411eb9d3a1:de.q60.mps.polymorphicfunctions" version="0" />
     <language slang="l:96089812-effe-4a96-bb2e-75f8162046af:de.q60.mps.shadowmodels.gen.afterPF" version="0" />
     <language slang="l:6f76dbc8-9615-4a2e-8034-c27700f8983b:de.q60.mps.shadowmodels.gen.desugar" version="0" />

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/models/editor.mps
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.examples.editor/models/editor.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -128,6 +129,9 @@
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -155,15 +159,11 @@
         </node>
         <node concept="2iRfu4" id="7NatPTM2wNO" role="2iSdaV" />
       </node>
-      <node concept="3F0ifn" id="7NatPTM2wNX" role="3EZMnx">
-        <property role="3F0ifm" value="-------------------------------------" />
-      </node>
+      <node concept="2T_mXK" id="inTShitUg3" role="3EZMnx" />
       <node concept="3F1sOY" id="7NatPTM2wOB" role="3EZMnx">
         <ref role="1NtTu8" to="hnll:7NatPTM2w$H" resolve="input" />
       </node>
-      <node concept="3F0ifn" id="7NatPTM2wO6" role="3EZMnx">
-        <property role="3F0ifm" value="-------------------------------------" />
-      </node>
+      <node concept="2T_mXK" id="inTShitUjn" role="3EZMnx" />
       <node concept="gc7cB" id="7NatPTM2wPa" role="3EZMnx">
         <node concept="3VJUX4" id="7NatPTM2wPc" role="3YsKMw">
           <node concept="3clFbS" id="7NatPTM2wPe" role="2VODD2">
@@ -258,9 +258,7 @@
         </node>
         <node concept="2iRfu4" id="3CYlK6ygJ05" role="2iSdaV" />
       </node>
-      <node concept="3F0ifn" id="3CYlK6ygJ08" role="3EZMnx">
-        <property role="3F0ifm" value="-------------------------------------" />
-      </node>
+      <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
       <node concept="gc7cB" id="3CYlK6ygJ09" role="3EZMnx">
         <node concept="3VJUX4" id="3CYlK6ygJ0a" role="3YsKMw">
           <node concept="3clFbS" id="3CYlK6ygJ0b" role="2VODD2">

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.transformation/de.q60.mps.shadowmodels.transformation.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.transformation/de.q60.mps.shadowmodels.transformation.mpl
@@ -139,6 +139,7 @@
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:bc963c22-d419-49b6-8543-ea411eb9d3a1:de.q60.mps.polymorphicfunctions" version="0" />
     <language slang="l:1dfdade0-0417-484f-b787-4c41692c0052:de.q60.mps.shadowmodels.util" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/shadowmodels/languages/de.q60.mps.shadowmodels.transformation/models/editor.mps
+++ b/code/shadowmodels/languages/de.q60.mps.shadowmodels.transformation/models/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="1dfdade0-0417-484f-b787-4c41692c0052" name="de.q60.mps.shadowmodels.util" version="-1" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
@@ -377,6 +378,9 @@
         <child id="1073389446424" name="childCellModel" index="3EZMny" />
         <child id="2490242408670937967" name="factoryMethod" index="3ZZHOD" />
       </concept>
+    </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="767145758118872828" name="jetbrains.mps.lang.actions.structure.NF_Node_ReplaceWithNewOperation" flags="nn" index="2DeJnW" />
@@ -4497,12 +4501,7 @@
             <property role="VOm3f" value="true" />
           </node>
           <node concept="2iRkQZ" id="YSRTOezhX9" role="2iSdaV" />
-          <node concept="3F0ifn" id="YSRTOezhYT" role="3EZMnx">
-            <property role="3F0ifm" value="----------------------------------------------------" />
-            <node concept="Vb9p2" id="YSRTOezhZc" role="3F10Kt" />
-            <node concept="VPM3Z" id="YSRTOezhZh" role="3F10Kt" />
-            <node concept="VPxyj" id="YSRTOezhZp" role="3F10Kt" />
-          </node>
+          <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
           <node concept="3F2HdR" id="YSRTOezhY_" role="3EZMnx">
             <ref role="1NtTu8" to="oyp0:YSRTOezhHB" resolve="content" />
             <node concept="2iRkQZ" id="YSRTOezhYB" role="2czzBx" />

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -486,6 +486,54 @@
             <property role="3oM_SC" value="column." />
           </node>
         </node>
+        <node concept="2DRihI" id="inTShirUMC" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="3oM_SD" id="inTShirUN6" role="1PaTwD">
+            <property role="3oM_SC" value="Copying" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUN7" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUN8" role="1PaTwD">
+            <property role="3oM_SC" value="custom" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUN9" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNa" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNd" role="1PaTwD">
+            <property role="3oM_SC" value="editors" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNe" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNf" role="1PaTwD">
+            <property role="3oM_SC" value="custom" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNi" role="1PaTwD">
+            <property role="3oM_SC" value="swing" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUNg" role="1PaTwD">
+            <property role="3oM_SC" value="components" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUWw" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="inTShirUWx" role="1PaTwD">
+            <property role="3oM_SC" value="plain" />
+          </node>
+          <node concept="3oM_SD" id="inTShirV$M" role="1PaTwD">
+            <property role="3oM_SC" value="text" />
+          </node>
+          <node concept="3oM_SD" id="inTShirV$N" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="inTShirV$O" role="1PaTwD">
+            <property role="3oM_SC" value="improved." />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="15bmVD" id="7TVB4chcCo0" role="15bmVC">

--- a/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
@@ -18,6 +18,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:05f762a9-99f5-4971-a9ed-5a6481dc2be4:de.itemis.mps.selection.intentions" version="0" />
     <language slang="l:7e450f4e-1ac3-41ef-a851-4598161bdb94:de.slisson.mps.tables" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables" version="0" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -257,6 +258,10 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828844315" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineColorStyle" flags="lg" index="2T_bXS" />
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
     <language id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables">
       <concept id="1925286362824252053" name="de.slisson.mps.tables.structure.ColumnShadeColor" flags="lg" index="9JesE" />
       <concept id="1925286362805506099" name="de.slisson.mps.tables.structure.RowShadeColor" flags="lg" index="bmIQc" />
@@ -499,9 +504,8 @@
         </node>
         <node concept="l2Vlx" id="1U60oYvFgT5" role="2iSdaV" />
       </node>
-      <node concept="3F0ifn" id="1U60oYvFglj" role="3EZMnx">
-        <property role="3F0ifm" value="---------------------------------------------------------------------------------------------" />
-        <node concept="VechU" id="1U60oYvFglk" role="3F10Kt">
+      <node concept="2T_mXK" id="inTShissSB" role="3EZMnx">
+        <node concept="2T_bXS" id="inTShix0wh" role="3F10Kt">
           <property role="Vb096" value="fLJRk5A/lightGray" />
         </node>
       </node>

--- a/code/tables/languages/de.slisson.mps.tables/de.slisson.mps.tables.mpl
+++ b/code/tables/languages/de.slisson.mps.tables/de.slisson.mps.tables.mpl
@@ -149,6 +149,7 @@
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -5,6 +5,7 @@
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -293,6 +294,10 @@
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
       </concept>
+    </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828844315" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineColorStyle" flags="lg" index="2T_bXS" />
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
@@ -1949,25 +1954,24 @@
           </node>
           <node concept="2iRfu4" id="3h9t8JndPS6" role="2iSdaV" />
         </node>
-        <node concept="3F0ifn" id="4cCuRQiERi0" role="3EZMnx">
-          <property role="3F0ifm" value="-----------------------------------------" />
-          <node concept="VechU" id="4cCuRQiERk5" role="3F10Kt">
-            <property role="Vb096" value="fLJRk5A/lightGray" />
-          </node>
-          <node concept="pkWqt" id="4cCuRQiERk9" role="pqm2j">
-            <node concept="3clFbS" id="4cCuRQiERka" role="2VODD2">
-              <node concept="3clFbF" id="4cCuRQiERuP" role="3cqZAp">
-                <node concept="2OqwBi" id="4cCuRQiEUCF" role="3clFbG">
-                  <node concept="2OqwBi" id="4cCuRQiER_e" role="2Oq$k0">
-                    <node concept="pncrf" id="4cCuRQiERuO" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="4cCuRQiESdN" role="2OqNvi">
+        <node concept="2T_mXK" id="inTShissSB" role="3EZMnx">
+          <node concept="pkWqt" id="inTShivHBD" role="pqm2j">
+            <node concept="3clFbS" id="inTShivHBE" role="2VODD2">
+              <node concept="3clFbF" id="inTShivIft" role="3cqZAp">
+                <node concept="2OqwBi" id="inTShivIfu" role="3clFbG">
+                  <node concept="2OqwBi" id="inTShivIfv" role="2Oq$k0">
+                    <node concept="pncrf" id="inTShivIfw" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="inTShivIfx" role="2OqNvi">
                       <ref role="3TtcxE" to="bnk3:3iamoN_rN58" resolve="items" />
                     </node>
                   </node>
-                  <node concept="3GX2aA" id="4cCuRQiF2td" role="2OqNvi" />
+                  <node concept="3GX2aA" id="inTShivIfy" role="2OqNvi" />
                 </node>
               </node>
             </node>
+          </node>
+          <node concept="2T_bXS" id="inTShivJ5J" role="3F10Kt">
+            <property role="Vb096" value="fLJRk5A/lightGray" />
           </node>
         </node>
         <node concept="3F2HdR" id="4cCuRQiERdC" role="3EZMnx">

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -3823,6 +3823,112 @@
       </node>
       <node concept="3Tm1VV" id="2rPTijxmmVE" role="1B3o_S" />
     </node>
+    <node concept="3clFb_" id="10diQy004nu" role="jymVt">
+      <property role="TrG5h" value="renderText" />
+      <node concept="3Tm1VV" id="10diQy004nv" role="1B3o_S" />
+      <node concept="3uibUv" id="10diQy004nx" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+      </node>
+      <node concept="3clFbS" id="10diQy004ny" role="3clF47">
+        <node concept="3cpWs8" id="10diQy00Ay1" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy00Ay2" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="10diQy00Ay3" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+            </node>
+            <node concept="2ShNRf" id="10diQy00HY_" role="33vP2m">
+              <node concept="1pGfFk" id="10diQy00P_3" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;()" resolve="TextBuilderImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="10diQy0hsaa" role="3cqZAp">
+          <node concept="3clFbS" id="10diQy0hsac" role="3clFbx">
+            <node concept="3clFbF" id="10diQy012Mw" role="3cqZAp">
+              <node concept="2OqwBi" id="10diQy017KT" role="3clFbG">
+                <node concept="37vLTw" id="10diQy012Mu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="10diQy00Ay2" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="10diQy01dMy" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                  <node concept="2OqwBi" id="10diQy029Hf" role="37wK5m">
+                    <node concept="37vLTw" id="10diQy01Mwa" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7GMtHW6$AKZ" resolve="myTreeRootCell" />
+                    </node>
+                    <node concept="liA8E" id="10diQy02fd1" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="10diQy020lD" role="3cqZAp">
+              <node concept="2OqwBi" id="10diQy024jv" role="3clFbG">
+                <node concept="37vLTw" id="10diQy020lB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="10diQy00Ay2" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="10diQy02mZd" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                  <node concept="2ShNRf" id="10diQy02tnu" role="37wK5m">
+                    <node concept="1pGfFk" id="10diQy02$aL" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+                      <node concept="Xl_RD" id="10diQy02BT4" role="37wK5m">
+                        <property role="Xl_RC" value="↓" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="10diQy0hPlU" role="3clFbw">
+            <node concept="10Nm6u" id="10diQy0hUVO" role="3uHU7w" />
+            <node concept="37vLTw" id="10diQy0hyAw" role="3uHU7B">
+              <ref role="3cqZAo" node="7GMtHW6$AKZ" resolve="myTreeRootCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="10diQy0ildy" role="3cqZAp">
+          <node concept="3clFbS" id="10diQy0ild$" role="3clFbx">
+            <node concept="3clFbF" id="10diQy03a4E" role="3cqZAp">
+              <node concept="2OqwBi" id="10diQy03f3w" role="3clFbG">
+                <node concept="37vLTw" id="10diQy03a4C" role="2Oq$k0">
+                  <ref role="3cqZAo" node="10diQy00Ay2" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="10diQy03l8u" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~TextBuilder.appendToTheBottom(jetbrains.mps.openapi.editor.TextBuilder)" resolve="appendToTheBottom" />
+                  <node concept="2OqwBi" id="10diQy03zv$" role="37wK5m">
+                    <node concept="37vLTw" id="10diQy03utM" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7GMtHW6$C4H" resolve="myTreeChildrenCell" />
+                    </node>
+                    <node concept="liA8E" id="10diQy03Dnj" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="10diQy0iwVR" role="3clFbw">
+            <node concept="10Nm6u" id="10diQy0iyty" role="3uHU7w" />
+            <node concept="37vLTw" id="10diQy0ir2P" role="3uHU7B">
+              <ref role="3cqZAo" node="7GMtHW6$C4H" resolve="myTreeChildrenCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="10diQy03PJ4" role="3cqZAp">
+          <node concept="37vLTw" id="10diQy03PJ2" role="3clFbG">
+            <ref role="3cqZAo" node="10diQy00Ay2" resolve="builder" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="10diQy004nz" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="7uOgiTbve2">
     <property role="TrG5h" value="TreeCellLayout" />

--- a/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
+++ b/code/treenotation/com.mbeddr.mpsutil.treenotation.runtime/models/com/mbeddr/mpsutil/treenotation/runtime.mps
@@ -3926,7 +3926,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="10diQy004nz" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/widgets/languages/de.itemis.mps.editor.bool.demolang/de.itemis.mps.editor.bool.demolang.mpl
+++ b/code/widgets/languages/de.itemis.mps.editor.bool.demolang/de.itemis.mps.editor.bool.demolang.mpl
@@ -13,6 +13,7 @@
   <accessoryModels />
   <languageVersions>
     <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/widgets/languages/de.itemis.mps.editor.bool.demolang/languageModels/editor.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.bool.demolang/languageModels/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="-1" />
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
   </languages>
   <imports>
     <import index="81p" ref="r:60cd01cc-8a5f-4a09-ae2a-d1083e859770(de.itemis.mps.editor.bool.demolang.structure)" implicit="true" />
@@ -43,6 +44,9 @@
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+    </language>
     <language id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool">
       <concept id="4900677560559655527" name="de.itemis.mps.editor.bool.structure.CellModel_Checkbox" flags="sg" stub="416014060004381438" index="27S6Sx">
         <property id="1160488491229" name="iconPathTrue" index="MwhBj" />
@@ -80,9 +84,7 @@
         <node concept="VPM3Z" id="6bmIkNC4$GR" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3F0ifn" id="6bmIkNC4Bbv" role="3EZMnx">
-          <property role="3F0ifm" value="--------------------------------------------------------------------" />
-        </node>
+        <node concept="2T_mXK" id="inTShissSB" role="3EZMnx" />
         <node concept="3F0ifn" id="1lPTJf7xdna" role="3EZMnx" />
         <node concept="3EZMnI" id="6bmIkNC4$I0" role="3EZMnx">
           <node concept="VPM3Z" id="6bmIkNC4$I2" role="3F10Kt">
@@ -149,9 +151,7 @@
           <ref role="1NtTu8" to="81p:QvUN5MYk1L" resolve="stringProperty" />
         </node>
         <node concept="3F0ifn" id="6bmIkNC4E6m" role="3EZMnx" />
-        <node concept="3F0ifn" id="7m16RPrk3lL" role="3EZMnx">
-          <property role="3F0ifm" value="--------------------------------------------------------------------" />
-        </node>
+        <node concept="2T_mXK" id="inTShissSR" role="3EZMnx" />
         <node concept="3F0ifn" id="7m16RPrk3mv" role="3EZMnx" />
         <node concept="3EZMnI" id="6bmIkNCb_jl" role="3EZMnx">
           <node concept="VPM3Z" id="6bmIkNCb_jn" role="3F10Kt">
@@ -198,9 +198,7 @@
           <node concept="2iRfu4" id="7m16RPrk1kJ" role="2iSdaV" />
         </node>
         <node concept="3F0ifn" id="7m16RPrjW7i" role="3EZMnx" />
-        <node concept="3F0ifn" id="1lPTJf7xdlD" role="3EZMnx">
-          <property role="3F0ifm" value="--------------------------------------------------------------------" />
-        </node>
+        <node concept="2T_mXK" id="inTShissSZ" role="3EZMnx" />
         <node concept="3F0ifn" id="1lPTJf7xdmp" role="3EZMnx" />
         <node concept="2EHx9g" id="6bmIkNC4_Y$" role="2iSdaV" />
       </node>

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
@@ -31,6 +31,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="w827" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs.openapi(MPS.Core/)" implicit="true" />
   </imports>
@@ -119,6 +120,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -126,6 +130,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -221,6 +226,11 @@
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -1414,6 +1424,40 @@
     </node>
     <node concept="2tJIrI" id="2Uj31fA1GuX" role="jymVt" />
     <node concept="2tJIrI" id="1QyV25GL$rM" role="jymVt" />
+    <node concept="3clFb_" id="10diQy0od0f" role="jymVt">
+      <property role="TrG5h" value="renderText" />
+      <node concept="3Tm1VV" id="10diQy0od0g" role="1B3o_S" />
+      <node concept="3uibUv" id="10diQy0od0i" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+      </node>
+      <node concept="3clFbS" id="10diQy0od0j" role="3clF47">
+        <node concept="3clFbF" id="10diQy0ooGu" role="3cqZAp">
+          <node concept="2ShNRf" id="10diQy0ooGs" role="3clFbG">
+            <node concept="1pGfFk" id="10diQy0ospt" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="3K4zz7" id="10diQy0oAF6" role="37wK5m">
+                <node concept="37vLTw" id="10diQy0oCnK" role="3K4E3e">
+                  <ref role="3cqZAo" node="1QyV25GLkD3" resolve="state" />
+                </node>
+                <node concept="Xl_RD" id="10diQy0oGIU" role="3K4GZi">
+                  <property role="Xl_RC" value="" />
+                </node>
+                <node concept="2OqwBi" id="10diQy0ow_q" role="3K4Cdx">
+                  <node concept="37vLTw" id="10diQy0ou6P" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1QyV25GLkD3" resolve="state" />
+                  </node>
+                  <node concept="17RvpY" id="10diQy0ozMc" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="10diQy0od0k" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="7bBLNlFIyOS">
     <property role="TrG5h" value="EnumerationCheckboxImages" />

--- a/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
+++ b/code/widgets/languages/de.itemis.mps.editor.enumeration/runtime/models/de.itemis.mps.editor.enumeration.runtime.mps
@@ -1455,7 +1455,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="10diQy0od0k" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -1421,7 +1421,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="10diQy0jDN8" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
+++ b/code/widgets/solutions/de.itemis.mps.editor.bool.runtime/models/de/itemis/mps/editor/bool/runtime.mps
@@ -33,6 +33,7 @@
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="hhnx" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime(MPS.Editor/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
     <import index="w827" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs.openapi(MPS.Core/)" implicit="true" />
@@ -117,6 +118,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -1376,10 +1380,49 @@
       </node>
     </node>
     <node concept="2tJIrI" id="1psyxY8SGG" role="jymVt" />
-    <node concept="2tJIrI" id="1psyxY8TRU" role="jymVt" />
     <node concept="3Tm1VV" id="4g2H4r3V4OF" role="1B3o_S" />
     <node concept="3uibUv" id="4g2H4r3V57T" role="1zkMxy">
       <ref role="3uigEE" to="g51k:~EditorCell_Basic" resolve="EditorCell_Basic" />
+    </node>
+    <node concept="3clFb_" id="10diQy0jDN3" role="jymVt">
+      <property role="TrG5h" value="renderText" />
+      <node concept="3Tm1VV" id="10diQy0jDN4" role="1B3o_S" />
+      <node concept="3uibUv" id="10diQy0jDN6" role="3clF45">
+        <ref role="3uigEE" to="cj4x:~TextBuilder" resolve="TextBuilder" />
+      </node>
+      <node concept="3clFbS" id="10diQy0jDN7" role="3clF47">
+        <node concept="3cpWs8" id="10diQy0jWIR" role="3cqZAp">
+          <node concept="3cpWsn" id="10diQy0jWIU" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="10diQy0jWIP" role="1tU5fm" />
+            <node concept="3K4zz7" id="10diQy0k332" role="33vP2m">
+              <node concept="Xl_RD" id="10diQy0k4HQ" role="3K4E3e">
+                <property role="Xl_RC" value="☑" />
+              </node>
+              <node concept="Xl_RD" id="10diQy0k7Y8" role="3K4GZi">
+                <property role="Xl_RC" value="☐" />
+              </node>
+              <node concept="37vLTw" id="10diQy0k1bc" role="3K4Cdx">
+                <ref role="3cqZAo" node="20OtND1xm1w" resolve="myIsChecked" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="10diQy0kenv" role="3cqZAp">
+          <node concept="2ShNRf" id="10diQy0kenr" role="3clFbG">
+            <node concept="1pGfFk" id="10diQy0kmVT" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="hhnx:~TextBuilderImpl.&lt;init&gt;(java.lang.String)" resolve="TextBuilderImpl" />
+              <node concept="37vLTw" id="10diQy0ktuv" role="37wK5m">
+                <ref role="3cqZAo" node="10diQy0jWIU" resolve="text" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="10diQy0jDN8" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
     </node>
   </node>
   <node concept="312cEu" id="4g2H4r3Ws82">


### PR DESCRIPTION
For the math notations, I went with a mix of LaTeX-style plaintext and some Unicode characters where they don't hurt readability. The treecells are not pretty now, but they are exported the same way that they are declared in the editor.