### PR TITLE
build: add bundled dependencies as optional runtime rather than provided

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -453,7 +453,8 @@ publishing {
                         if (it.moduleArtifacts.isNotEmpty()) {
                             dependencyNode.appendNode("type", it.moduleArtifacts.first().type)
                         }
-                        dependencyNode.appendNode("scope", "provided")
+                        dependencyNode.appendNode("scope", "runtime")
+                        dependencyNode.appendNode("optional", "true")
                     }
                 }
             }


### PR DESCRIPTION
Test whether this will make them more visible to dependency analysis tools such as ORT.