### PR TITLE
Run mkdocs as a python module and not from the global installation path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -470,12 +470,12 @@ tasks.register<Exec>("pipInstall") {
 
 tasks.register<Exec>("previewDocs") {
     dependsOn("pipInstall")
-    commandLine("mkdocs", "serve")
+    commandLine("python3", "-m", "mkdocs", "serve")
 }
 
 tasks.register<Exec>("deployDocs") {
     dependsOn("pipInstall")
-    commandLine("mkdocs", "gh-deploy", "--clean", "-r", "gh-pages", "--force")
+    commandLine("python3", "-", "mkdocs", "gh-deploy", "--clean", "-r", "gh-pages", "--force")
 }
 
 defaultTasks("build_languages")


### PR DESCRIPTION
Running mkdocs didn't work on macOS.