### PR TITLE
mps.tables: Support copying, pasting and deleting of table selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## September 2025
 
+### Added
+
+- *de.slisson.mps.tables* Tables now support copying & pasting, cutting and deleting when multiple cells are selected with the mouse. Implement the extension point *TableCopyPaste* to support these features for a specific table.
+- *de.slisson.mps.tables* Two new intention are available for tables that implement the extension point *DataTransformation.* *It* allows to parse table data in textual form (comma- or tab-separated) and paste it into the table (e.g. 10 as a number literal).
+
 ### Fixed
 
 - *de.itemis.mps.spellcheck* An exception coming from the WordsToDictionaryIntention was fixed.

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -4295,6 +4295,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="7NamNJWLm3U" role="3bR37C">
+          <node concept="3bR9La" id="7NamNJWLm3V" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="29so9Vb$6Th" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -4476,6 +4481,11 @@
         <node concept="1SiIV0" id="2obP5Y847Xl" role="3bR37C">
           <node concept="3bR9La" id="2obP5Y847Xm" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:rD7wKO6k$" resolve="MPS.Generator" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="1vOmbReDN0i" role="3bR37C">
+          <node concept="Rbm2T" id="1vOmbReDN0j" role="1SiIV1">
+            <ref role="1E1Vl2" to="ffeo:7Kfy9QB6L2F" resolve="jetbrains.mps.baseLanguage.tuples" />
           </node>
         </node>
       </node>
@@ -19143,6 +19153,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="7NamNJXoLvU" role="3bR37C">
+          <node concept="3bR9La" id="7NamNJXoLvV" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5mH$9t6eA1O" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -19227,6 +19242,11 @@
             <node concept="3qWCbU" id="7q24334ZKAc" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2P8zLSglyLQ" role="3bR37C">
+          <node concept="3bR9La" id="2P8zLSglyLR" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
           </node>
         </node>
       </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -235,6 +235,234 @@
       </node>
     </node>
     <node concept="15bmVD" id="4xFP9J_Gj2t" role="15bmVC">
+      <node concept="15bAme" id="1vOmbReLlX0" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="1vOmbReLlX1" role="15bAlk">
+          <node concept="15Ami3" id="1vOmbReLlX2" role="1PaTwD">
+            <node concept="37shsh" id="1vOmbReLlX3" role="15Aodc">
+              <node concept="1dCxOk" id="1vOmbReLlX8" role="37shsm">
+                <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                <property role="1XxBO9" value="de.slisson.mps.tables" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXd" role="1PaTwD">
+            <property role="3oM_SC" value="Tables" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXe" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXf" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXg" role="1PaTwD">
+            <property role="3oM_SC" value="copying" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl0" role="1PaTwD">
+            <property role="3oM_SC" value="&amp;" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl1" role="1PaTwD">
+            <property role="3oM_SC" value="pasting," />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXj" role="1PaTwD">
+            <property role="3oM_SC" value="cutting" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXk" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXl" role="1PaTwD">
+            <property role="3oM_SC" value="deleting" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXm" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXn" role="1PaTwD">
+            <property role="3oM_SC" value="multiple" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXo" role="1PaTwD">
+            <property role="3oM_SC" value="cells" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXp" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXq" role="1PaTwD">
+            <property role="3oM_SC" value="selected" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXr" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXs" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlXt" role="1PaTwD">
+            <property role="3oM_SC" value="mouse." />
+          </node>
+          <node concept="3oM_SD" id="419sLI2Je7V" role="1PaTwD">
+            <property role="3oM_SC" value="Implement" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlYZ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlZ0" role="1PaTwD">
+            <property role="3oM_SC" value="extension" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLlZ1" role="1PaTwD">
+            <property role="3oM_SC" value="point" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm0m" role="1PaTwD">
+            <property role="3oM_SC" value="TableCopyPaste" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm0p" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm0q" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm0r" role="1PaTwD">
+            <property role="3oM_SC" value="these" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm0s" role="1PaTwD">
+            <property role="3oM_SC" value="features" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm5l" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm5m" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="1vOmbReLm5n" role="1PaTwD">
+            <property role="3oM_SC" value="specific" />
+          </node>
+          <node concept="3oM_SD" id="419sLI2Je2Z" role="1PaTwD">
+            <property role="3oM_SC" value="table." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="6hm_9jqmTf_" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="6hm_9jqmTkO" role="1PaTwD">
+            <node concept="37shsh" id="6hm_9jqmTkQ" role="15Aodc">
+              <node concept="1dCxOk" id="6hm_9jqmTkW" role="37shsm">
+                <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                <property role="1XxBO9" value="de.slisson.mps.tables" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTkN" role="1PaTwD">
+            <property role="3oM_SC" value="Two" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjD" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjE" role="1PaTwD">
+            <property role="3oM_SC" value="intention" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjF" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjG" role="1PaTwD">
+            <property role="3oM_SC" value="available" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjH" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjI" role="1PaTwD">
+            <property role="3oM_SC" value="tables" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjJ" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjK" role="1PaTwD">
+            <property role="3oM_SC" value="implement" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjL" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjM" role="1PaTwD">
+            <property role="3oM_SC" value="extension" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjN" role="1PaTwD">
+            <property role="3oM_SC" value="point" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl2" role="1PaTwD">
+            <property role="3oM_SC" value="DataTransformation." />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl3" role="1PaTwD">
+            <property role="3oM_SC" value="It" />
+            <property role="1X82VY" value="true" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjQ" role="1PaTwD">
+            <property role="3oM_SC" value="allows" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjR" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjS" role="1PaTwD">
+            <property role="3oM_SC" value="parse" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjT" role="1PaTwD">
+            <property role="3oM_SC" value="table" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjU" role="1PaTwD">
+            <property role="3oM_SC" value="data" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjV" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjW" role="1PaTwD">
+            <property role="3oM_SC" value="textual" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjX" role="1PaTwD">
+            <property role="3oM_SC" value="form" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjY" role="1PaTwD">
+            <property role="3oM_SC" value="(comma-" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTjZ" role="1PaTwD">
+            <property role="3oM_SC" value="or" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk0" role="1PaTwD">
+            <property role="3oM_SC" value="tab-separated)" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk1" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk2" role="1PaTwD">
+            <property role="3oM_SC" value="paste" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk3" role="1PaTwD">
+            <property role="3oM_SC" value="it" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl4" role="1PaTwD">
+            <property role="3oM_SC" value="into" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTl5" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk4" role="1PaTwD">
+            <property role="3oM_SC" value="table" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk5" role="1PaTwD">
+            <property role="3oM_SC" value="(e.g." />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk6" role="1PaTwD">
+            <property role="3oM_SC" value="10" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk7" role="1PaTwD">
+            <property role="3oM_SC" value="as" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk8" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTk9" role="1PaTwD">
+            <property role="3oM_SC" value="number" />
+          </node>
+          <node concept="3oM_SD" id="6hm_9jqmTka" role="1PaTwD">
+            <property role="3oM_SC" value="literal)." />
+          </node>
+        </node>
+      </node>
       <node concept="15ShDW" id="4xFP9J_Gj2q" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgB0/September" />
         <property role="15ShDw" value="2025" />

--- a/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/de.slisson.mps.tables.demolang.mpl
@@ -16,6 +16,7 @@
     <dependency reexport="false">da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
@@ -29,7 +30,9 @@
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:f159adf4-3c93-40f9-9c5a-1f245a8697af:jetbrains.mps.lang.aspect" version="2" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
@@ -41,9 +44,11 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
@@ -53,6 +58,8 @@
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:c9d137c4-3259-44f8-80ff-33ab2b506ee4:jetbrains.mps.lang.util.order" version="0" />
+    <language slang="l:696c1165-4a59-463b-bc5d-902caab85dd0:jetbrains.mps.make.facet" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/behavior.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/behavior.mps
@@ -13,20 +13,82 @@
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
         <child id="1225194240801" name="constructor" index="13h7CW" />
       </concept>
       <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz" />
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
     </language>
   </registry>
   <node concept="13h7C7" id="1dAqnm8I96d">
@@ -40,6 +102,84 @@
     <ref role="13h7C2" to="nnej:6OOkb_bbRR8" resolve="BaseConceptComment" />
     <node concept="13hLZK" id="6OOkb_bc2Vz" role="13h7CW">
       <node concept="3clFbS" id="6OOkb_bc2V$" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2P8zLSgfHrI">
+    <property role="3GE5qa" value="CellOriented" />
+    <ref role="13h7C2" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+    <node concept="13i0hz" id="2P8zLSgfHs1" role="13h7CS">
+      <property role="TrG5h" value="getTransition" />
+      <node concept="3Tm1VV" id="2P8zLSgfHs2" role="1B3o_S" />
+      <node concept="3Tqbb2" id="2P8zLSgfHsl" role="3clF45">
+        <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+      </node>
+      <node concept="3clFbS" id="2P8zLSgfHs4" role="3clF47">
+        <node concept="3clFbF" id="2P8zLSgfH$g" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgfKTQ" role="3clFbG">
+            <node concept="2OqwBi" id="2P8zLSgfHND" role="2Oq$k0">
+              <node concept="13iPFW" id="2P8zLSgfH$f" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="2P8zLSgfHZ7" role="2OqNvi">
+                <ref role="3TtcxE" to="nnej:1dAqnm8uyz8" resolve="transitions" />
+              </node>
+            </node>
+            <node concept="1z4cxt" id="2P8zLSgfMvE" role="2OqNvi">
+              <node concept="1bVj0M" id="2P8zLSgfMvG" role="23t8la">
+                <node concept="3clFbS" id="2P8zLSgfMvH" role="1bW5cS">
+                  <node concept="3clFbF" id="2P8zLSgfMAh" role="3cqZAp">
+                    <node concept="1Wc70l" id="2P8zLSgfP4o" role="3clFbG">
+                      <node concept="17R0WA" id="2P8zLSgfV1O" role="3uHU7w">
+                        <node concept="37vLTw" id="2P8zLSgfWjF" role="3uHU7w">
+                          <ref role="3cqZAo" node="2P8zLSgfHtS" resolve="event" />
+                        </node>
+                        <node concept="2OqwBi" id="2P8zLSgfTHj" role="3uHU7B">
+                          <node concept="37vLTw" id="2P8zLSgfThB" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2P8zLSgfMvI" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="2P8zLSgfUy2" role="2OqNvi">
+                            <ref role="3Tt5mk" to="nnej:1dAqnm8uy$f" resolve="trigger" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="17R0WA" id="2P8zLSgfNyT" role="3uHU7B">
+                        <node concept="2OqwBi" id="2P8zLSgfMNC" role="3uHU7B">
+                          <node concept="37vLTw" id="2P8zLSgfMAg" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2P8zLSgfMvI" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="2P8zLSgfN7I" role="2OqNvi">
+                            <ref role="3Tt5mk" to="nnej:1dAqnm8uy$k" resolve="from" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2P8zLSgfOd0" role="3uHU7w">
+                          <ref role="3cqZAo" node="2P8zLSgfHyt" resolve="state" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="2P8zLSgfMvI" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="2P8zLSgfMvJ" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgfHtS" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3Tqbb2" id="2P8zLSgfHtR" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyl" resolve="Event" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgfHyt" role="3clF46">
+        <property role="TrG5h" value="state" />
+        <node concept="3Tqbb2" id="2P8zLSgfHyN" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="2P8zLSgfHrJ" role="13h7CW">
+      <node concept="3clFbS" id="2P8zLSgfHrK" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/intentions.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/intentions.mps
@@ -960,13 +960,13 @@
             <node concept="3cpWsd" id="630t2b8e2SV" role="3uHU7B">
               <node concept="2OqwBi" id="630t2b8e2cp" role="3uHU7B">
                 <node concept="71T_Y" id="630t2b8e263" role="2Oq$k0" />
-                <node concept="liA8E" id="630t2b8e2vm" role="2OqNvi">
+                <node concept="liA8E" id="6hm_9jpKkMp" role="2OqNvi">
                   <ref role="37wK5l" to="9p8b:630t2b85S9S" resolve="getEndColumn" />
                 </node>
               </node>
               <node concept="2OqwBi" id="630t2b8e35Z" role="3uHU7w">
                 <node concept="71T_Y" id="630t2b8e2YE" role="2Oq$k0" />
-                <node concept="liA8E" id="630t2b8e3AO" role="2OqNvi">
+                <node concept="liA8E" id="6hm_9jpKljG" role="2OqNvi">
                   <ref role="37wK5l" to="9p8b:630t2b85S9G" resolve="getStartColumn" />
                 </node>
               </node>

--- a/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables.demolang/languageModels/plugin.mps
@@ -1,0 +1,1959 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f1c5f6f4-f735-4c95-8571-0c9b99e0bba3(de.slisson.mps.tables.demolang.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="2" />
+    <use id="696c1165-4a59-463b-bc5d-902caab85dd0" name="jetbrains.mps.make.facet" version="0" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
+    <use id="c9d137c4-3259-44f8-80ff-33ab2b506ee4" name="jetbrains.mps.lang.util.order" version="0" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="nnej" ref="r:41c447ce-0fca-4a98-ad9f-dc62c992880f(de.slisson.mps.tables.demolang.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+        <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable">
+      <concept id="1177714083117" name="jetbrains.mps.baseLanguage.varVariable.structure.VarType" flags="in" index="PeGgZ" />
+      <concept id="1236693300889" name="jetbrains.mps.baseLanguage.varVariable.structure.VarVariableDeclaration" flags="ng" index="3KEzu6" />
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+    </language>
+  </registry>
+  <node concept="1lYeZD" id="2P8zLSga6VA">
+    <property role="TrG5h" value="StateMachineCopyPaste" />
+    <ref role="1lYe$Y" to="3bri:12YYiosIAdh" resolve="TableCopyPaste" />
+    <node concept="3Tm1VV" id="2P8zLSga6VB" role="1B3o_S" />
+    <node concept="2tJIrI" id="2P8zLSga6VC" role="jymVt" />
+    <node concept="3tTeZs" id="2P8zLSga6VD" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="2P8zLSga6VE" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="2P8zLSga6VF" role="jymVt" />
+    <node concept="q3mfD" id="2P8zLSga6VG" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="2P8zLSga6VI" role="1B3o_S" />
+      <node concept="3clFbS" id="2P8zLSga6VK" role="3clF47">
+        <node concept="3clFbF" id="2P8zLSgfPgQ" role="3cqZAp">
+          <node concept="2ShNRf" id="2P8zLSgfPgO" role="3clFbG">
+            <node concept="HV5vD" id="2P8zLSgfPrW" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="2P8zLSga6VL" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="2P8zLSga6VG" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="2P8zLSga70b">
+    <property role="TrG5h" value="StateMachineCopyPasteImpl" />
+    <node concept="2tJIrI" id="12YYiosYGsB" role="jymVt" />
+    <node concept="Wx3nA" id="12YYiosYHnp" role="jymVt">
+      <property role="TrG5h" value="navigationColumnsLeft" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="12YYiosYGIj" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosYHn8" role="1tU5fm" />
+      <node concept="3cmrfG" id="12YYiosYHnZ" role="33vP2m">
+        <property role="3cmrfH" value="1" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosYNt_" role="jymVt" />
+    <node concept="312cEg" id="12YYiosYOh2" role="jymVt">
+      <property role="TrG5h" value="table" />
+      <node concept="3Tm6S6" id="12YYiosYNMg" role="1B3o_S" />
+      <node concept="3Tqbb2" id="12YYiosYOg1" role="1tU5fm">
+        <ref role="ehGHo" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosYOhI" role="jymVt" />
+    <node concept="3clFb_" id="12YYiotbprz" role="jymVt">
+      <property role="TrG5h" value="setTableNode" />
+      <node concept="3Tm1VV" id="12YYiotbpr_" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiotbprA" role="3clF45" />
+      <node concept="3clFbS" id="12YYiotbprB" role="3clF47">
+        <node concept="3clFbF" id="12YYiotbJBi" role="3cqZAp">
+          <node concept="37vLTI" id="12YYiotbPbw" role="3clFbG">
+            <node concept="1PxgMI" id="12YYiotbSne" role="37vLTx">
+              <property role="1BlNFB" value="true" />
+              <node concept="37vLTw" id="12YYiotbQFE" role="1m5AlR">
+                <ref role="3cqZAo" node="12YYiotbA54" resolve="table" />
+              </node>
+              <node concept="chp4Y" id="2P8zLSgaJaj" role="3oSUPX">
+                <ref role="cht4Q" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="12YYiotbM0k" role="37vLTJ">
+              <node concept="Xjq3P" id="12YYiotbJBh" role="2Oq$k0" />
+              <node concept="2OwXpG" id="12YYiotbNGY" role="2OqNvi">
+                <ref role="2Oxat5" node="12YYiosYOh2" resolve="table" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYiotbprC" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="37vLTG" id="12YYiotbA54" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="12YYiotbA53" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosYPAg" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosYPRP" role="jymVt">
+      <property role="TrG5h" value="withoutNavigationColumns" />
+      <node concept="3clFbS" id="12YYiosYPRS" role="3clF47">
+        <node concept="3clFbF" id="12YYiosZgwS" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosZgIe" role="3clFbG">
+            <node concept="2OqwBi" id="6hm_9jpPekk" role="2Oq$k0">
+              <node concept="37vLTw" id="12YYiosZgwQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosYPY0" resolve="tableSelection" />
+              </node>
+              <node concept="liA8E" id="6hm_9jpPfXs" role="2OqNvi">
+                <ref role="37wK5l" to="9p8b:12YYiosUGf3" resolve="toUndirectedRange" />
+              </node>
+            </node>
+            <node concept="liA8E" id="12YYiosZgZo" role="2OqNvi">
+              <ref role="37wK5l" to="9p8b:12YYios_Li$" resolve="withOffset" />
+              <node concept="3cmrfG" id="2P8zLSgl1c7" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="1ZRNhn" id="12YYiosZj9S" role="37wK5m">
+                <node concept="37vLTw" id="12YYiosZjgf" role="2$L3a6">
+                  <ref role="3cqZAo" node="12YYiosYHnp" resolve="navigationColumnsLeft" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="12YYiosYPKe" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosYPRm" role="3clF45">
+        <ref role="3uigEE" to="9p8b:12YYioszPcw" resolve="UndirectedTableRange" />
+      </node>
+      <node concept="37vLTG" id="12YYiosYPY0" role="3clF46">
+        <property role="TrG5h" value="tableSelection" />
+        <node concept="3uibUv" id="12YYiosYPXZ" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosZjm9" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosZjAa" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="3Tm1VV" id="12YYiosZjAc" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosZjAd" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosZjAe" role="3clF47">
+        <node concept="3clFbF" id="12YYiosZjAh" role="3cqZAp">
+          <node concept="3cmrfG" id="12YYiosZjAg" role="3clFbG">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYiosZjAf" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1Yhk3kSO7ki" role="jymVt" />
+    <node concept="3clFb_" id="1Yhk3kSObr9" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3Tm1VV" id="1Yhk3kSObrb" role="1B3o_S" />
+      <node concept="10P_77" id="1Yhk3kSObrc" role="3clF45" />
+      <node concept="37vLTG" id="1Yhk3kSObrd" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1Yhk3kSObre" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRnhJ" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRnqJ" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1Yhk3kSObrf" role="3clF47">
+        <node concept="3clFbF" id="1Yhk3kSOlIt" role="3cqZAp">
+          <node concept="2OqwBi" id="1Yhk3kSOswR" role="3clFbG">
+            <node concept="2OqwBi" id="1Yhk3kSOntc" role="2Oq$k0">
+              <node concept="37vLTw" id="1Yhk3kSOlIq" role="2Oq$k0">
+                <ref role="3cqZAo" node="1Yhk3kSObrd" resolve="node" />
+              </node>
+              <node concept="2yIwOk" id="1Yhk3kSOqUr" role="2OqNvi" />
+            </node>
+            <node concept="2Zo12i" id="1Yhk3kSOv9o" role="2OqNvi">
+              <node concept="chp4Y" id="1Yhk3kSOweq" role="2Zo12j">
+                <ref role="cht4Q" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1Yhk3kSObrg" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosZmkJ" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosZjAI" role="jymVt">
+      <property role="TrG5h" value="delete" />
+      <node concept="37vLTG" id="12YYiosZjAJ" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosZjAK" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jq6WVd" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jq6XVj" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosZjAM" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosZjAN" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosZjAO" role="3clF47">
+        <node concept="3clFbF" id="12YYiosZqnC" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosZqS1" role="3clFbG">
+            <node concept="1rXfSq" id="12YYiosZqnB" role="2Oq$k0">
+              <ref role="37wK5l" node="12YYiosYPRP" resolve="withoutNavigationColumns" />
+              <node concept="37vLTw" id="12YYiosZq$j" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosZjAJ" resolve="selection" />
+              </node>
+            </node>
+            <node concept="liA8E" id="12YYiosZrf8" role="2OqNvi">
+              <ref role="37wK5l" to="9p8b:12YYios_kJJ" resolve="iterate" />
+              <node concept="1bVj0M" id="12YYiosZrt1" role="37wK5m">
+                <node concept="37vLTG" id="12YYiosZso7" role="1bW2Oz">
+                  <property role="TrG5h" value="rowIndex" />
+                  <node concept="10Oyi0" id="12YYiosZso4" role="1tU5fm" />
+                </node>
+                <node concept="37vLTG" id="12YYiosZtch" role="1bW2Oz">
+                  <property role="TrG5h" value="colIndex" />
+                  <node concept="10Oyi0" id="12YYiosZtce" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="12YYiosZrti" role="1bW5cS">
+                  <node concept="3clFbJ" id="12YYiosZtUJ" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiosZtUL" role="3clFbx">
+                      <node concept="3cpWs6" id="12YYiosZRnJ" role="3cqZAp" />
+                    </node>
+                    <node concept="22lmx$" id="12YYiosZFKq" role="3clFbw">
+                      <node concept="3eOSWO" id="12YYiosZGgU" role="3uHU7w">
+                        <node concept="2OqwBi" id="12YYiosZM3K" role="3uHU7w">
+                          <node concept="2OqwBi" id="12YYiosZGD3" role="2Oq$k0">
+                            <node concept="37vLTw" id="12YYiosZGx6" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="12YYiosZGTS" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                            </node>
+                          </node>
+                          <node concept="34oBXx" id="12YYiosZQNY" role="2OqNvi" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiosZG0_" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZtch" resolve="colIndex" />
+                        </node>
+                      </node>
+                      <node concept="3eOSWO" id="12YYiosZwEG" role="3uHU7B">
+                        <node concept="37vLTw" id="12YYiosZu9r" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZso7" resolve="rowIndex" />
+                        </node>
+                        <node concept="2OqwBi" id="12YYiosZB2i" role="3uHU7w">
+                          <node concept="2OqwBi" id="12YYiosZxK9" role="2Oq$k0">
+                            <node concept="37vLTw" id="12YYiosZwTq" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="12YYiosZyBs" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                            </node>
+                          </node>
+                          <node concept="34oBXx" id="12YYiosZF1I" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiosZRCW" role="3cqZAp" />
+                  <node concept="3cpWs8" id="12YYiosZS6F" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiosZS6I" role="3cpWs9">
+                      <property role="TrG5h" value="dataColIndex" />
+                      <node concept="10Oyi0" id="12YYiosZS6D" role="1tU5fm" />
+                      <node concept="3cpWsd" id="12YYiosZTu8" role="33vP2m">
+                        <node concept="3cmrfG" id="12YYiosZTuq" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiosZTcg" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZtch" resolve="colIndex" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiosZUdY" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiosZUe1" role="3cpWs9">
+                      <property role="TrG5h" value="dataRowIndex" />
+                      <node concept="10Oyi0" id="12YYiosZUdW" role="1tU5fm" />
+                      <node concept="3cpWsd" id="12YYiosZYaR" role="33vP2m">
+                        <node concept="3cmrfG" id="12YYiosZYb9" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiosZVkR" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZso7" resolve="rowIndex" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="2P8zLSgkrBw" role="3cqZAp" />
+                  <node concept="3clFbJ" id="12YYiosZYSh" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiosZYSj" role="3clFbx">
+                      <node concept="3cpWs6" id="12YYiot02YQ" role="3cqZAp" />
+                    </node>
+                    <node concept="22lmx$" id="12YYiot01xo" role="3clFbw">
+                      <node concept="3clFbC" id="12YYiot026L" role="3uHU7w">
+                        <node concept="3cmrfG" id="12YYiot02pK" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiot01NY" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZso7" resolve="rowIndex" />
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="12YYiosZZPa" role="3uHU7B">
+                        <node concept="37vLTw" id="12YYiosZZaC" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiosZtch" resolve="colIndex" />
+                        </node>
+                        <node concept="3cmrfG" id="12YYiot01eL" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot03ht" role="3cqZAp" />
+                  <node concept="3cpWs8" id="12YYiot06mp" role="3cqZAp">
+                    <node concept="3KEzu6" id="12YYiot06mm" role="3cpWs9">
+                      <property role="TrG5h" value="selectedState" />
+                      <node concept="PeGgZ" id="12YYiot06mn" role="1tU5fm" />
+                      <node concept="1y4W85" id="12YYiot0d5n" role="33vP2m">
+                        <node concept="37vLTw" id="12YYiot0dpe" role="1y58nS">
+                          <ref role="3cqZAo" node="12YYiosZUe1" resolve="dataRowIndex" />
+                        </node>
+                        <node concept="2OqwBi" id="12YYiot07Ob" role="1y566C">
+                          <node concept="37vLTw" id="12YYiot07eQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot0a3I" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiot0eta" role="3cqZAp">
+                    <node concept="3KEzu6" id="12YYiot0et7" role="3cpWs9">
+                      <property role="TrG5h" value="selectedEvent" />
+                      <node concept="PeGgZ" id="12YYiot0et8" role="1tU5fm" />
+                      <node concept="1y4W85" id="12YYiot0lXQ" role="33vP2m">
+                        <node concept="37vLTw" id="12YYiot0miw" role="1y58nS">
+                          <ref role="3cqZAo" node="12YYiosZS6I" resolve="dataColIndex" />
+                        </node>
+                        <node concept="2OqwBi" id="12YYiot0hs_" role="1y566C">
+                          <node concept="37vLTw" id="12YYiot0f4_" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot0ioV" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiot0n4w" role="3cqZAp">
+                    <node concept="3KEzu6" id="12YYiot0n4t" role="3cpWs9">
+                      <property role="TrG5h" value="selectedTransition" />
+                      <node concept="PeGgZ" id="12YYiot0n4u" role="1tU5fm" />
+                      <node concept="2OqwBi" id="2P8zLSgbOeO" role="33vP2m">
+                        <node concept="2OqwBi" id="2P8zLSgbFvU" role="2Oq$k0">
+                          <node concept="37vLTw" id="2P8zLSgbDnp" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="2P8zLSgbHbT" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz8" resolve="transitions" />
+                          </node>
+                        </node>
+                        <node concept="1z4cxt" id="2P8zLSgcWlw" role="2OqNvi">
+                          <node concept="1bVj0M" id="2P8zLSgcWly" role="23t8la">
+                            <node concept="3clFbS" id="2P8zLSgcWlz" role="1bW5cS">
+                              <node concept="3clFbF" id="2P8zLSgcWl$" role="3cqZAp">
+                                <node concept="1Wc70l" id="2P8zLSgcWl_" role="3clFbG">
+                                  <node concept="17R0WA" id="2P8zLSgcWlA" role="3uHU7w">
+                                    <node concept="37vLTw" id="2P8zLSgcWlB" role="3uHU7w">
+                                      <ref role="3cqZAo" node="12YYiot0et7" resolve="selectedEvent" />
+                                    </node>
+                                    <node concept="2OqwBi" id="2P8zLSgcWlC" role="3uHU7B">
+                                      <node concept="37vLTw" id="2P8zLSgcWlD" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2P8zLSgcWlK" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="2P8zLSgcWlE" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="nnej:1dAqnm8uy$f" resolve="trigger" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="17R0WA" id="2P8zLSgcWlF" role="3uHU7B">
+                                    <node concept="2OqwBi" id="2P8zLSgcWlG" role="3uHU7B">
+                                      <node concept="37vLTw" id="2P8zLSgcWlH" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2P8zLSgcWlK" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="2P8zLSgcWlI" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="nnej:1dAqnm8uy$k" resolve="from" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="2P8zLSgcWlJ" role="3uHU7w">
+                                      <ref role="3cqZAo" node="12YYiot06mm" resolve="selectedState" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="2P8zLSgcWlK" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="2P8zLSgcWlL" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="12YYiot0Agn" role="3cqZAp">
+                    <node concept="2OqwBi" id="12YYiot0ABI" role="3clFbG">
+                      <node concept="37vLTw" id="12YYiot0Agl" role="2Oq$k0">
+                        <ref role="3cqZAo" node="12YYiot0n4t" resolve="selectedTransition" />
+                      </node>
+                      <node concept="3YRAZt" id="12YYiot0B7O" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYiosZjAP" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosZq62" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosZjAo" role="jymVt">
+      <property role="TrG5h" value="copy" />
+      <node concept="3Tm1VV" id="12YYiosZjAq" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosZjAr" role="3clF45">
+        <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="12YYiosZjAs" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="12YYiosZjAt" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosZjAu" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jq7302" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jq7303" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="12YYiosZjAv" role="3clF47">
+        <node concept="3cpWs8" id="12YYiot0BZ5" role="3cqZAp">
+          <node concept="3KEzu6" id="12YYiot0BZ3" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="PeGgZ" id="12YYiot0BZ4" role="1tU5fm" />
+            <node concept="2ShNRf" id="12YYiot0CHO" role="33vP2m">
+              <node concept="1pGfFk" id="12YYiot0Dk5" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="3bri:12YYiosxYju" resolve="TableData" />
+                <node concept="3Tqbb2" id="12YYiot0DIh" role="1pMfVU" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6hm_9jpPNtw" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpPNtx" role="3cpWs9">
+            <property role="TrG5h" value="range" />
+            <node concept="3uibUv" id="6hm_9jpPNty" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:12YYioszPcw" resolve="UndirectedTableRange" />
+            </node>
+            <node concept="1rXfSq" id="12YYiot0Gau" role="33vP2m">
+              <ref role="37wK5l" node="12YYiosYPRP" resolve="withoutNavigationColumns" />
+              <node concept="37vLTw" id="12YYiot0IzB" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosZjAt" resolve="selection" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiot0J0g" role="3cqZAp" />
+        <node concept="3clFbF" id="12YYiot0JUC" role="3cqZAp">
+          <node concept="0kSF2" id="12YYiot4zUz" role="3clFbG">
+            <node concept="3uibUv" id="12YYiot4zU_" role="0kSFW">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="12YYiot4Ame" role="11_B2D" />
+            </node>
+            <node concept="2OqwBi" id="12YYiot0Kwp" role="0kSFX">
+              <node concept="37vLTw" id="12YYiot0JUA" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiot0BZ3" resolve="data" />
+              </node>
+              <node concept="liA8E" id="12YYiot0LVq" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:12YYioszEw1" resolve="collect" />
+                <node concept="37vLTw" id="12YYiot0Mpq" role="37wK5m">
+                  <ref role="3cqZAo" node="6hm_9jpPNtx" resolve="range" />
+                </node>
+                <node concept="1bVj0M" id="12YYiot0PRq" role="37wK5m">
+                  <node concept="37vLTG" id="12YYiot0Qxi" role="1bW2Oz">
+                    <property role="TrG5h" value="rowIndex" />
+                    <node concept="10Oyi0" id="12YYiot0Qxf" role="1tU5fm" />
+                  </node>
+                  <node concept="37vLTG" id="12YYiot0S0c" role="1bW2Oz">
+                    <property role="TrG5h" value="colIndex" />
+                    <node concept="10Oyi0" id="12YYiot0S09" role="1tU5fm" />
+                  </node>
+                  <node concept="3clFbS" id="12YYiot0PRH" role="1bW5cS">
+                    <node concept="3clFbJ" id="12YYiot0T32" role="3cqZAp">
+                      <node concept="22lmx$" id="12YYiot18B_" role="3clFbw">
+                        <node concept="3eOSWO" id="12YYiot19_i" role="3uHU7w">
+                          <node concept="2OqwBi" id="12YYiot1gL_" role="3uHU7w">
+                            <node concept="2OqwBi" id="12YYiot1aUo" role="2Oq$k0">
+                              <node concept="37vLTw" id="12YYiot1a4E" role="2Oq$k0">
+                                <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                              </node>
+                              <node concept="3Tsc0h" id="12YYiot1bpt" role="2OqNvi">
+                                <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                              </node>
+                            </node>
+                            <node concept="34oBXx" id="12YYiot1lIq" role="2OqNvi" />
+                          </node>
+                          <node concept="37vLTw" id="12YYiot196H" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0S0c" resolve="colIndex" />
+                          </node>
+                        </node>
+                        <node concept="3eOSWO" id="12YYiot0Wgb" role="3uHU7B">
+                          <node concept="37vLTw" id="12YYiot0TvW" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0Qxi" resolve="rowIndex" />
+                          </node>
+                          <node concept="2OqwBi" id="12YYiot13uu" role="3uHU7w">
+                            <node concept="2OqwBi" id="12YYiot0XJP" role="2Oq$k0">
+                              <node concept="37vLTw" id="12YYiot0WH9" role="2Oq$k0">
+                                <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                              </node>
+                              <node concept="3Tsc0h" id="12YYiot0YPo" role="2OqNvi">
+                                <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                              </node>
+                            </node>
+                            <node concept="34oBXx" id="12YYiot17Ga" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="12YYiot0T34" role="3clFbx">
+                        <node concept="3cpWs6" id="12YYiot1mwr" role="3cqZAp">
+                          <node concept="10Nm6u" id="12YYiot1p77" role="3cqZAk" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="12YYiot1pAE" role="3cqZAp" />
+                    <node concept="3cpWs8" id="12YYiot1srw" role="3cqZAp">
+                      <node concept="3cpWsn" id="12YYiot1srz" role="3cpWs9">
+                        <property role="TrG5h" value="dataColIndex" />
+                        <node concept="10Oyi0" id="12YYiot1sru" role="1tU5fm" />
+                        <node concept="3cpWsd" id="12YYiot1xLx" role="33vP2m">
+                          <node concept="3cmrfG" id="12YYiot1xLN" role="3uHU7w">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="37vLTw" id="12YYiot1trf" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0S0c" resolve="colIndex" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="12YYiot1yY3" role="3cqZAp">
+                      <node concept="3cpWsn" id="12YYiot1yY6" role="3cpWs9">
+                        <property role="TrG5h" value="dataRowIndex" />
+                        <node concept="10Oyi0" id="12YYiot1yY1" role="1tU5fm" />
+                        <node concept="3cpWsd" id="12YYiot1$YV" role="33vP2m">
+                          <node concept="3cmrfG" id="12YYiot1$Zd" role="3uHU7w">
+                            <property role="3cmrfH" value="1" />
+                          </node>
+                          <node concept="37vLTw" id="12YYiot1$uo" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0Qxi" resolve="rowIndex" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="12YYiot1_vp" role="3cqZAp" />
+                    <node concept="3clFbJ" id="12YYiot1AoW" role="3cqZAp">
+                      <node concept="3clFbS" id="12YYiot1AoY" role="3clFbx">
+                        <node concept="3cpWs6" id="12YYiot1I3t" role="3cqZAp">
+                          <node concept="10Nm6u" id="12YYiot1J7R" role="3cqZAk" />
+                        </node>
+                      </node>
+                      <node concept="1Wc70l" id="12YYiot1FGB" role="3clFbw">
+                        <node concept="3clFbC" id="12YYiot1GIG" role="3uHU7w">
+                          <node concept="3cmrfG" id="12YYiot1Hg1" role="3uHU7w">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="37vLTw" id="12YYiot1Gdz" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0Qxi" resolve="rowIndex" />
+                          </node>
+                        </node>
+                        <node concept="3clFbC" id="12YYiot1EEI" role="3uHU7B">
+                          <node concept="37vLTw" id="12YYiot1ATD" role="3uHU7B">
+                            <ref role="3cqZAo" node="12YYiot0S0c" resolve="colIndex" />
+                          </node>
+                          <node concept="3cmrfG" id="12YYiot1FbE" role="3uHU7w">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="12YYiot1Kjl" role="3cqZAp">
+                      <node concept="3clFbS" id="12YYiot1Kjn" role="3clFbx">
+                        <node concept="3cpWs6" id="12YYiot1MG5" role="3cqZAp">
+                          <node concept="2pJPEk" id="12YYiot1NJ3" role="3cqZAk">
+                            <node concept="2pJPED" id="12YYiot1NJ5" role="2pJPEn">
+                              <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                              <node concept="2pJxcG" id="12YYiot1ONP" role="2pJxcM">
+                                <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
+                                <node concept="WxPPo" id="12YYiot1Pmp" role="28ntcv">
+                                  <node concept="2OqwBi" id="12YYiot1Z5o" role="WxPPp">
+                                    <node concept="1y4W85" id="12YYiot1XLv" role="2Oq$k0">
+                                      <node concept="37vLTw" id="12YYiot1YmO" role="1y58nS">
+                                        <ref role="3cqZAo" node="12YYiot1srz" resolve="dataColIndex" />
+                                      </node>
+                                      <node concept="2OqwBi" id="12YYiot1R$G" role="1y566C">
+                                        <node concept="37vLTw" id="12YYiot1Pmn" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                                        </node>
+                                        <node concept="3Tsc0h" id="12YYiot1Tk2" role="2OqNvi">
+                                          <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3TrcHB" id="12YYiot204i" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="12YYiot1Lms" role="3clFbw">
+                        <node concept="3cmrfG" id="12YYiot1LSd" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiot1KOR" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot0Qxi" resolve="rowIndex" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="12YYiot21f4" role="3cqZAp">
+                      <node concept="3cpWsn" id="12YYiot21f7" role="3cpWs9">
+                        <property role="TrG5h" value="selectedState" />
+                        <node concept="3Tqbb2" id="12YYiot21f2" role="1tU5fm">
+                          <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+                        </node>
+                        <node concept="1y4W85" id="12YYiot28Hy" role="33vP2m">
+                          <node concept="37vLTw" id="12YYiot29ha" role="1y58nS">
+                            <ref role="3cqZAo" node="12YYiot1yY6" resolve="dataRowIndex" />
+                          </node>
+                          <node concept="2OqwBi" id="12YYiot24o2" role="1y566C">
+                            <node concept="37vLTw" id="12YYiot23gD" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="12YYiot24Vr" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="12YYiot2ax4" role="3cqZAp">
+                      <node concept="3clFbS" id="12YYiot2ax6" role="3clFbx">
+                        <node concept="3cpWs6" id="12YYiot2g8R" role="3cqZAp">
+                          <node concept="2pJPEk" id="12YYiot2gGz" role="3cqZAk">
+                            <node concept="2pJPED" id="12YYiot2gG_" role="2pJPEn">
+                              <ref role="2pJxaS" to="tpee:f$Xl_Og" resolve="StringLiteral" />
+                              <node concept="2pJxcG" id="12YYiot2hNH" role="2pJxcM">
+                                <ref role="2pJxcJ" to="tpee:f$Xl_Oh" resolve="value" />
+                                <node concept="WxPPo" id="12YYiot2k_e" role="28ntcv">
+                                  <node concept="2OqwBi" id="12YYiot2llI" role="WxPPp">
+                                    <node concept="37vLTw" id="12YYiot2k_c" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="12YYiot21f7" resolve="selectedState" />
+                                    </node>
+                                    <node concept="3TrcHB" id="12YYiot2mBB" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="12YYiot2fiG" role="3clFbw">
+                        <node concept="37vLTw" id="12YYiot2b4Q" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot0S0c" resolve="colIndex" />
+                        </node>
+                        <node concept="3cmrfG" id="12YYiot2eIH" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="12YYiot2nbr" role="3cqZAp" />
+                    <node concept="3cpWs8" id="12YYiot2nM$" role="3cqZAp">
+                      <node concept="3cpWsn" id="12YYiot2nMB" role="3cpWs9">
+                        <property role="TrG5h" value="selectedEvent" />
+                        <node concept="3Tqbb2" id="12YYiot2nMy" role="1tU5fm">
+                          <ref role="ehGHo" to="nnej:1dAqnm8uyyl" resolve="Event" />
+                        </node>
+                        <node concept="1y4W85" id="12YYiot2zjm" role="33vP2m">
+                          <node concept="37vLTw" id="12YYiot2zSs" role="1y58nS">
+                            <ref role="3cqZAo" node="12YYiot1srz" resolve="dataColIndex" />
+                          </node>
+                          <node concept="2OqwBi" id="12YYiot2tAG" role="1y566C">
+                            <node concept="37vLTw" id="12YYiot2sdg" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="12YYiot2uNq" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="12YYiot2_5b" role="3cqZAp">
+                      <node concept="3cpWsn" id="12YYiot2_5e" role="3cpWs9">
+                        <property role="TrG5h" value="content" />
+                        <node concept="3Tqbb2" id="12YYiot2_59" role="1tU5fm">
+                          <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+                        </node>
+                        <node concept="2OqwBi" id="2P8zLSgdw1e" role="33vP2m">
+                          <node concept="2OqwBi" id="2P8zLSgdw1f" role="2Oq$k0">
+                            <node concept="37vLTw" id="2P8zLSgdw1g" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="2P8zLSgdw1h" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz8" resolve="transitions" />
+                            </node>
+                          </node>
+                          <node concept="1z4cxt" id="2P8zLSgdw1i" role="2OqNvi">
+                            <node concept="1bVj0M" id="2P8zLSgdw1j" role="23t8la">
+                              <node concept="3clFbS" id="2P8zLSgdw1k" role="1bW5cS">
+                                <node concept="3clFbF" id="2P8zLSgdw1l" role="3cqZAp">
+                                  <node concept="1Wc70l" id="2P8zLSgdw1m" role="3clFbG">
+                                    <node concept="17R0WA" id="2P8zLSgdw1n" role="3uHU7w">
+                                      <node concept="37vLTw" id="2P8zLSgdw1o" role="3uHU7w">
+                                        <ref role="3cqZAo" node="12YYiot2nMB" resolve="selectedEvent" />
+                                      </node>
+                                      <node concept="2OqwBi" id="2P8zLSgdw1p" role="3uHU7B">
+                                        <node concept="37vLTw" id="2P8zLSgdw1q" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2P8zLSgdw1x" resolve="it" />
+                                        </node>
+                                        <node concept="3TrEf2" id="2P8zLSgdw1r" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="nnej:1dAqnm8uy$f" resolve="trigger" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="17R0WA" id="2P8zLSgdw1s" role="3uHU7B">
+                                      <node concept="2OqwBi" id="2P8zLSgdw1t" role="3uHU7B">
+                                        <node concept="37vLTw" id="2P8zLSgdw1u" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2P8zLSgdw1x" resolve="it" />
+                                        </node>
+                                        <node concept="3TrEf2" id="2P8zLSgdw1v" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="nnej:1dAqnm8uy$k" resolve="from" />
+                                        </node>
+                                      </node>
+                                      <node concept="37vLTw" id="2P8zLSgdw1w" role="3uHU7w">
+                                        <ref role="3cqZAo" node="12YYiot21f7" resolve="selectedState" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="gl6BB" id="2P8zLSgdw1x" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="2P8zLSgdw1y" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="12YYiot2QfA" role="3cqZAp">
+                      <node concept="2OqwBi" id="12YYiot2Rf0" role="3cqZAk">
+                        <node concept="37vLTw" id="12YYiot2QRn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiot2_5e" resolve="content" />
+                        </node>
+                        <node concept="1$rogu" id="2P8zLSgdT9Y" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYiosZjAw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosZp4E" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosZjAz" role="jymVt">
+      <property role="TrG5h" value="paste" />
+      <node concept="37vLTG" id="12YYiosZjA$" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosZjA_" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYiosZjAA" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="3uibUv" id="12YYiosZjAB" role="1tU5fm">
+          <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+          <node concept="3Tqbb2" id="12YYiosZjAC" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jpR_3X" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpR_3Y" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosZjAE" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosZjAF" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosZjAG" role="3clF47">
+        <node concept="3cpWs8" id="12YYiot4BgK" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiot4BgN" role="3cpWs9">
+            <property role="TrG5h" value="startRow" />
+            <node concept="10Oyi0" id="12YYiot4BgJ" role="1tU5fm" />
+            <node concept="2OqwBi" id="12YYiot4ImX" role="33vP2m">
+              <node concept="37vLTw" id="12YYiot4HPa" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+              </node>
+              <node concept="liA8E" id="6hm_9jpBxkc" role="2OqNvi">
+                <ref role="37wK5l" to="9p8b:630t2b85S9A" resolve="getStartRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="12YYiot4Oh3" role="3cqZAp">
+          <node concept="1PaTwC" id="12YYiot4Oh4" role="1aUNEU">
+            <node concept="3oM_SD" id="12YYiot4OUc" role="1PaTwD">
+              <property role="3oM_SC" value="The" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUd" role="1PaTwD">
+              <property role="3oM_SC" value="user" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUe" role="1PaTwD">
+              <property role="3oM_SC" value="may" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUf" role="1PaTwD">
+              <property role="3oM_SC" value="have" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUg" role="1PaTwD">
+              <property role="3oM_SC" value="selected" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUh" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUi" role="1PaTwD">
+              <property role="3oM_SC" value="first" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUj" role="1PaTwD">
+              <property role="3oM_SC" value="navigation" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUk" role="1PaTwD">
+              <property role="3oM_SC" value="column." />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUl" role="1PaTwD">
+              <property role="3oM_SC" value="If" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUm" role="1PaTwD">
+              <property role="3oM_SC" value="so," />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUn" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUo" role="1PaTwD">
+              <property role="3oM_SC" value="start" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUp" role="1PaTwD">
+              <property role="3oM_SC" value="column" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUq" role="1PaTwD">
+              <property role="3oM_SC" value="index" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUr" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4OUu" role="1PaTwD">
+              <property role="3oM_SC" value="fine." />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="12YYiot4RUQ" role="3cqZAp">
+          <node concept="1PaTwC" id="12YYiot4RUR" role="1aUNEU">
+            <node concept="3oM_SD" id="12YYiot4SzV" role="1PaTwD">
+              <property role="3oM_SC" value="If" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4SzW" role="1PaTwD">
+              <property role="3oM_SC" value="not," />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4SzX" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4SzY" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4SzZ" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$0" role="1PaTwD">
+              <property role="3oM_SC" value="shift" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$1" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$2" role="1PaTwD">
+              <property role="3oM_SC" value="column" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$3" role="1PaTwD">
+              <property role="3oM_SC" value="by" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$4" role="1PaTwD">
+              <property role="3oM_SC" value="one" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$5" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$6" role="1PaTwD">
+              <property role="3oM_SC" value="order" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$7" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$8" role="1PaTwD">
+              <property role="3oM_SC" value="iterate" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$9" role="1PaTwD">
+              <property role="3oM_SC" value="over" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$a" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$b" role="1PaTwD">
+              <property role="3oM_SC" value="correct" />
+            </node>
+            <node concept="3oM_SD" id="12YYiot4S$c" role="1PaTwD">
+              <property role="3oM_SC" value="indices." />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiot4TpE" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiot4TpH" role="3cpWs9">
+            <property role="TrG5h" value="startCol" />
+            <node concept="10Oyi0" id="12YYiot4TpC" role="1tU5fm" />
+            <node concept="3K4zz7" id="12YYiot54py" role="33vP2m">
+              <node concept="3cpWsd" id="12YYiot5s9W" role="3K4GZi">
+                <node concept="37vLTw" id="12YYiot5sQY" role="3uHU7w">
+                  <ref role="3cqZAo" node="12YYiosYHnp" resolve="navigationColumnsLeft" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpBSQO" role="3uHU7B">
+                  <node concept="37vLTw" id="6hm_9jpBSQP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jpBSQQ" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9G" resolve="getStartColumn" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="12YYiot52Rw" role="3K4Cdx">
+                <node concept="3cmrfG" id="12YYiot53J4" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="12YYiot4Wqz" role="3uHU7B">
+                  <node concept="37vLTw" id="12YYiot4VEn" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jpBB5z" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9G" resolve="getStartColumn" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpBRRz" role="3K4E3e">
+                <node concept="37vLTw" id="6hm_9jpBRR$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+                </node>
+                <node concept="liA8E" id="6hm_9jpBRR_" role="2OqNvi">
+                  <ref role="37wK5l" to="9p8b:630t2b85S9G" resolve="getStartColumn" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiot5tJw" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiot5uwg" role="3clFbG">
+            <node concept="37vLTw" id="12YYiot5tJu" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosZjAA" resolve="data" />
+            </node>
+            <node concept="liA8E" id="12YYiot5v_6" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:12YYiosyq_Y" resolve="forEach" />
+              <node concept="37vLTw" id="12YYiot5Cb1" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiot4BgN" resolve="startRow" />
+              </node>
+              <node concept="37vLTw" id="12YYiot5EHF" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiot4TpH" resolve="startCol" />
+              </node>
+              <node concept="1bVj0M" id="12YYiot5HLz" role="37wK5m">
+                <node concept="37vLTG" id="12YYiot5KhS" role="1bW2Oz">
+                  <property role="TrG5h" value="value" />
+                  <node concept="3Tqbb2" id="12YYiot5KhP" role="1tU5fm" />
+                </node>
+                <node concept="37vLTG" id="12YYiot5Oc1" role="1bW2Oz">
+                  <property role="TrG5h" value="row" />
+                  <node concept="10Oyi0" id="12YYiot5ObY" role="1tU5fm" />
+                </node>
+                <node concept="37vLTG" id="12YYiot5PO_" role="1bW2Oz">
+                  <property role="TrG5h" value="col" />
+                  <node concept="10Oyi0" id="12YYiot5POy" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="12YYiot5HLT" role="1bW5cS">
+                  <node concept="3clFbJ" id="12YYiot5RtF" role="3cqZAp">
+                    <node concept="3eOSWO" id="12YYiot5Vgm" role="3clFbw">
+                      <node concept="2OqwBi" id="12YYiot64_Q" role="3uHU7w">
+                        <node concept="2OqwBi" id="12YYiot5Xwz" role="2Oq$k0">
+                          <node concept="37vLTw" id="12YYiot5W0s" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot5YTe" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                          </node>
+                        </node>
+                        <node concept="34oBXx" id="12YYiot69Op" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiot5SdH" role="3uHU7B">
+                        <ref role="3cqZAo" node="12YYiot5PO_" resolve="col" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="12YYiot5RtH" role="3clFbx">
+                      <node concept="3SKdUt" id="12YYiot6aFK" role="3cqZAp">
+                        <node concept="1PaTwC" id="12YYiot6aFL" role="1aUNEU">
+                          <node concept="3oM_SD" id="2P8zLSgdYpJ" role="1PaTwD">
+                            <property role="3oM_SC" value="ignore" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6bsU" role="1PaTwD">
+                            <property role="3oM_SC" value="columns" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6bsV" role="1PaTwD">
+                            <property role="3oM_SC" value="which" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6bsW" role="1PaTwD">
+                            <property role="3oM_SC" value="are" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6bsX" role="1PaTwD">
+                            <property role="3oM_SC" value="outside" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6cZ8" role="1PaTwD">
+                            <property role="3oM_SC" value="of" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6efU" role="1PaTwD">
+                            <property role="3oM_SC" value="the" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6efV" role="1PaTwD">
+                            <property role="3oM_SC" value="table" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="12YYiot6j78" role="3cqZAp" />
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot6jSj" role="3cqZAp" />
+                  <node concept="2$JKZl" id="12YYiot6kGC" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiot6kGE" role="2LFqv$">
+                      <node concept="3SKdUt" id="12YYiot6B6K" role="3cqZAp">
+                        <node concept="1PaTwC" id="12YYiot6B6L" role="1aUNEU">
+                          <node concept="3oM_SD" id="12YYiot6BTg" role="1PaTwD">
+                            <property role="3oM_SC" value="append" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6Dub" role="1PaTwD">
+                            <property role="3oM_SC" value="new" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot6F36" role="1PaTwD">
+                            <property role="3oM_SC" value="rows" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="12YYiot6GGz" role="3cqZAp">
+                        <node concept="2OqwBi" id="12YYiot6JGZ" role="3clFbG">
+                          <node concept="2OqwBi" id="12YYiot6Hgw" role="2Oq$k0">
+                            <node concept="37vLTw" id="12YYiot6GGx" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="12YYiot6I3Y" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                            </node>
+                          </node>
+                          <node concept="WFELt" id="12YYiot6L95" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3eOSWO" id="12YYiot6oym" role="2$JKZa">
+                      <node concept="2OqwBi" id="12YYiot6xFI" role="3uHU7w">
+                        <node concept="2OqwBi" id="12YYiot6rjR" role="2Oq$k0">
+                          <node concept="37vLTw" id="12YYiot6pkR" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot6sI1" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                          </node>
+                        </node>
+                        <node concept="34oBXx" id="12YYiot6Ae1" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiot6lue" role="3uHU7B">
+                        <ref role="3cqZAo" node="12YYiot5Oc1" resolve="row" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot6MuH" role="3cqZAp" />
+                  <node concept="3clFbJ" id="12YYiot6Nl5" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiot6Nl7" role="3clFbx">
+                      <node concept="3cpWs6" id="12YYiot6U6l" role="3cqZAp" />
+                    </node>
+                    <node concept="1Wc70l" id="12YYiot6QzZ" role="3clFbw">
+                      <node concept="3clFbC" id="12YYiot6SbO" role="3uHU7w">
+                        <node concept="3cmrfG" id="12YYiot6T01" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiot6RnN" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot5PO_" resolve="col" />
+                        </node>
+                      </node>
+                      <node concept="3clFbC" id="12YYiot6OWm" role="3uHU7B">
+                        <node concept="37vLTw" id="12YYiot6O8I" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot5Oc1" resolve="row" />
+                        </node>
+                        <node concept="3cmrfG" id="12YYiot6PKa" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot6UUa" role="3cqZAp" />
+                  <node concept="3cpWs8" id="12YYiot6VU_" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiot6VUC" role="3cpWs9">
+                      <property role="TrG5h" value="dataRowIndex" />
+                      <node concept="10Oyi0" id="12YYiot6VUz" role="1tU5fm" />
+                      <node concept="3cpWsd" id="12YYiot74Kc" role="33vP2m">
+                        <node concept="3cmrfG" id="12YYiot74Ku" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiot722h" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot5Oc1" resolve="row" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiot76_m" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiot76_p" role="3cpWs9">
+                      <property role="TrG5h" value="dataColIndex" />
+                      <node concept="10Oyi0" id="12YYiot76_k" role="1tU5fm" />
+                      <node concept="3cpWsd" id="12YYiot79Sa" role="33vP2m">
+                        <node concept="3cmrfG" id="12YYiot79Ss" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="12YYiot793l" role="3uHU7B">
+                          <ref role="3cqZAo" node="12YYiot5PO_" resolve="col" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot7aGU" role="3cqZAp" />
+                  <node concept="3clFbJ" id="12YYiot7bBM" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiot7bBO" role="3clFbx">
+                      <node concept="3clFbF" id="12YYiot7gpw" role="3cqZAp">
+                        <node concept="37vLTI" id="12YYiot7tn$" role="3clFbG">
+                          <node concept="2OqwBi" id="12YYiot7pXS" role="37vLTJ">
+                            <node concept="1y4W85" id="12YYiot7nVm" role="2Oq$k0">
+                              <node concept="37vLTw" id="12YYiot7oTl" role="1y58nS">
+                                <ref role="3cqZAo" node="12YYiot76_p" resolve="dataColIndex" />
+                              </node>
+                              <node concept="2OqwBi" id="12YYiot7hHn" role="1y566C">
+                                <node concept="37vLTw" id="12YYiot7gpu" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                                </node>
+                                <node concept="3Tsc0h" id="12YYiot7jax" role="2OqNvi">
+                                  <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrcHB" id="12YYiot7rg4" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                          <node concept="2YIFZM" id="1vOmbReBkqI" role="37vLTx">
+                            <ref role="37wK5l" to="3bri:1vOmbRe_nkb" resolve="nodeToData" />
+                            <ref role="1Pybhc" to="3bri:12YYiosJFef" resolve="TableTransformationManager" />
+                            <node concept="37vLTw" id="1vOmbReBkqJ" role="37wK5m">
+                              <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+                            </node>
+                            <node concept="37vLTw" id="1vOmbReBkqK" role="37wK5m">
+                              <ref role="3cqZAo" node="12YYiot5KhS" resolve="value" />
+                            </node>
+                            <node concept="37vLTw" id="7NamNJWYP4B" role="37wK5m">
+                              <ref role="3cqZAo" node="6hm_9jpR_3X" resolve="editorContext" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="12YYiot7B1e" role="3cqZAp" />
+                    </node>
+                    <node concept="3clFbC" id="12YYiot7eGp" role="3clFbw">
+                      <node concept="3cmrfG" id="12YYiot7fxB" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiot7cty" role="3uHU7B">
+                        <ref role="3cqZAo" node="12YYiot5Oc1" resolve="row" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiot7D5r" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiot7D5u" role="3cpWs9">
+                      <property role="TrG5h" value="selectedState" />
+                      <node concept="3Tqbb2" id="12YYiot7D5p" role="1tU5fm">
+                        <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+                      </node>
+                      <node concept="1y4W85" id="12YYiot7Rft" role="33vP2m">
+                        <node concept="37vLTw" id="12YYiot7Sg7" role="1y58nS">
+                          <ref role="3cqZAo" node="12YYiot6VUC" resolve="dataRowIndex" />
+                        </node>
+                        <node concept="2OqwBi" id="12YYiot7Lld" role="1y566C">
+                          <node concept="37vLTw" id="12YYiot7JZC" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot7MZ8" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="12YYiot7Ul0" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiot7Ul2" role="3clFbx">
+                      <node concept="3clFbF" id="12YYiot80Hp" role="3cqZAp">
+                        <node concept="37vLTI" id="12YYiot86zR" role="3clFbG">
+                          <node concept="2YIFZM" id="1vOmbReBm8K" role="37vLTx">
+                            <ref role="37wK5l" to="3bri:1vOmbRe_nkb" resolve="nodeToData" />
+                            <ref role="1Pybhc" to="3bri:12YYiosJFef" resolve="TableTransformationManager" />
+                            <node concept="37vLTw" id="1vOmbReBn8a" role="37wK5m">
+                              <ref role="3cqZAo" node="12YYiosZjA$" resolve="selection" />
+                            </node>
+                            <node concept="37vLTw" id="1vOmbReBo72" role="37wK5m">
+                              <ref role="3cqZAo" node="12YYiot5KhS" resolve="value" />
+                            </node>
+                            <node concept="37vLTw" id="7NamNJWYTW5" role="37wK5m">
+                              <ref role="3cqZAo" node="6hm_9jpR_3X" resolve="editorContext" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="12YYiot82X9" role="37vLTJ">
+                            <node concept="37vLTw" id="12YYiot80Hn" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiot7D5u" resolve="selectedState" />
+                            </node>
+                            <node concept="3TrcHB" id="12YYiot84jl" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="12YYiot8h4e" role="3cqZAp" />
+                    </node>
+                    <node concept="3clFbC" id="12YYiot7YCS" role="3clFbw">
+                      <node concept="3cmrfG" id="12YYiot7ZDN" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiot7Vna" role="3uHU7B">
+                        <ref role="3cqZAo" node="12YYiot5PO_" resolve="col" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="12YYiot8i78" role="3cqZAp" />
+                  <node concept="3cpWs8" id="12YYiot8kv8" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiot8kvb" role="3cpWs9">
+                      <property role="TrG5h" value="selectedEvent" />
+                      <node concept="3Tqbb2" id="12YYiot8kv6" role="1tU5fm">
+                        <ref role="ehGHo" to="nnej:1dAqnm8uyyl" resolve="Event" />
+                      </node>
+                      <node concept="1y4W85" id="12YYiot8A3M" role="33vP2m">
+                        <node concept="37vLTw" id="12YYiot8B6Y" role="1y58nS">
+                          <ref role="3cqZAo" node="12YYiot76_p" resolve="dataColIndex" />
+                        </node>
+                        <node concept="2OqwBi" id="12YYiot8u0E" role="1y566C">
+                          <node concept="37vLTw" id="12YYiot8sC$" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="12YYiot8x6U" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz0" resolve="events" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="12YYiot8Di3" role="3cqZAp">
+                    <node concept="3cpWsn" id="12YYiot8Di6" role="3cpWs9">
+                      <property role="TrG5h" value="transition" />
+                      <node concept="3Tqbb2" id="12YYiot8Di1" role="1tU5fm">
+                        <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+                      </node>
+                      <node concept="2OqwBi" id="2P8zLSgeMwf" role="33vP2m">
+                        <node concept="2OqwBi" id="2P8zLSgeMwg" role="2Oq$k0">
+                          <node concept="37vLTw" id="2P8zLSgeMwh" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                          </node>
+                          <node concept="3Tsc0h" id="2P8zLSgeMwi" role="2OqNvi">
+                            <ref role="3TtcxE" to="nnej:1dAqnm8uyz8" resolve="transitions" />
+                          </node>
+                        </node>
+                        <node concept="1z4cxt" id="2P8zLSgeMwj" role="2OqNvi">
+                          <node concept="1bVj0M" id="2P8zLSgeMwk" role="23t8la">
+                            <node concept="3clFbS" id="2P8zLSgeMwl" role="1bW5cS">
+                              <node concept="3clFbF" id="2P8zLSgeMwm" role="3cqZAp">
+                                <node concept="1Wc70l" id="2P8zLSgeMwn" role="3clFbG">
+                                  <node concept="17R0WA" id="2P8zLSgeMwo" role="3uHU7w">
+                                    <node concept="37vLTw" id="2P8zLSgeMwp" role="3uHU7w">
+                                      <ref role="3cqZAo" node="12YYiot8kvb" resolve="selectedEvent" />
+                                    </node>
+                                    <node concept="2OqwBi" id="2P8zLSgeMwq" role="3uHU7B">
+                                      <node concept="37vLTw" id="2P8zLSgeMwr" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2P8zLSgeMwy" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="2P8zLSgeMws" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="nnej:1dAqnm8uy$f" resolve="trigger" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="17R0WA" id="2P8zLSgeMwt" role="3uHU7B">
+                                    <node concept="2OqwBi" id="2P8zLSgeMwu" role="3uHU7B">
+                                      <node concept="37vLTw" id="2P8zLSgeMwv" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2P8zLSgeMwy" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="2P8zLSgeMww" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="nnej:1dAqnm8uy$k" resolve="from" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="2P8zLSgeMwx" role="3uHU7w">
+                                      <ref role="3cqZAo" node="12YYiot7D5u" resolve="selectedState" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="2P8zLSgeMwy" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="2P8zLSgeMwz" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="12YYiot91Fq" role="3cqZAp">
+                    <node concept="3clFbS" id="12YYiot91Fs" role="3clFbx">
+                      <node concept="3SKdUt" id="12YYiot962W" role="3cqZAp">
+                        <node concept="1PaTwC" id="12YYiot962X" role="1aUNEU">
+                          <node concept="3oM_SD" id="12YYiot978y" role="1PaTwD">
+                            <property role="3oM_SC" value="new" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot9bbG" role="1PaTwD">
+                            <property role="3oM_SC" value="data" />
+                          </node>
+                          <node concept="3oM_SD" id="12YYiot9bbH" role="1PaTwD">
+                            <property role="3oM_SC" value="cell" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="12YYiot9dGw" role="3cqZAp">
+                        <node concept="37vLTI" id="12YYiot9iAg" role="3clFbG">
+                          <node concept="2ShNRf" id="12YYiot9k09" role="37vLTx">
+                            <node concept="3zrR0B" id="12YYiot9lbU" role="2ShVmc">
+                              <node concept="3Tqbb2" id="12YYiot9lbW" role="3zrR0E">
+                                <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="12YYiot9dGu" role="37vLTJ">
+                            <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="12YYiot9o_X" role="3cqZAp">
+                        <node concept="37vLTI" id="12YYiot9slB" role="3clFbG">
+                          <node concept="37vLTw" id="12YYiot9trV" role="37vLTx">
+                            <ref role="3cqZAo" node="12YYiot8kvb" resolve="selectedEvent" />
+                          </node>
+                          <node concept="2OqwBi" id="12YYiot9pA1" role="37vLTJ">
+                            <node concept="37vLTw" id="12YYiot9o_V" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                            </node>
+                            <node concept="3TrEf2" id="12YYiot9qUl" role="2OqNvi">
+                              <ref role="3Tt5mk" to="nnej:1dAqnm8uy$f" resolve="trigger" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2P8zLSgfiH5" role="3cqZAp">
+                        <node concept="37vLTI" id="2P8zLSgfpZo" role="3clFbG">
+                          <node concept="37vLTw" id="2P8zLSgfrq$" role="37vLTx">
+                            <ref role="3cqZAo" node="12YYiot7D5u" resolve="selectedState" />
+                          </node>
+                          <node concept="2OqwBi" id="2P8zLSgfmko" role="37vLTJ">
+                            <node concept="37vLTw" id="2P8zLSgfiH3" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                            </node>
+                            <node concept="3TrEf2" id="2P8zLSgfoFx" role="2OqNvi">
+                              <ref role="3Tt5mk" to="nnej:1dAqnm8uy$k" resolve="from" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2P8zLSgeYtq" role="3cqZAp">
+                        <node concept="2OqwBi" id="2P8zLSgf8qj" role="3clFbG">
+                          <node concept="2OqwBi" id="2P8zLSgf0pR" role="2Oq$k0">
+                            <node concept="37vLTw" id="2P8zLSgeYto" role="2Oq$k0">
+                              <ref role="3cqZAo" node="12YYiosYOh2" resolve="table" />
+                            </node>
+                            <node concept="3Tsc0h" id="2P8zLSgf1Ot" role="2OqNvi">
+                              <ref role="3TtcxE" to="nnej:1dAqnm8uyz8" resolve="transitions" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="2P8zLSgfcEn" role="2OqNvi">
+                            <node concept="37vLTw" id="2P8zLSgff2V" role="25WWJ7">
+                              <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="12YYiot93Vn" role="3clFbw">
+                      <node concept="10Nm6u" id="12YYiot94Rc" role="3uHU7w" />
+                      <node concept="37vLTw" id="12YYiot92NB" role="3uHU7B">
+                        <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="1vOmbRevOyM" role="3cqZAp">
+                    <node concept="37vLTI" id="1vOmbRevTg2" role="3clFbG">
+                      <node concept="2OqwBi" id="1vOmbRew1Xw" role="37vLTx">
+                        <node concept="1PxgMI" id="1vOmbRevVUB" role="2Oq$k0">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="1vOmbRevYff" role="3oSUPX">
+                            <ref role="cht4Q" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+                          </node>
+                          <node concept="37vLTw" id="1vOmbRevUvf" role="1m5AlR">
+                            <ref role="3cqZAo" node="12YYiot5KhS" resolve="value" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="1vOmbRew3kr" role="2OqNvi">
+                          <ref role="3Tt5mk" to="nnej:1dAqnm8uy$r" resolve="to" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1vOmbRevPqS" role="37vLTJ">
+                        <node concept="37vLTw" id="1vOmbRevOyK" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiot8Di6" resolve="transition" />
+                        </node>
+                        <node concept="3TrEf2" id="1vOmbRevRXx" role="2OqNvi">
+                          <ref role="3Tt5mk" to="nnej:1dAqnm8uy$r" resolve="to" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYiosZjAH" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2P8zLSga9H9" role="jymVt" />
+    <node concept="3Tm1VV" id="2P8zLSga70c" role="1B3o_S" />
+    <node concept="3uibUv" id="2P8zLSga70Q" role="EKbjA">
+      <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+    </node>
+  </node>
+  <node concept="1lYeZD" id="1vOmbReydi4">
+    <property role="TrG5h" value="StateMachineTransformer" />
+    <ref role="1lYe$Y" to="3bri:12YYiosJH7W" resolve="DataTransformation" />
+    <node concept="3Tm1VV" id="1vOmbReydi5" role="1B3o_S" />
+    <node concept="2tJIrI" id="1vOmbReydi6" role="jymVt" />
+    <node concept="3tTeZs" id="1vOmbReydi7" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="1vOmbReydi8" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="1vOmbReydi9" role="jymVt" />
+    <node concept="q3mfD" id="1vOmbReydia" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="1vOmbReydic" role="1B3o_S" />
+      <node concept="3clFbS" id="1vOmbReydie" role="3clF47">
+        <node concept="3clFbF" id="1vOmbRezRGv" role="3cqZAp">
+          <node concept="2ShNRf" id="1vOmbRezRGt" role="3clFbG">
+            <node concept="HV5vD" id="1vOmbRezRRL" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="1vOmbReydkM" resolve="StateMachineTransformerImpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="1vOmbReydif" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="1vOmbReydia" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1vOmbReydkM">
+    <property role="TrG5h" value="StateMachineTransformerImpl" />
+    <node concept="312cEg" id="1vOmbRezTcV" role="jymVt">
+      <property role="TrG5h" value="stateMachine" />
+      <node concept="3Tqbb2" id="1vOmbRezT1q" role="1tU5fm">
+        <ref role="ehGHo" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+      </node>
+      <node concept="3Tm6S6" id="1vOmbRezTsY" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1vOmbRezSSb" role="jymVt" />
+    <node concept="3Tm1VV" id="1vOmbReydkN" role="1B3o_S" />
+    <node concept="3uibUv" id="1vOmbReydmV" role="EKbjA">
+      <ref role="3uigEE" to="3bri:12YYiosJH84" resolve="DataTransformer" />
+    </node>
+    <node concept="3clFb_" id="1vOmbReydo1" role="jymVt">
+      <property role="TrG5h" value="getPriority" />
+      <node concept="3Tm1VV" id="1vOmbReydo3" role="1B3o_S" />
+      <node concept="10Oyi0" id="1vOmbReydo4" role="3clF45" />
+      <node concept="3clFbS" id="1vOmbReydo5" role="3clF47">
+        <node concept="3clFbF" id="1vOmbReydo8" role="3cqZAp">
+          <node concept="3cmrfG" id="1vOmbReydo7" role="3clFbG">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1vOmbReydo6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpQO4x" role="jymVt" />
+    <node concept="3clFb_" id="2CQc9DOyqsp" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3Tm1VV" id="2CQc9DOyqsr" role="1B3o_S" />
+      <node concept="10P_77" id="2CQc9DOyqss" role="3clF45" />
+      <node concept="37vLTG" id="2CQc9DOyqst" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="2CQc9DOyqsu" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQOrU" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQOEP" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="2CQc9DOyqsv" role="3clF47">
+        <node concept="3clFbF" id="2CQc9DOysff" role="3cqZAp">
+          <node concept="2OqwBi" id="2CQc9DOyszA" role="3clFbG">
+            <node concept="37vLTw" id="2CQc9DOysfe" role="2Oq$k0">
+              <ref role="3cqZAo" node="2CQc9DOyqst" resolve="node" />
+            </node>
+            <node concept="1mIQ4w" id="2CQc9DOysT6" role="2OqNvi">
+              <node concept="chp4Y" id="2CQc9DOyt4z" role="cj9EA">
+                <ref role="cht4Q" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="2CQc9DOyqsw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbRezS45" role="jymVt" />
+    <node concept="3clFb_" id="1vOmbRezS9l" role="jymVt">
+      <property role="TrG5h" value="setTable" />
+      <node concept="3Tm1VV" id="1vOmbRezS9n" role="1B3o_S" />
+      <node concept="3cqZAl" id="1vOmbRezS9o" role="3clF45" />
+      <node concept="37vLTG" id="1vOmbRezS9p" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="1vOmbRezS9q" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1vOmbRezS9r" role="3clF47">
+        <node concept="3clFbF" id="1vOmbRezTIW" role="3cqZAp">
+          <node concept="37vLTI" id="1vOmbRezUzl" role="3clFbG">
+            <node concept="1PxgMI" id="1vOmbRezV30" role="37vLTx">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="1vOmbRezVad" role="3oSUPX">
+                <ref role="cht4Q" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+              </node>
+              <node concept="37vLTw" id="1vOmbRezUG_" role="1m5AlR">
+                <ref role="3cqZAo" node="1vOmbRezS9p" resolve="table" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1vOmbRezTUC" role="37vLTJ">
+              <node concept="Xjq3P" id="1vOmbRezTIV" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1vOmbRezUey" role="2OqNvi">
+                <ref role="2Oxat5" node="1vOmbRezTcV" resolve="stateMachine" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1vOmbRezS9s" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbReyeEw" role="jymVt" />
+    <node concept="3clFb_" id="1vOmbReydo9" role="jymVt">
+      <property role="TrG5h" value="fromString" />
+      <node concept="3Tm1VV" id="1vOmbReydob" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1vOmbReydoc" role="3clF45" />
+      <node concept="37vLTG" id="1vOmbReydod" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="17QB3L" id="1vOmbReydoe" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="1vOmbReydof" role="3clF47">
+        <node concept="3cpWs8" id="1vOmbReCYf1" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbReCYf4" role="3cpWs9">
+            <property role="TrG5h" value="transition" />
+            <node concept="3Tqbb2" id="1vOmbReCYeZ" role="1tU5fm">
+              <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+            </node>
+            <node concept="2ShNRf" id="1vOmbReCYY1" role="33vP2m">
+              <node concept="3zrR0B" id="1vOmbReCZde" role="2ShVmc">
+                <node concept="3Tqbb2" id="1vOmbReCZdg" role="3zrR0E">
+                  <ref role="ehGHo" to="nnej:1dAqnm8uyyZ" resolve="Transition" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReD0_K" role="3cqZAp">
+          <node concept="37vLTI" id="1vOmbReD1AB" role="3clFbG">
+            <node concept="2OqwBi" id="1vOmbReD0ST" role="37vLTJ">
+              <node concept="37vLTw" id="1vOmbReD0_I" role="2Oq$k0">
+                <ref role="3cqZAo" node="1vOmbReCYf4" resolve="transition" />
+              </node>
+              <node concept="3TrEf2" id="1vOmbReD1gf" role="2OqNvi">
+                <ref role="3Tt5mk" to="nnej:1dAqnm8uy$r" resolve="to" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1vOmbReD1VH" role="37vLTx">
+              <node concept="2OqwBi" id="1vOmbReD1VI" role="2Oq$k0">
+                <node concept="37vLTw" id="1vOmbReD1VJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1vOmbRezTcV" resolve="stateMachine" />
+                </node>
+                <node concept="3Tsc0h" id="1vOmbReD1VK" role="2OqNvi">
+                  <ref role="3TtcxE" to="nnej:1dAqnm8uyz3" resolve="states" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="1vOmbReD1VL" role="2OqNvi">
+                <node concept="1bVj0M" id="1vOmbReD1VM" role="23t8la">
+                  <node concept="3clFbS" id="1vOmbReD1VN" role="1bW5cS">
+                    <node concept="3clFbF" id="1vOmbReD1VO" role="3cqZAp">
+                      <node concept="17R0WA" id="1vOmbReD1VP" role="3clFbG">
+                        <node concept="37vLTw" id="1vOmbReD1VQ" role="3uHU7w">
+                          <ref role="3cqZAo" node="1vOmbReydod" resolve="data" />
+                        </node>
+                        <node concept="2OqwBi" id="1vOmbReD1VR" role="3uHU7B">
+                          <node concept="37vLTw" id="1vOmbReD1VS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1vOmbReD1VU" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="1vOmbReD1VT" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="1vOmbReD1VU" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1vOmbReD1VV" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReD2xA" role="3cqZAp">
+          <node concept="37vLTw" id="1vOmbReD2x$" role="3clFbG">
+            <ref role="3cqZAo" node="1vOmbReCYf4" resolve="transition" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1vOmbReydog" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/tables/languages/de.slisson.mps.tables/de.slisson.mps.tables.mpl
+++ b/code/tables/languages/de.slisson.mps.tables/de.slisson.mps.tables.mpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language namespace="de.slisson.mps.tables" uuid="7e450f4e-1ac3-41ef-a851-4598161bdb94" languageVersion="0" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="languageModels" />
     </modelRoot>
   </models>
@@ -50,6 +50,7 @@
         <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
         <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
         <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
@@ -147,9 +148,11 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
+    <dependency reexport="false" scope="generate-into">a247e09e-2435-45ba-b8d2-07e93feba96a(jetbrains.mps.baseLanguage.tuples)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
+    <language slang="l:05f762a9-99f5-4971-a9ed-5a6481dc2be4:de.itemis.mps.selection.intentions" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -158,6 +161,7 @@
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
@@ -206,6 +210,7 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="a247e09e-2435-45ba-b8d2-07e93feba96a(jetbrains.mps.baseLanguage.tuples)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
+++ b/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
@@ -10,6 +10,7 @@
     <use id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal" version="-1" />
     <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -47,6 +48,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="wwqx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.logging(MPS.Core/)" />
+    <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -61,6 +63,9 @@
         <child id="1238857764950" name="tuple" index="1LFl5Q" />
         <child id="1238857834412" name="index" index="1LF_Uc" />
       </concept>
+    </language>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
@@ -300,6 +305,7 @@
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
         <child id="1200911492601" name="mappingLabel" index="2rTMjI" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+        <child id="1195502100749" name="preMappingScript" index="1puA0r" />
       </concept>
       <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
         <child id="1177093586806" name="templateNode" index="gfFT$" />
@@ -343,6 +349,15 @@
       </concept>
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1195499912406" name="jetbrains.mps.lang.generator.structure.MappingScript" flags="lg" index="1pmfR0">
+        <property id="1195595592106" name="scriptKind" index="1v3f2W" />
+        <property id="1195595611951" name="modifiesModel" index="1v3jST" />
+        <child id="1195501105008" name="codeBlock" index="1pqMTA" />
+      </concept>
+      <concept id="1195500722856" name="jetbrains.mps.lang.generator.structure.MappingScript_CodeBlock" flags="in" index="1pplIY" />
+      <concept id="1195502151594" name="jetbrains.mps.lang.generator.structure.MappingScriptReference" flags="lg" index="1puMqW">
+        <reference id="1195502167610" name="mappingScript" index="1puQsG" />
       </concept>
       <concept id="982871510064032177" name="jetbrains.mps.lang.generator.structure.IParameterizedTemplate" flags="ngI" index="1s_3nv">
         <child id="982871510064032342" name="parameter" index="1s_3oS" />
@@ -394,10 +409,30 @@
         <child id="1216860049632" name="inputNode" index="1iwH7V" />
       </concept>
       <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
+      <concept id="1217026863835" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetOriginalInputModel" flags="nn" index="1st3f0" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -434,6 +469,12 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -447,12 +488,16 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
+      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
+        <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
+      </concept>
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
       </concept>
+      <concept id="3648723375513868532" name="jetbrains.mps.lang.smodel.structure.NodePointer_ResolveOperation" flags="ng" index="Vyspw" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
         <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
@@ -471,11 +516,16 @@
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
+        <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
+      </concept>
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -552,6 +602,7 @@
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
@@ -560,6 +611,7 @@
         <child id="1225711191269" name="index" index="1y58nS" />
       </concept>
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
@@ -1312,6 +1364,9 @@
           <node concept="3Tm1VV" id="7EUu569j_qO" role="1B3o_S" />
         </node>
       </node>
+    </node>
+    <node concept="1puMqW" id="7NamNJWFJWH" role="1puA0r">
+      <ref role="1puQsG" node="7NamNJWFqGT" resolve="preprocessTables" />
     </node>
   </node>
   <node concept="13MO4I" id="fXNk7yt">
@@ -13602,6 +13657,168 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="7Pt6c$zhMfQ" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="1pmfR0" id="7NamNJWFqGT">
+    <property role="TrG5h" value="preprocessTables" />
+    <property role="1v3f2W" value="hpv1Zf2/pre_processing" />
+    <property role="1v3jST" value="true" />
+    <node concept="1pplIY" id="7NamNJWFqGU" role="1pqMTA">
+      <node concept="3clFbS" id="7NamNJWFqGV" role="2VODD2">
+        <node concept="3clFbF" id="7NamNJWFu6j" role="3cqZAp">
+          <node concept="2OqwBi" id="7NamNJWFy94" role="3clFbG">
+            <node concept="2OqwBi" id="7NamNJWFufd" role="2Oq$k0">
+              <node concept="1Q6Npb" id="7NamNJWFu6i" role="2Oq$k0" />
+              <node concept="2SmgA7" id="7NamNJWFuuO" role="2OqNvi">
+                <node concept="chp4Y" id="7NamNJWFuvd" role="1dBWTz">
+                  <ref role="cht4Q" to="bnk3:1dAqnm8m1Em" resolve="Table" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="7NamNJWF_97" role="2OqNvi">
+              <node concept="1bVj0M" id="7NamNJWF_99" role="23t8la">
+                <node concept="3clFbS" id="7NamNJWF_9a" role="1bW5cS">
+                  <node concept="3clFbJ" id="7NamNJWF_cS" role="3cqZAp">
+                    <node concept="2OqwBi" id="7NamNJWFAzQ" role="3clFbw">
+                      <node concept="2OqwBi" id="7NamNJWF_zx" role="2Oq$k0">
+                        <node concept="37vLTw" id="7NamNJWF_hM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7NamNJWF_9b" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="7NamNJWFA4O" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
+                        </node>
+                      </node>
+                      <node concept="3w_OXm" id="7NamNJWFB0H" role="2OqNvi" />
+                    </node>
+                    <node concept="3clFbS" id="7NamNJWF_cU" role="3clFbx">
+                      <node concept="3cpWs8" id="2CQc9DPhiHO" role="3cqZAp">
+                        <node concept="3cpWsn" id="2CQc9DPhiHR" role="3cpWs9">
+                          <property role="TrG5h" value="newCellActionMap" />
+                          <node concept="3Tqbb2" id="2CQc9DPhiHM" role="1tU5fm">
+                            <ref role="ehGHo" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
+                          </node>
+                          <node concept="2pJPEk" id="2CQc9DPhkwL" role="33vP2m">
+                            <node concept="2pJPED" id="2CQc9DPhkwN" role="2pJPEn">
+                              <ref role="2pJxaS" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
+                              <node concept="2pJxcG" id="2CQc9DPhkJ5" role="2pJxcM">
+                                <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                                <node concept="WxPPo" id="2CQc9DPhkOC" role="28ntcv">
+                                  <node concept="Xl_RD" id="2CQc9DPhkOB" role="WxPPp">
+                                    <property role="Xl_RC" value="TableSelectionActionMap" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="2CQc9DPhlgl" role="3cqZAp">
+                        <node concept="3cpWsn" id="2CQc9DPhlgm" role="3cpWs9">
+                          <property role="TrG5h" value="templateCellActionMap" />
+                          <node concept="3Tqbb2" id="2CQc9DPhldA" role="1tU5fm">
+                            <ref role="ehGHo" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
+                          </node>
+                          <node concept="2OqwBi" id="2CQc9DPhlgn" role="33vP2m">
+                            <node concept="2tJFMh" id="2CQc9DPhlgo" role="2Oq$k0">
+                              <node concept="ZC_QK" id="2CQc9DPhlgp" role="2tJFKM">
+                                <ref role="2aWVGs" to="reoo:12YYiosTWdF" resolve="TableSelectionActionMap" />
+                              </node>
+                            </node>
+                            <node concept="Vyspw" id="2CQc9DPhlgq" role="2OqNvi">
+                              <node concept="2OqwBi" id="2CQc9DPhlgr" role="Vysub">
+                                <node concept="2JrnkZ" id="2CQc9DPhlgs" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="2CQc9DPhlgt" role="2JrQYb">
+                                    <node concept="1iwH7S" id="2CQc9DPhlgu" role="2Oq$k0" />
+                                    <node concept="1st3f0" id="2CQc9DPhlgv" role="2OqNvi" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="2CQc9DPhlgw" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2CQc9DPhmhj" role="3cqZAp">
+                        <node concept="2OqwBi" id="2CQc9DPhqdU" role="3clFbG">
+                          <node concept="2OqwBi" id="2CQc9DPhm$6" role="2Oq$k0">
+                            <node concept="37vLTw" id="2CQc9DPhmhh" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
+                            </node>
+                            <node concept="3Tsc0h" id="2CQc9DPhn4o" role="2OqNvi">
+                              <ref role="3TtcxE" to="tpc2:g_h_SO1" resolve="item" />
+                            </node>
+                          </node>
+                          <node concept="X8dFx" id="2CQc9DPhsN6" role="2OqNvi">
+                            <node concept="2OqwBi" id="2CQc9DPhuHF" role="25WWJ7">
+                              <node concept="2OqwBi" id="2CQc9DPhtUd" role="2Oq$k0">
+                                <node concept="37vLTw" id="2CQc9DPhtbD" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2CQc9DPhlgm" resolve="templateCellActionMap" />
+                                </node>
+                                <node concept="3Tsc0h" id="2CQc9DPhu3l" role="2OqNvi">
+                                  <ref role="3TtcxE" to="tpc2:g_h_SO1" resolve="item" />
+                                </node>
+                              </node>
+                              <node concept="3$u5V9" id="2CQc9DPhvku" role="2OqNvi">
+                                <node concept="1bVj0M" id="2CQc9DPhvkw" role="23t8la">
+                                  <node concept="3clFbS" id="2CQc9DPhvkx" role="1bW5cS">
+                                    <node concept="3clFbF" id="2CQc9DPhvyD" role="3cqZAp">
+                                      <node concept="2OqwBi" id="2CQc9DPhvO_" role="3clFbG">
+                                        <node concept="37vLTw" id="2CQc9DPhvyC" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2CQc9DPhvky" resolve="it" />
+                                        </node>
+                                        <node concept="1$rogu" id="2CQc9DPhwCs" role="2OqNvi" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="gl6BB" id="2CQc9DPhvky" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="2CQc9DPhvkz" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="2CQc9DPhxnM" role="3cqZAp">
+                        <node concept="2OqwBi" id="2CQc9DPhxC3" role="3clFbG">
+                          <node concept="1Q6Npb" id="2CQc9DPhxnL" role="2Oq$k0" />
+                          <node concept="3BYIHo" id="2CQc9DPhxTE" role="2OqNvi">
+                            <node concept="37vLTw" id="2CQc9DPhy2F" role="3BYIHq">
+                              <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="7NamNJWFBdY" role="3cqZAp">
+                        <node concept="37vLTI" id="7NamNJWFDRq" role="3clFbG">
+                          <node concept="2OqwBi" id="7NamNJWFBuQ" role="37vLTJ">
+                            <node concept="37vLTw" id="7NamNJWFBdX" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7NamNJWF_9b" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="7NamNJWFC1S" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="2CQc9DPhyAd" role="37vLTx">
+                            <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="7NamNJWF_9b" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7NamNJWF_9c" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -6,6 +6,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
+    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -22,10 +23,14 @@
     <import index="oghc" ref="r:356c0504-b4a3-4458-9604-13fbb48838d7(de.slisson.mps.tables.runtime.style)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
@@ -48,6 +53,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="3459162043708467089" name="jetbrains.mps.lang.editor.structure.CellActionMap_CanExecuteFunction" flags="in" index="jK8Ss" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
@@ -120,6 +126,15 @@
         <child id="414384289274424751" name="parts" index="3ft5RZ" />
       </concept>
       <concept id="414384289274418284" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Condition" flags="ig" index="3ft6gW" />
+      <concept id="1139535219966" name="jetbrains.mps.lang.editor.structure.CellActionMapDeclaration" flags="ig" index="1h_SRR">
+        <child id="1139535219969" name="item" index="1h_SK8" />
+      </concept>
+      <concept id="1139535280617" name="jetbrains.mps.lang.editor.structure.CellActionMapItem" flags="lg" index="1hA7zw">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="3459162043708468028" name="canExecuteFunction" index="jK8aL" />
+        <child id="1139535280620" name="executeFunction" index="1hA7z_" />
+      </concept>
+      <concept id="1139535439104" name="jetbrains.mps.lang.editor.structure.CellActionMap_ExecuteFunction" flags="in" index="1hAIg9" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
@@ -198,6 +213,7 @@
       </concept>
       <concept id="6918029743850363447" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_targetNode" flags="ng" index="1NM5Ph" />
       <concept id="6918029743850308467" name="jetbrains.mps.lang.editor.structure.QueryFunction_RefPresentation" flags="ig" index="1NMggl" />
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
         <property id="1088613081987" name="vertical" index="1QpmdY" />
         <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
@@ -211,8 +227,13 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1153422305557" name="jetbrains.mps.baseLanguage.structure.LessThanOrEqualsExpression" flags="nn" index="2dkUwp" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -230,6 +251,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -246,6 +270,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
@@ -256,6 +281,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -280,15 +306,18 @@
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
@@ -375,6 +404,10 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable">
+      <concept id="1177714083117" name="jetbrains.mps.baseLanguage.varVariable.structure.VarType" flags="in" index="PeGgZ" />
+      <concept id="1236693300889" name="jetbrains.mps.baseLanguage.varVariable.structure.VarVariableDeclaration" flags="ng" index="3KEzu6" />
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
@@ -552,6 +585,10 @@
         </node>
       </node>
       <node concept="3F0ifn" id="5ivXze3cgdo" role="3EZMnx" />
+      <node concept="PMmxH" id="12YYiorPfYl" role="3EZMnx">
+        <ref role="PMmxG" to="tpc5:3h9t8Jnexr_" resolve="Common_Component" />
+      </node>
+      <node concept="3F0ifn" id="12YYiorPfYk" role="3EZMnx" />
       <node concept="3F0ifn" id="fGPA53L" role="3EZMnx">
         <property role="3F0ifm" value="Table:" />
         <ref role="1k5W1q" to="tpc5:hF4yUZ8" resolve="header" />
@@ -3470,6 +3507,615 @@
   <node concept="22mcaB" id="4iNiUqGz3n0">
     <ref role="aqKnT" to="bnk3:3t1pVyvZ48U" resolve="CellCreateOperation" />
     <node concept="22hDWj" id="7q24335a1Cp" role="22hAXT" />
+  </node>
+  <node concept="1h_SRR" id="12YYiosTWdF">
+    <property role="TrG5h" value="TableSelectionActionMap" />
+    <node concept="1hA7zw" id="12YYiosTWdG" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="12YYiosTWdH" role="1hA7z_">
+        <node concept="3clFbS" id="12YYiosTWdI" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosTWrC" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosTWrD" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosTWrf" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosTWrE" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosTWrF" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2HEu" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosTZ9L" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosTZ9M" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosTZ9N" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosTZPq" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosTZPt" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosTZpV" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosTZbO" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosTZbx" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosTZjG" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosTZyJ" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosVVlm" role="3cqZAp">
+            <node concept="2OqwBi" id="12YYiosVVui" role="3clFbG">
+              <node concept="37vLTw" id="12YYiosVVlk" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosTWrD" resolve="support" />
+              </node>
+              <node concept="liA8E" id="12YYiosVVCw" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:12YYiosI$xW" resolve="delete" />
+                <node concept="37vLTw" id="12YYiosVVDj" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosTZ9M" resolve="selection" />
+                </node>
+                <node concept="1Q80Hx" id="6hm_9jq77WO" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="12YYiosXoA6" role="jK8aL">
+        <node concept="3clFbS" id="12YYiosXoA7" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosXoQB" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXoQC" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosXoQD" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosXoQE" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosXoQF" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2HBl" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXoQG" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXoQH" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosXoQI" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosXoQJ" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosXoQK" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosXoQL" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosXoQM" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosXoQN" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosXoQO" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosXoQP" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosXp3D" role="3cqZAp">
+            <node concept="1Wc70l" id="12YYiosXqtS" role="3clFbG">
+              <node concept="3y3z36" id="12YYiosXrcZ" role="3uHU7w">
+                <node concept="10Nm6u" id="12YYiosXs7o" role="3uHU7w" />
+                <node concept="37vLTw" id="12YYiosXqvA" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXoQH" resolve="selection" />
+                </node>
+              </node>
+              <node concept="3y3z36" id="12YYiosXpel" role="3uHU7B">
+                <node concept="37vLTw" id="12YYiosXp3B" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXoQC" resolve="support" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXpU3" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1hA7zw" id="12YYiosTWe_" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABBii/cut_action_id" />
+      <node concept="1hAIg9" id="12YYiosTWeA" role="1hA7z_">
+        <node concept="3clFbS" id="12YYiosTWeB" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosVVEb" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVVEc" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosVVEd" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosVVEe" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosVVEf" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2I2r" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiotbZlz" role="3cqZAp">
+            <node concept="2OqwBi" id="12YYiotbZz8" role="3clFbG">
+              <node concept="37vLTw" id="12YYiotbZlx" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosVVEc" resolve="support" />
+              </node>
+              <node concept="liA8E" id="12YYiotbZNd" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:12YYiotb5ZU" resolve="setTableNode" />
+                <node concept="0IXxy" id="12YYiotbZPw" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosVVEg" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVVEh" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosVVEi" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosVVEj" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosVVEk" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosVVEl" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosVVEm" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosVVEn" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosVVEo" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosVVEp" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXw_q" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXw_r" role="3cpWs9">
+              <property role="TrG5h" value="data" />
+              <node concept="3uibUv" id="12YYiosXtKx" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+                <node concept="3Tqbb2" id="12YYiosXtK$" role="11_B2D" />
+              </node>
+              <node concept="2OqwBi" id="12YYiosXw_s" role="33vP2m">
+                <node concept="37vLTw" id="12YYiosXw_t" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosVVEc" resolve="support" />
+                </node>
+                <node concept="liA8E" id="12YYiosXw_u" role="2OqNvi">
+                  <ref role="37wK5l" to="3bri:12YYiosI$_L" resolve="cut" />
+                  <node concept="37vLTw" id="12YYiosXw_v" role="37wK5m">
+                    <ref role="3cqZAo" node="12YYiosVVEh" resolve="selection" />
+                  </node>
+                  <node concept="1Q80Hx" id="6hm_9jq7836" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5LghDpmxc2v" role="3cqZAp">
+            <node concept="2OqwBi" id="5LghDpmxcnQ" role="3clFbG">
+              <node concept="2YIFZM" id="5LghDpmxceu" role="2Oq$k0">
+                <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+                <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+              </node>
+              <node concept="liA8E" id="5LghDpmxcyd" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:5LghDpmwTyC" resolve="put" />
+                <node concept="37vLTw" id="5LghDpmxcz7" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosXw_r" resolve="data" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXytT" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXytU" role="3cpWs9">
+              <property role="TrG5h" value="dataAsString" />
+              <node concept="3uibUv" id="12YYiosXytR" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+                <node concept="17QB3L" id="12YYiosXyDZ" role="11_B2D" />
+              </node>
+              <node concept="2YIFZM" id="1vOmbRe_T79" role="33vP2m">
+                <ref role="37wK5l" to="3bri:1vOmbRe_boa" resolve="nodeDataToStringData" />
+                <ref role="1Pybhc" to="3bri:12YYiosJFef" resolve="TableTransformationManager" />
+                <node concept="37vLTw" id="7NamNJXAZIw" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosVVEh" resolve="selection" />
+                </node>
+                <node concept="37vLTw" id="1vOmbRe_Tbi" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosXw_r" resolve="data" />
+                </node>
+                <node concept="1Q80Hx" id="7NamNJWMhnM" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosX$OW" role="3cqZAp">
+            <node concept="2YIFZM" id="12YYiosX$Zr" role="3clFbG">
+              <ref role="37wK5l" to="3bri:12YYiosJ5bq" resolve="putIntoOSClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+              <node concept="37vLTw" id="12YYiosX_1n" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosXytU" resolve="dataAsString" />
+              </node>
+              <node concept="Rm8GO" id="12YYiosX_cP" role="37wK5m">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9FV" resolve="TAB" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="12YYiosXsN4" role="jK8aL">
+        <node concept="3clFbS" id="12YYiosXsN5" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosXsQQ" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXsQR" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosXsQS" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosXsQT" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosXsQU" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2HUF" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXsQV" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXsQW" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosXsQX" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosXsQY" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosXsQZ" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosXsR0" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosXsR1" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosXsR2" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosXsR3" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosXsR4" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosXt2N" role="3cqZAp">
+            <node concept="1Wc70l" id="12YYiosXsZN" role="3clFbG">
+              <node concept="3y3z36" id="12YYiosXsXS" role="3uHU7B">
+                <node concept="37vLTw" id="12YYiosXsRd" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXsQR" resolve="support" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXsRe" role="3uHU7w" />
+              </node>
+              <node concept="3y3z36" id="12YYiosXtGs" role="3uHU7w">
+                <node concept="37vLTw" id="12YYiosXsRb" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXsQW" resolve="selection" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXsRa" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1hA7zw" id="12YYiosTWdZ" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABBih/copy_action_id" />
+      <node concept="1hAIg9" id="12YYiosTWe0" role="1hA7z_">
+        <node concept="3clFbS" id="12YYiosTWe1" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosVVP4" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVVP5" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosVVP6" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosVVP7" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosVVP8" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2JnE" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosVVP9" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVVPa" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosVVPb" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosVVPc" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosVVPd" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosVVPe" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosVVPf" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosVVPg" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosVVPh" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosVVPi" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXjQG" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXjQH" role="3cpWs9">
+              <property role="TrG5h" value="data" />
+              <node concept="3uibUv" id="12YYiosXjPk" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+                <node concept="3Tqbb2" id="12YYiosXjPn" role="11_B2D" />
+              </node>
+              <node concept="2OqwBi" id="12YYiosXjQI" role="33vP2m">
+                <node concept="37vLTw" id="12YYiosXjQJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosVVP5" resolve="support" />
+                </node>
+                <node concept="liA8E" id="12YYiosXjQK" role="2OqNvi">
+                  <ref role="37wK5l" to="3bri:12YYiosIoWm" resolve="copy" />
+                  <node concept="37vLTw" id="12YYiosXjQL" role="37wK5m">
+                    <ref role="3cqZAo" node="12YYiosVVPa" resolve="selection" />
+                  </node>
+                  <node concept="1Q80Hx" id="6hm_9jq76us" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5LghDpmxd5D" role="3cqZAp">
+            <node concept="2OqwBi" id="5LghDpmxdqR" role="3clFbG">
+              <node concept="2YIFZM" id="5LghDpmxdh0" role="2Oq$k0">
+                <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+                <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+              </node>
+              <node concept="liA8E" id="5LghDpmxd$T" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:5LghDpmwTyC" resolve="put" />
+                <node concept="37vLTw" id="5LghDpmxdA4" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosXjQH" resolve="data" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="12YYiosXlFt" role="3cqZAp" />
+          <node concept="3cpWs8" id="12YYiosXlUM" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXlUN" role="3cpWs9">
+              <property role="TrG5h" value="dataAsString" />
+              <node concept="3uibUv" id="12YYiosXlUK" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+                <node concept="17QB3L" id="12YYiosXmwS" role="11_B2D" />
+              </node>
+              <node concept="2YIFZM" id="1vOmbRe_U_f" role="33vP2m">
+                <ref role="37wK5l" to="3bri:1vOmbRe_boa" resolve="nodeDataToStringData" />
+                <ref role="1Pybhc" to="3bri:12YYiosJFef" resolve="TableTransformationManager" />
+                <node concept="37vLTw" id="7NamNJXB1aN" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosVVPa" resolve="selection" />
+                </node>
+                <node concept="37vLTw" id="1vOmbRe_U_h" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosXjQH" resolve="data" />
+                </node>
+                <node concept="1Q80Hx" id="7NamNJWMhKb" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosXo16" role="3cqZAp">
+            <node concept="2YIFZM" id="12YYiosXoc5" role="3clFbG">
+              <ref role="37wK5l" to="3bri:12YYiosJ5bq" resolve="putIntoOSClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+              <node concept="37vLTw" id="12YYiosXodJ" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosXlUN" resolve="dataAsString" />
+              </node>
+              <node concept="Rm8GO" id="12YYiosXoop" role="37wK5m">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9FV" resolve="TAB" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="12YYiosXtLP" role="jK8aL">
+        <node concept="3clFbS" id="12YYiosXtLQ" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosXtZE" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXtZF" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosXtZG" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosXtZH" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosXtZI" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2Jgj" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXtZJ" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXtZK" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosXtZL" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosXtZM" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosXtZN" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosXtZO" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosXtZP" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosXtZQ" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosXtZR" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosXtZS" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosXu83" role="3cqZAp">
+            <node concept="1Wc70l" id="12YYiosXw0_" role="3clFbG">
+              <node concept="3y3z36" id="12YYiosXuLS" role="3uHU7B">
+                <node concept="37vLTw" id="12YYiosXu01" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXtZF" resolve="support" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXu02" role="3uHU7w" />
+              </node>
+              <node concept="3y3z36" id="12YYiosXv0T" role="3uHU7w">
+                <node concept="37vLTw" id="12YYiosXtZZ" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXtZK" resolve="selection" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXtZY" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1hA7zw" id="12YYiosTWei" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABBij/paste_action_id" />
+      <node concept="1hAIg9" id="12YYiosTWej" role="1hA7z_">
+        <node concept="3clFbS" id="12YYiosTWek" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosVW0t" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVW0u" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosVW0v" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosVW0w" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosVW0x" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2JWW" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosVW0y" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosVW0z" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosVW0$" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosVW0_" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosVW0A" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosVW0B" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosVW0C" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosVW0D" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosVW0E" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosVW0F" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXCpY" role="3cqZAp">
+            <node concept="3KEzu6" id="12YYiosXCpV" role="3cpWs9">
+              <property role="TrG5h" value="data" />
+              <node concept="PeGgZ" id="12YYiosXCpW" role="1tU5fm" />
+              <node concept="2OqwBi" id="5LghDpmxedk" role="33vP2m">
+                <node concept="2YIFZM" id="5LghDpmxe56" role="2Oq$k0">
+                  <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+                </node>
+                <node concept="liA8E" id="5LghDpmxemJ" role="2OqNvi">
+                  <ref role="37wK5l" to="3bri:5LghDpmwTpN" resolve="get" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosVW0X" role="3cqZAp">
+            <node concept="2OqwBi" id="12YYiosVW0Y" role="3clFbG">
+              <node concept="37vLTw" id="12YYiosVW0Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosVW0u" resolve="support" />
+              </node>
+              <node concept="liA8E" id="12YYiosVW10" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:12YYiosIoZg" resolve="paste" />
+                <node concept="37vLTw" id="12YYiosVW11" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosVW0z" resolve="selection" />
+                </node>
+                <node concept="37vLTw" id="12YYiosXEIc" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosXCpV" resolve="data" />
+                </node>
+                <node concept="1Q80Hx" id="7NamNJWXzP2" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="12YYiosXwdx" role="jK8aL">
+        <node concept="3clFbS" id="12YYiosXwdy" role="2VODD2">
+          <node concept="3cpWs8" id="12YYiosXwh4" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXwh5" role="3cpWs9">
+              <property role="TrG5h" value="support" />
+              <node concept="3uibUv" id="12YYiosXwh6" role="1tU5fm">
+                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              </node>
+              <node concept="2YIFZM" id="12YYiosXwh7" role="33vP2m">
+                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="12YYiosXwh8" role="37wK5m" />
+                <node concept="1Q80Hx" id="6hm_9jq2JG5" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="12YYiosXwh9" role="3cqZAp">
+            <node concept="3cpWsn" id="12YYiosXwha" role="3cpWs9">
+              <property role="TrG5h" value="selection" />
+              <node concept="3uibUv" id="12YYiosXwhb" role="1tU5fm">
+                <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+              </node>
+              <node concept="0kSF2" id="12YYiosXwhc" role="33vP2m">
+                <node concept="3uibUv" id="12YYiosXwhd" role="0kSFW">
+                  <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosXwhe" role="0kSFX">
+                  <node concept="2OqwBi" id="12YYiosXwhf" role="2Oq$k0">
+                    <node concept="1Q80Hx" id="12YYiosXwhg" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosXwhh" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getSelectionManager()" resolve="getSelectionManager" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="12YYiosXwhi" role="2OqNvi">
+                    <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="12YYiosXwpO" role="3cqZAp">
+            <node concept="1Wc70l" id="12YYiosXws8" role="3clFbG">
+              <node concept="3y3z36" id="12YYiosXwue" role="3uHU7B">
+                <node concept="37vLTw" id="12YYiosXwhr" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXwh5" resolve="support" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXwhs" role="3uHU7w" />
+              </node>
+              <node concept="3y3z36" id="12YYiosXwwg" role="3uHU7w">
+                <node concept="37vLTw" id="12YYiosXwhp" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosXwha" resolve="selection" />
+                </node>
+                <node concept="10Nm6u" id="12YYiosXwho" role="3uHU7w" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/intentions.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/intentions.mps
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:343baeb3-4eac-45b0-a29c-c8fdd66be702(de.slisson.mps.tables.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="05f762a9-99f5-4971-a9ed-5a6481dc2be4" name="de.itemis.mps.selection.intentions" version="0" />
+    <engage id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" implicit="true" />
+    <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" implicit="true" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1201385106094" name="jetbrains.mps.baseLanguage.structure.PropertyReference" flags="nn" index="2S8uIT">
+        <reference id="1201385237847" name="property" index="2S8YL0" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="05f762a9-99f5-4971-a9ed-5a6481dc2be4" name="de.itemis.mps.selection.intentions">
+      <concept id="6009478650970401999" name="de.itemis.mps.selection.intentions.structure.Description" flags="ig" index="71TwL" />
+      <concept id="6009478650970402176" name="de.itemis.mps.selection.intentions.structure.Parameter_Selection" flags="ng" index="71T_Y" />
+      <concept id="6009478650970402162" name="de.itemis.mps.selection.intentions.structure.Execute" flags="ig" index="71TAc" />
+      <concept id="6009478650970402067" name="de.itemis.mps.selection.intentions.structure.IsApplicable" flags="ig" index="71TBH" />
+      <concept id="6009478650970401247" name="de.itemis.mps.selection.intentions.structure.SelectionIntention" flags="ng" index="71TOx">
+        <child id="6009478650970402171" name="execute" index="71TA5" />
+        <child id="6009478650970402167" name="isApplicable" index="71TA9" />
+        <child id="6009478650970402164" name="description" index="71TAa" />
+        <child id="6009478650970401248" name="selectionType" index="71TOu" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="71TOx" id="2P8zLSg8lJ7">
+    <property role="TrG5h" value="PasteCellsFromClipboardSpaceSeparated" />
+    <node concept="3uibUv" id="2P8zLSg8lZL" role="71TOu">
+      <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+    </node>
+    <node concept="71TwL" id="2P8zLSg8lJ9" role="71TAa">
+      <node concept="3clFbS" id="2P8zLSg8lJa" role="2VODD2">
+        <node concept="3clFbF" id="2P8zLSg8tvN" role="3cqZAp">
+          <node concept="2YIFZM" id="2P8zLSg8txe" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="2P8zLSg8tyh" role="37wK5m">
+              <property role="Xl_RC" value="Paste Cells from Clipboard (%s)" />
+            </node>
+            <node concept="2OqwBi" id="2P8zLSg8wVw" role="37wK5m">
+              <node concept="Rm8GO" id="2P8zLSg8u6q" role="2Oq$k0">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9Ix" resolve="SPACE" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+              <node concept="2S8uIT" id="2P8zLSg8ygi" role="2OqNvi">
+                <ref role="2S8YL0" to="3bri:12YYiosJcic" resolve="description" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TAc" id="2P8zLSg8lJb" role="71TA5">
+      <node concept="3clFbS" id="2P8zLSg8lJc" role="2VODD2">
+        <node concept="3cpWs8" id="2P8zLSg8A66" role="3cqZAp">
+          <node concept="3cpWsn" id="2P8zLSg8A67" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="3uibUv" id="2P8zLSg8A64" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="2P8zLSg8A7w" role="11_B2D" />
+            </node>
+            <node concept="2YIFZM" id="2P8zLSg8BfU" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosQuM5" resolve="fromClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+              <node concept="2OqwBi" id="1vOmbRezqtF" role="37wK5m">
+                <node concept="2OqwBi" id="1vOmbRezo7u" role="2Oq$k0">
+                  <node concept="71T_Y" id="1vOmbRezmRj" role="2Oq$k0" />
+                  <node concept="liA8E" id="1vOmbRezoCH" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1vOmbRezrBv" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="Rm8GO" id="2P8zLSg8Bir" role="37wK5m">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9Ix" resolve="SPACE" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpR7eb" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpR5wg" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpR477" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpR72Z" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpR8dh" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2P8zLSg9cBk" role="3cqZAp">
+          <node concept="3cpWsn" id="2P8zLSg9cBl" role="3cpWs9">
+            <property role="TrG5h" value="handler" />
+            <node concept="3uibUv" id="2P8zLSg9bBQ" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+            </node>
+            <node concept="2YIFZM" id="2P8zLSg9cBm" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+              <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              <node concept="2OqwBi" id="2P8zLSg9cBn" role="37wK5m">
+                <node concept="2OqwBi" id="2P8zLSg9cBo" role="2Oq$k0">
+                  <node concept="71T_Y" id="2P8zLSg9cBp" role="2Oq$k0" />
+                  <node concept="liA8E" id="2P8zLSg9cBq" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2P8zLSg9cBr" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpRV1M" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpRUmV" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpRTIE" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpRUSv" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpRVcf" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSg9aOe" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSg9bB7" role="3clFbG">
+            <node concept="37vLTw" id="2P8zLSg9aOc" role="2Oq$k0">
+              <ref role="3cqZAo" node="2P8zLSg9cBl" resolve="handler" />
+            </node>
+            <node concept="liA8E" id="2P8zLSg9bN_" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:12YYiosIoZg" resolve="paste" />
+              <node concept="71T_Y" id="6hm_9jpQtxJ" role="37wK5m" />
+              <node concept="37vLTw" id="2P8zLSg9bRH" role="37wK5m">
+                <ref role="3cqZAo" node="2P8zLSg8A67" resolve="data" />
+              </node>
+              <node concept="2OqwBi" id="7NamNJWXA_k" role="37wK5m">
+                <node concept="2OqwBi" id="7NamNJWX_WS" role="2Oq$k0">
+                  <node concept="71T_Y" id="7NamNJWX_nv" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJWXAsm" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7NamNJWXAPn" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TBH" id="2P8zLSg8$sw" role="71TA9">
+      <node concept="3clFbS" id="2P8zLSg8$sx" role="2VODD2">
+        <node concept="3clFbF" id="2P8zLSg8$Ew" role="3cqZAp">
+          <node concept="1Wc70l" id="2P8zLSg9VwL" role="3clFbG">
+            <node concept="2YIFZM" id="2P8zLSg9Vz8" role="3uHU7w">
+              <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+              <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              <node concept="2OqwBi" id="2P8zLSg9V$q" role="37wK5m">
+                <node concept="2OqwBi" id="2P8zLSg9V$r" role="2Oq$k0">
+                  <node concept="71T_Y" id="2P8zLSg9V$s" role="2Oq$k0" />
+                  <node concept="liA8E" id="2P8zLSg9V$t" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="2P8zLSg9V$u" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpRTum" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpRSPf" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpRSdZ" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpRTmI" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpRTC1" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="2P8zLSg8$Fl" role="3uHU7B">
+              <ref role="37wK5l" to="3bri:12YYiosQtsQ" resolve="isSupportedFlavorAvailableInClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="71TOx" id="1vOmbReLoFe">
+    <property role="TrG5h" value="PasteCellsFromClipboardTabSeparated" />
+    <node concept="3uibUv" id="1vOmbReLoFf" role="71TOu">
+      <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+    </node>
+    <node concept="71TwL" id="1vOmbReLoFg" role="71TAa">
+      <node concept="3clFbS" id="1vOmbReLoFh" role="2VODD2">
+        <node concept="3clFbF" id="1vOmbReLoFi" role="3cqZAp">
+          <node concept="2YIFZM" id="1vOmbReLoFj" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="1vOmbReLoFk" role="37wK5m">
+              <property role="Xl_RC" value="Paste Cells from Clipboard (%s)" />
+            </node>
+            <node concept="2OqwBi" id="1vOmbReLoFl" role="37wK5m">
+              <node concept="Rm8GO" id="1vOmbReLqti" role="2Oq$k0">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9FV" resolve="TAB" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+              <node concept="2S8uIT" id="1vOmbReLoFn" role="2OqNvi">
+                <ref role="2S8YL0" to="3bri:12YYiosJcic" resolve="description" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TAc" id="1vOmbReLoFo" role="71TA5">
+      <node concept="3clFbS" id="1vOmbReLoFp" role="2VODD2">
+        <node concept="3cpWs8" id="1vOmbReLoFw" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbReLoFx" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="3uibUv" id="1vOmbReLoFy" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="1vOmbReLoFz" role="11_B2D" />
+            </node>
+            <node concept="2YIFZM" id="1vOmbReLoF$" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosQuM5" resolve="fromClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+              <node concept="2OqwBi" id="1vOmbReLoF_" role="37wK5m">
+                <node concept="2OqwBi" id="1vOmbReLoFA" role="2Oq$k0">
+                  <node concept="71T_Y" id="1vOmbReLoFB" role="2Oq$k0" />
+                  <node concept="liA8E" id="1vOmbReLoFC" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1vOmbReLoFD" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="Rm8GO" id="1vOmbReLqyq" role="37wK5m">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9FV" resolve="TAB" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpR9xC" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpR9xD" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpR9xE" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpR9xF" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpR9xG" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1vOmbReLoFF" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbReLoFG" role="3cpWs9">
+            <property role="TrG5h" value="handler" />
+            <node concept="3uibUv" id="1vOmbReLoFH" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+            </node>
+            <node concept="2YIFZM" id="1vOmbReLoFI" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+              <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              <node concept="2OqwBi" id="1vOmbReLoFJ" role="37wK5m">
+                <node concept="2OqwBi" id="1vOmbReLoFK" role="2Oq$k0">
+                  <node concept="71T_Y" id="1vOmbReLoFL" role="2Oq$k0" />
+                  <node concept="liA8E" id="1vOmbReLoFM" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1vOmbReLoFN" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpRZci" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpRZ5_" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpRZ3i" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpRZ9R" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpRZn8" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReLoFO" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReLoFP" role="3clFbG">
+            <node concept="37vLTw" id="1vOmbReLoFQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="1vOmbReLoFG" resolve="handler" />
+            </node>
+            <node concept="liA8E" id="1vOmbReLoFR" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:12YYiosIoZg" resolve="paste" />
+              <node concept="71T_Y" id="6hm_9jpQu$R" role="37wK5m" />
+              <node concept="37vLTw" id="1vOmbReLoFT" role="37wK5m">
+                <ref role="3cqZAo" node="1vOmbReLoFx" resolve="data" />
+              </node>
+              <node concept="2OqwBi" id="7NamNJWXE_R" role="37wK5m">
+                <node concept="2OqwBi" id="7NamNJWXE_S" role="2Oq$k0">
+                  <node concept="71T_Y" id="7NamNJWXE_T" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJWXE_U" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="7NamNJWXE_V" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="71TBH" id="1vOmbReLoFU" role="71TA9">
+      <node concept="3clFbS" id="1vOmbReLoFV" role="2VODD2">
+        <node concept="3clFbF" id="1vOmbReLoFW" role="3cqZAp">
+          <node concept="1Wc70l" id="1vOmbReLoFX" role="3clFbG">
+            <node concept="2YIFZM" id="1vOmbReLoFY" role="3uHU7w">
+              <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+              <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              <node concept="2OqwBi" id="1vOmbReLoFZ" role="37wK5m">
+                <node concept="2OqwBi" id="1vOmbReLoG0" role="2Oq$k0">
+                  <node concept="71T_Y" id="1vOmbReLoG1" role="2Oq$k0" />
+                  <node concept="liA8E" id="1vOmbReLoG2" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="1vOmbReLoG3" role="2OqNvi">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpRYN2" role="37wK5m">
+                <node concept="2OqwBi" id="6hm_9jpRXV5" role="2Oq$k0">
+                  <node concept="71T_Y" id="6hm_9jpRX8g" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpRYD4" role="2OqNvi">
+                    <ref role="37wK5l" to="b8lf:~AbstractSelection.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6hm_9jpRYWH" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="1vOmbReLoG4" role="3uHU7B">
+              <ref role="37wK5l" to="3bri:12YYiosQtsQ" resolve="isSupportedFlavorAvailableInClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/de.slisson.mps.tables.runtime.msd
@@ -26,6 +26,7 @@
     <dependency reexport="true">848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)</dependency>
     <dependency reexport="false">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -39,6 +40,7 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:515552c7-fcc0-4ab4-9789-2f3c49344e85:jetbrains.mps.baseLanguage.varVariable" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
@@ -72,6 +74,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -68,6 +68,7 @@
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" />
     <import index="nivk" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.descriptor(MPS.Editor/)" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" />
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -4417,7 +4418,6 @@
       </node>
       <node concept="3Tm1VV" id="6L2tYd2Kknj" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="7DPEkiwLZNn" role="jymVt" />
     <node concept="3Tm1VV" id="1dAqnm8$zBo" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="6OOkb_bf0Q2">

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -7,6 +7,8 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -20,11 +22,29 @@
     <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
-    <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
     <import index="z2i8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.icons(MPS.IDEA/)" />
+    <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="jmi8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util(MPS.IDEA/)" />
+    <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="tqvn" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.tempmodel(MPS.Core/)" />
+    <import index="jbqa" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ide(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
@@ -70,6 +90,13 @@
       </concept>
     </language>
     <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="481983775135178851" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginInitBlock" flags="in" index="2uRRBj" />
+      <concept id="481983775135178840" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginDeclaration" flags="ng" index="2uRRBC">
+        <child id="481983775135178842" name="initBlock" index="2uRRBE" />
+        <child id="481983775135178843" name="disposeBlock" index="2uRRBF" />
+        <child id="481983775135178844" name="fieldDeclaration" index="2uRRBG" />
+      </concept>
+      <concept id="481983775135178846" name="jetbrains.mps.lang.plugin.standalone.structure.ApplicationPluginDisposeBlock" flags="in" index="2uRRBI" />
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -77,8 +104,19 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1153422305557" name="jetbrains.mps.baseLanguage.structure.LessThanOrEqualsExpression" flags="nn" index="2dkUwp" />
+      <concept id="2323553266850475941" name="jetbrains.mps.baseLanguage.structure.IHasModifiers" flags="ngI" index="2frcj7">
+        <child id="2323553266850475953" name="modifiers" index="2frcjj" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -88,13 +126,33 @@
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
+      <concept id="4678410916365116210" name="jetbrains.mps.baseLanguage.structure.DefaultModifier" flags="ng" index="2JFqV2" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1083245097125" name="jetbrains.mps.baseLanguage.structure.EnumClass" flags="ig" index="Qs71p">
+        <child id="1083245396908" name="enumConstant" index="Qtgdg" />
+      </concept>
+      <concept id="1083245299891" name="jetbrains.mps.baseLanguage.structure.EnumConstantDeclaration" flags="ig" index="QsSxf" />
+      <concept id="1201370618622" name="jetbrains.mps.baseLanguage.structure.Property" flags="ig" index="2RhdJD">
+        <property id="1201371481316" name="propertyName" index="2RkwnN" />
+        <child id="1201371521209" name="type" index="2RkE6I" />
+        <child id="1201372378714" name="propertyImplementation" index="2RnVtd" />
+      </concept>
       <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
         <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1201372606839" name="jetbrains.mps.baseLanguage.structure.DefaultPropertyImplementation" flags="ng" index="2RoN1w">
+        <child id="1202065356069" name="defaultGetAccessor" index="3wFrgM" />
+        <child id="1202078082794" name="defaultSetAccessor" index="3xrYvX" />
+      </concept>
+      <concept id="1201385106094" name="jetbrains.mps.baseLanguage.structure.PropertyReference" flags="nn" index="2S8uIT">
+        <reference id="1201385237847" name="property" index="2S8YL0" />
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
@@ -102,8 +160,25 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
@@ -111,16 +186,24 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
+      <concept id="5862977038373003187" name="jetbrains.mps.baseLanguage.structure.LocalPropertyReference" flags="nn" index="338YkY">
+        <reference id="5862977038373003188" name="property" index="338YkT" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
@@ -138,6 +221,8 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271546410" name="jetbrains.mps.baseLanguage.structure.TrimOperation" flags="nn" index="17S1cR" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -166,14 +251,22 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -185,6 +278,7 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -193,9 +287,30 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1202065242027" name="jetbrains.mps.baseLanguage.structure.DefaultGetAccessor" flags="ng" index="3wEZqW" />
+      <concept id="1202077725299" name="jetbrains.mps.baseLanguage.structure.DefaultSetAccessor" flags="ng" index="3xqBd$">
+        <child id="1202077744034" name="visibility" index="3xqFEP" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -206,11 +321,47 @@
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
+        <child id="8029776554053057803" name="objectType" index="luc8K" />
+      </concept>
+      <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
+        <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
+      </concept>
+      <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
         <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
       </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
       <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
@@ -226,14 +377,30 @@
       </concept>
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1213999088275" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldDeclaration" flags="ig" index="2BZ0e9" />
+      <concept id="1213999117680" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierFieldAccessOperation" flags="nn" index="2BZ7hE" />
       <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
       <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
         <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
     </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1227264722563" name="jetbrains.mps.lang.smodel.structure.EqualsStructurallyExpression" flags="nn" index="2YFouu" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -246,6 +413,55 @@
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
+    </language>
+    <language id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable">
+      <concept id="1177714083117" name="jetbrains.mps.baseLanguage.varVariable.structure.VarType" flags="in" index="PeGgZ" />
+      <concept id="1236693300889" name="jetbrains.mps.baseLanguage.varVariable.structure.VarVariableDeclaration" flags="ng" index="3KEzu6" />
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
+        <child id="1205679832066" name="ascending" index="2S7zOq" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="7775192435301616820" name="jetbrains.mps.baseLanguage.collections.structure.ToStreamOperation" flags="ng" index="1l$wjB" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="2DaZZR" id="6Y0V2RJgCUU" />
@@ -1194,6 +1410,2947 @@
       <node concept="10M0yZ" id="6R0q0mZSZL2" role="3xaMm5">
         <ref role="3cqZAo" to="z2i8:~AllIcons$General.Remove" resolve="Remove" />
         <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
+      </node>
+    </node>
+  </node>
+  <node concept="vrV6u" id="12YYiosIAdh">
+    <property role="TrG5h" value="TableCopyPaste" />
+    <property role="3GE5qa" value="copyPaste" />
+    <node concept="3uibUv" id="12YYiosIAOd" role="luc8K">
+      <ref role="3uigEE" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+    </node>
+  </node>
+  <node concept="3HP615" id="12YYiosxYeH">
+    <property role="TrG5h" value="CopyPasteSupport" />
+    <property role="3GE5qa" value="copyPaste" />
+    <node concept="2tJIrI" id="12YYiosxYga" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosINlT" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="3clFbS" id="12YYiosINlW" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosINlX" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosINj6" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosITpj" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosIW5a" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3clFbS" id="12YYiosIW5d" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosIW5e" role="1B3o_S" />
+      <node concept="10P_77" id="1Yhk3kSO04j" role="3clF45" />
+      <node concept="37vLTG" id="1Yhk3kSO0Jv" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1Yhk3kSO0Ju" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRnhJ" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRnqJ" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiotb5_U" role="jymVt" />
+    <node concept="3clFb_" id="12YYiotb5ZU" role="jymVt">
+      <property role="TrG5h" value="setTableNode" />
+      <node concept="3clFbS" id="12YYiotb5ZX" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiotb5ZY" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiotb5VI" role="3clF45" />
+      <node concept="37vLTG" id="12YYiotb$T_" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="12YYiotb$T$" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosIN1S" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosIoWm" role="jymVt">
+      <property role="TrG5h" value="copy" />
+      <node concept="3clFbS" id="12YYiosIoWp" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosIoWq" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosIoVC" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="12YYiosIoVP" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="12YYiosIoWP" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosIoWO" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jq6WVd" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jq6XVj" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosIoY3" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosIoZg" role="jymVt">
+      <property role="TrG5h" value="paste" />
+      <node concept="37vLTG" id="12YYiosI$uf" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosI$ug" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYiosI$uW" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="3uibUv" id="12YYiosI$vD" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+          <node concept="3Tqbb2" id="12YYiosI$vE" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQ_B9" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQ_Kf" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="12YYiosIoZj" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosIoZk" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosIoYP" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosI$w_" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosI$xW" role="jymVt">
+      <property role="TrG5h" value="delete" />
+      <node concept="37vLTG" id="12YYiosI$yV" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosI$yW" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jq75pY" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jq75pZ" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="12YYiosI$xZ" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosI$y0" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosI$xg" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosI$zT" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosI$_L" role="jymVt">
+      <property role="TrG5h" value="cut" />
+      <node concept="37vLTG" id="12YYiosI$DE" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="12YYiosI$DF" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jq76Z_" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jq76ZA" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="12YYiosI$_O" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosI_rj" role="3cqZAp">
+          <node concept="3KEzu6" id="12YYiosI_rh" role="3cpWs9">
+            <property role="TrG5h" value="copy" />
+            <node concept="PeGgZ" id="12YYiosI_ri" role="1tU5fm" />
+            <node concept="1rXfSq" id="12YYiosI_y3" role="33vP2m">
+              <ref role="37wK5l" node="12YYiosIoWm" resolve="copy" />
+              <node concept="37vLTw" id="12YYiosI_$X" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosI$DE" resolve="selection" />
+              </node>
+              <node concept="37vLTw" id="6hm_9jq77k$" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jq76Z_" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosI_CP" role="3cqZAp">
+          <node concept="1rXfSq" id="12YYiosI_CN" role="3clFbG">
+            <ref role="37wK5l" node="12YYiosI$xW" resolve="delete" />
+            <node concept="37vLTw" id="12YYiosI_GC" role="37wK5m">
+              <ref role="3cqZAo" node="12YYiosI$DE" resolve="selection" />
+            </node>
+            <node concept="37vLTw" id="6hm_9jq77uk" role="37wK5m">
+              <ref role="3cqZAo" node="6hm_9jq76Z_" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosI_LQ" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiosI_LO" role="3clFbG">
+            <ref role="3cqZAo" node="12YYiosI_rh" resolve="copy" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosI$_P" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosI$B1" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="12YYiosI$B2" role="11_B2D" />
+      </node>
+      <node concept="2JFqV2" id="12YYiosIB0C" role="2frcjj" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosI_V3" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosIA6b" role="jymVt">
+      <property role="TrG5h" value="existsFor" />
+      <node concept="3clFbS" id="12YYiosIA6e" role="3clF47">
+        <node concept="3clFbF" id="12YYiosIU0S" role="3cqZAp">
+          <node concept="2YIFZM" id="12YYiosIU2k" role="3clFbG">
+            <ref role="37wK5l" node="12YYiosIC6m" resolve="isSupported" />
+            <ref role="1Pybhc" node="12YYiosIBcY" resolve="CopyPasteManager" />
+            <node concept="37vLTw" id="12YYiosIU4p" role="37wK5m">
+              <ref role="3cqZAo" node="12YYiosIA9b" resolve="node" />
+            </node>
+            <node concept="37vLTw" id="6hm_9jpRPvP" role="37wK5m">
+              <ref role="3cqZAo" node="6hm_9jpRPpa" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosIA6f" role="1B3o_S" />
+      <node concept="10P_77" id="12YYiosIA0q" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosIA9b" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="12YYiosIA9a" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRPpa" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRPpb" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosIU5x" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosIUi1" role="jymVt">
+      <property role="TrG5h" value="forNode" />
+      <node concept="3clFbS" id="12YYiosIUi4" role="3clF47">
+        <node concept="3cpWs8" id="12YYiotc1LS" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiotc1LT" role="3cpWs9">
+            <property role="TrG5h" value="support" />
+            <node concept="3uibUv" id="12YYiotb$UZ" role="1tU5fm">
+              <ref role="3uigEE" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+            </node>
+            <node concept="2YIFZM" id="12YYiotc1LU" role="33vP2m">
+              <ref role="37wK5l" node="12YYiosICXq" resolve="create" />
+              <ref role="1Pybhc" node="12YYiosIBcY" resolve="CopyPasteManager" />
+              <node concept="37vLTw" id="12YYiotc1LV" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosIU$4" resolve="table" />
+              </node>
+              <node concept="37vLTw" id="6hm_9jpRPcv" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpRP2l" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiotc2bP" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiotc2o0" role="3clFbG">
+            <node concept="37vLTw" id="12YYiotc2bN" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiotc1LT" resolve="support" />
+            </node>
+            <node concept="liA8E" id="12YYiotc2yy" role="2OqNvi">
+              <ref role="37wK5l" node="12YYiotb5ZU" resolve="setTableNode" />
+              <node concept="37vLTw" id="12YYiotc3az" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosIU$4" resolve="table" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiotc3Ln" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiotc3Ll" role="3clFbG">
+            <ref role="3cqZAo" node="12YYiotc1LT" resolve="support" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosIUi5" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosIUhA" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+      </node>
+      <node concept="37vLTG" id="12YYiosIU$4" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="12YYiosIU$3" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRP2l" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRP2m" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosxYeI" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="12YYiosIBcY">
+    <property role="3GE5qa" value="copyPaste" />
+    <property role="TrG5h" value="CopyPasteManager" />
+    <node concept="2YIFZL" id="12YYiosIC6m" role="jymVt">
+      <property role="TrG5h" value="isSupported" />
+      <node concept="3clFbS" id="12YYiosIC6p" role="3clF47">
+        <node concept="3clFbF" id="12YYiosINV4" role="3cqZAp">
+          <node concept="3y3z36" id="12YYiosIOkO" role="3clFbG">
+            <node concept="10Nm6u" id="12YYiosIOr0" role="3uHU7w" />
+            <node concept="1rXfSq" id="12YYiosINV3" role="3uHU7B">
+              <ref role="37wK5l" node="12YYiosIEmZ" resolve="createIfSupported" />
+              <node concept="37vLTw" id="12YYiosINZA" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosIClr" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="6hm_9jpROcI" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpRNV6" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosIBvS" role="1B3o_S" />
+      <node concept="10P_77" id="12YYiosIC6c" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosIClr" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="12YYiosIClq" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRNV6" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRNV7" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosICmz" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosICXq" role="jymVt">
+      <property role="TrG5h" value="create" />
+      <node concept="3clFbS" id="12YYiosICXt" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosIDne" role="3cqZAp">
+          <node concept="3KEzu6" id="12YYiosIDnc" role="3cpWs9">
+            <property role="TrG5h" value="copyPasteSupport" />
+            <node concept="PeGgZ" id="12YYiosIDnd" role="1tU5fm" />
+            <node concept="1rXfSq" id="12YYiosIEve" role="33vP2m">
+              <ref role="37wK5l" node="12YYiosIEmZ" resolve="createIfSupported" />
+              <node concept="37vLTw" id="12YYiosIEwF" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosIDcw" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="6hm_9jpRNwC" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpRNav" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYiosIEGl" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiosIEGn" role="3clFbx">
+            <node concept="YS8fn" id="12YYiosIF8J" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYiosIFaU" role="YScLw">
+                <node concept="1pGfFk" id="12YYiosIFxb" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalArgumentException.&lt;init&gt;(java.lang.String)" resolve="IllegalArgumentException" />
+                  <node concept="2YIFZM" id="12YYiosIFY1" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="Xl_RD" id="12YYiosIG3l" role="37wK5m">
+                      <property role="Xl_RC" value="No %s for %s" />
+                    </node>
+                    <node concept="2OqwBi" id="12YYiosII6H" role="37wK5m">
+                      <node concept="3VsKOn" id="12YYiosIGOd" role="2Oq$k0">
+                        <ref role="3VsUkX" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+                      </node>
+                      <node concept="liA8E" id="12YYiosIJ_w" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Class.getSimpleName()" resolve="getSimpleName" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="12YYiosILmh" role="37wK5m">
+                      <node concept="2OqwBi" id="12YYiosIKvp" role="2Oq$k0">
+                        <node concept="37vLTw" id="12YYiosIKke" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiosIDcw" resolve="node" />
+                        </node>
+                        <node concept="2yIwOk" id="12YYiosIKK_" role="2OqNvi" />
+                      </node>
+                      <node concept="liA8E" id="12YYiosIMhT" role="2OqNvi">
+                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="12YYiosIEQh" role="3clFbw">
+            <node concept="10Nm6u" id="12YYiosIER$" role="3uHU7w" />
+            <node concept="37vLTw" id="12YYiosIEHJ" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosIDnc" resolve="copyPasteSupport" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosIMno" role="3cqZAp" />
+        <node concept="3cpWs6" id="12YYiosIML_" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiosIMSU" role="3cqZAk">
+            <ref role="3cqZAo" node="12YYiosIDnc" resolve="copyPasteSupport" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosICCr" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosICXf" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+      </node>
+      <node concept="37vLTG" id="12YYiosIDcw" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="12YYiosIDcv" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRNav" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRNaw" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosIDoB" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosIEmZ" role="jymVt">
+      <property role="TrG5h" value="createIfSupported" />
+      <node concept="3clFbS" id="12YYiosIEn2" role="3clF47">
+        <node concept="3clFbF" id="12YYiosIPpF" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosJ2Iv" role="3clFbG">
+            <node concept="2OqwBi" id="12YYiosJ0uP" role="2Oq$k0">
+              <node concept="2OqwBi" id="12YYiosIRot" role="2Oq$k0">
+                <node concept="2OqwBi" id="12YYiosIPR4" role="2Oq$k0">
+                  <node concept="2O5UvJ" id="12YYiosIPpE" role="2Oq$k0">
+                    <ref role="2O5UnU" node="12YYiosIAdh" resolve="TableCopyPaste" />
+                  </node>
+                  <node concept="SfwO_" id="12YYiosIQ8X" role="2OqNvi" />
+                </node>
+                <node concept="3zZkjj" id="12YYiosISpT" role="2OqNvi">
+                  <node concept="1bVj0M" id="12YYiosISpV" role="23t8la">
+                    <node concept="3clFbS" id="12YYiosISpW" role="1bW5cS">
+                      <node concept="3clFbF" id="12YYiosISHm" role="3cqZAp">
+                        <node concept="2OqwBi" id="1Yhk3kSOJA5" role="3clFbG">
+                          <node concept="37vLTw" id="1Yhk3kSOJd8" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosISpX" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="1Yhk3kSOK6F" role="2OqNvi">
+                            <ref role="37wK5l" node="12YYiosIW5a" resolve="isApplicable" />
+                            <node concept="37vLTw" id="1Yhk3kSOKv$" role="37wK5m">
+                              <ref role="3cqZAo" node="12YYiosIEtT" resolve="node" />
+                            </node>
+                            <node concept="37vLTw" id="6hm_9jpRMzT" role="37wK5m">
+                              <ref role="3cqZAo" node="6hm_9jpRLm2" resolve="editorContext" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="12YYiosISpX" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="12YYiosISpY" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2S7cBI" id="12YYiosJ1_R" role="2OqNvi">
+                <node concept="1nlBCl" id="12YYiosJ1_T" role="2S7zOq">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="1bVj0M" id="12YYiosJ1_U" role="23t8la">
+                  <node concept="3clFbS" id="12YYiosJ1_V" role="1bW5cS">
+                    <node concept="3clFbF" id="12YYiosJ1Yk" role="3cqZAp">
+                      <node concept="2OqwBi" id="12YYiosJ274" role="3clFbG">
+                        <node concept="37vLTw" id="12YYiosJ1Yj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiosJ1_W" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="12YYiosJ2sk" role="2OqNvi">
+                          <ref role="37wK5l" node="12YYiosINlT" resolve="priority" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="12YYiosJ1_W" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="12YYiosJ1_X" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1yVyf7" id="12YYiosJ3bW" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosIDED" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosIEqt" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYeH" resolve="CopyPasteSupport" />
+      </node>
+      <node concept="37vLTG" id="12YYiosIEtT" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="12YYiosIEtS" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpRLm2" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpRLm3" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosIBcZ" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="12YYiosJ3v6">
+    <property role="3GE5qa" value="copyPaste" />
+    <property role="TrG5h" value="ClipboardTableUtils" />
+    <node concept="2tJIrI" id="12YYiosJ3vD" role="jymVt" />
+    <node concept="Wx3nA" id="12YYiosJ4qS" role="jymVt">
+      <property role="TrG5h" value="SUPPORTED_FLAVOR" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="12YYiosJ3Oh" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosJ4qI" role="1tU5fm">
+        <ref role="3uigEE" to="kt01:~DataFlavor" resolve="DataFlavor" />
+      </node>
+      <node concept="10M0yZ" id="12YYiosJ4rC" role="33vP2m">
+        <ref role="3cqZAo" to="kt01:~DataFlavor.stringFlavor" resolve="stringFlavor" />
+        <ref role="1PxDUh" to="kt01:~DataFlavor" resolve="DataFlavor" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosJ4rY" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosJ5bq" role="jymVt">
+      <property role="TrG5h" value="putIntoOSClipboard" />
+      <node concept="3clFbS" id="12YYiosJ5bt" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosQrf6" role="3cqZAp">
+          <node concept="3KEzu6" id="12YYiosQrf4" role="3cpWs9">
+            <property role="TrG5h" value="clipboardContent" />
+            <node concept="PeGgZ" id="12YYiosQrf5" role="1tU5fm" />
+            <node concept="2ShNRf" id="12YYiosQrhF" role="33vP2m">
+              <node concept="1pGfFk" id="12YYiosQrw2" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="kt01:~StringSelection.&lt;init&gt;(java.lang.String)" resolve="StringSelection" />
+                <node concept="2OqwBi" id="12YYiosQrFh" role="37wK5m">
+                  <node concept="37vLTw" id="12YYiosQrxG" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYiosJ5eO" resolve="data" />
+                  </node>
+                  <node concept="liA8E" id="12YYiosQs2Z" role="2OqNvi">
+                    <ref role="37wK5l" node="12YYiosNg8b" resolve="toFlatString" />
+                    <node concept="37vLTw" id="12YYiosQs9c" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYiosJ5_l" resolve="separator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosQTiR" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosQTy6" role="3clFbG">
+            <node concept="1rXfSq" id="12YYiosQTiP" role="2Oq$k0">
+              <ref role="37wK5l" node="12YYiosQxD9" resolve="getClipboard" />
+            </node>
+            <node concept="liA8E" id="12YYiosQTKD" role="2OqNvi">
+              <ref role="37wK5l" to="kt01:~Clipboard.setContents(java.awt.datatransfer.Transferable,java.awt.datatransfer.ClipboardOwner)" resolve="setContents" />
+              <node concept="37vLTw" id="12YYiosQTQ5" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosQrf4" resolve="clipboardContent" />
+              </node>
+              <node concept="10Nm6u" id="12YYiosQU7u" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosJ4HG" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosJ5bg" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosJ5eO" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="3uibUv" id="12YYiosJ5eN" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+          <node concept="17QB3L" id="12YYiosJ5$8" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYiosJ5_l" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="12YYiosQrbf" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosJ9Cy" resolve="TableDataSeparator" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosQsoe" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosQtsQ" role="jymVt">
+      <property role="TrG5h" value="isSupportedFlavorAvailableInClipboard" />
+      <node concept="3clFbS" id="12YYiosQtsT" role="3clF47">
+        <node concept="3clFbF" id="12YYiosQT5r" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosQQEs" role="3clFbG">
+            <node concept="2OqwBi" id="12YYiosQPmx" role="2Oq$k0">
+              <node concept="2OqwBi" id="12YYiosQLyO" role="2Oq$k0">
+                <node concept="1rXfSq" id="12YYiosQLiO" role="2Oq$k0">
+                  <ref role="37wK5l" node="12YYiosQxD9" resolve="getClipboard" />
+                </node>
+                <node concept="liA8E" id="12YYiosQLJW" role="2OqNvi">
+                  <ref role="37wK5l" to="kt01:~Clipboard.getAvailableDataFlavors()" resolve="getAvailableDataFlavors" />
+                </node>
+              </node>
+              <node concept="39bAoz" id="12YYiosQPB1" role="2OqNvi" />
+            </node>
+            <node concept="3JPx81" id="12YYiosQRKl" role="2OqNvi">
+              <node concept="37vLTw" id="12YYiosQT5v" role="25WWJ7">
+                <ref role="3cqZAo" node="12YYiosJ4qS" resolve="SUPPORTED_FLAVOR" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosQsMm" role="1B3o_S" />
+      <node concept="10P_77" id="12YYiosQtsE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosQtOW" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosQuM5" role="jymVt">
+      <property role="TrG5h" value="fromClipboard" />
+      <node concept="3clFbS" id="12YYiosQuM8" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosQvgk" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosQvgn" role="3cpWs9">
+            <property role="TrG5h" value="clipboardContent" />
+            <node concept="17QB3L" id="12YYiosQvgj" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3J1_TO" id="12YYiosQvv8" role="3cqZAp">
+          <node concept="3uVAMA" id="12YYiosQz2w" role="1zxBo5">
+            <node concept="XOnhg" id="12YYiosQz2x" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="12YYiosQz2y" role="1tU5fm">
+                <node concept="3uibUv" id="12YYiosQzaX" role="nSUat">
+                  <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                </node>
+                <node concept="3uibUv" id="12YYiosQGdb" role="nSUat">
+                  <ref role="3uigEE" to="kt01:~UnsupportedFlavorException" resolve="UnsupportedFlavorException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="12YYiosQz2z" role="1zc67A">
+              <node concept="YS8fn" id="12YYiosQzLC" role="3cqZAp">
+                <node concept="2ShNRf" id="12YYiosQzSJ" role="YScLw">
+                  <node concept="1pGfFk" id="12YYiosQ$zU" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.Throwable)" resolve="RuntimeException" />
+                    <node concept="37vLTw" id="12YYiosQ$IG" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYiosQz2x" resolve="e" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYiosQvva" role="1zxBo7">
+            <node concept="3clFbF" id="12YYiosQvyR" role="3cqZAp">
+              <node concept="37vLTI" id="12YYiosQwMZ" role="3clFbG">
+                <node concept="1eOMI4" id="12YYiosQwOs" role="37vLTx">
+                  <node concept="10QFUN" id="12YYiosQwOp" role="1eOMHV">
+                    <node concept="17QB3L" id="12YYiosQwOu" role="10QFUM" />
+                    <node concept="2OqwBi" id="12YYiosQy_D" role="10QFUP">
+                      <node concept="1rXfSq" id="12YYiosQydh" role="2Oq$k0">
+                        <ref role="37wK5l" node="12YYiosQxD9" resolve="getClipboard" />
+                      </node>
+                      <node concept="liA8E" id="12YYiosQyJU" role="2OqNvi">
+                        <ref role="37wK5l" to="kt01:~Clipboard.getData(java.awt.datatransfer.DataFlavor)" resolve="getData" />
+                        <node concept="10M0yZ" id="12YYiosQyRM" role="37wK5m">
+                          <ref role="3cqZAo" to="kt01:~DataFlavor.stringFlavor" resolve="stringFlavor" />
+                          <ref role="1PxDUh" to="kt01:~DataFlavor" resolve="DataFlavor" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="12YYiosQvyP" role="37vLTJ">
+                  <ref role="3cqZAo" node="12YYiosQvgn" resolve="clipboardContent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosQGsc" role="3cqZAp" />
+        <node concept="3cpWs8" id="12YYiosQG_z" role="3cqZAp">
+          <node concept="3KEzu6" id="12YYiosQG_w" role="3cpWs9">
+            <property role="TrG5h" value="dataAsString" />
+            <node concept="PeGgZ" id="12YYiosQG_x" role="1tU5fm" />
+            <node concept="2OqwBi" id="12YYiosQHWe" role="33vP2m">
+              <node concept="2ShNRf" id="12YYiosQGWW" role="2Oq$k0">
+                <node concept="1pGfFk" id="12YYiosQHFl" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" node="12YYiosJjev" resolve="TableDataParser" />
+                  <node concept="37vLTw" id="12YYiosQHLC" role="37wK5m">
+                    <ref role="3cqZAo" node="12YYiosQuUj" resolve="elementSeparator" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="12YYiosQIaf" role="2OqNvi">
+                <ref role="37wK5l" node="12YYiosJmoN" resolve="fromString" />
+                <node concept="37vLTw" id="12YYiosQIhr" role="37wK5m">
+                  <ref role="3cqZAo" node="12YYiosQvgn" resolve="clipboardContent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="12YYiosQL2X" role="3cqZAp">
+          <node concept="2YIFZM" id="1vOmbRezzt1" role="3cqZAk">
+            <ref role="37wK5l" node="12YYiosKLX8" resolve="stringDataToNodeData" />
+            <ref role="1Pybhc" node="12YYiosJFef" resolve="TableTransformationManager" />
+            <node concept="37vLTw" id="1vOmbRezzt2" role="37wK5m">
+              <ref role="3cqZAo" node="1vOmbRezjaE" resolve="table" />
+            </node>
+            <node concept="37vLTw" id="1vOmbRezzt3" role="37wK5m">
+              <ref role="3cqZAo" node="12YYiosQG_w" resolve="dataAsString" />
+            </node>
+            <node concept="37vLTw" id="6hm_9jpR2zr" role="37wK5m">
+              <ref role="3cqZAo" node="6hm_9jpR1GG" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosQugo" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosQuE2" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="12YYiosQuLR" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="1vOmbRezjaE" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="1vOmbRezj$6" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosQuUj" role="3clF46">
+        <property role="TrG5h" value="elementSeparator" />
+        <node concept="3uibUv" id="12YYiosQuUi" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosJ9Cy" resolve="TableDataSeparator" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jpR1GG" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpR1RM" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosQwPf" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosQxD9" role="jymVt">
+      <property role="TrG5h" value="getClipboard" />
+      <node concept="3clFbS" id="12YYiosQxDc" role="3clF47">
+        <node concept="3clFbF" id="12YYiosQxQp" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosQxZd" role="3clFbG">
+            <node concept="2YIFZM" id="12YYiosQxR8" role="2Oq$k0">
+              <ref role="37wK5l" to="z60i:~Toolkit.getDefaultToolkit()" resolve="getDefaultToolkit" />
+              <ref role="1Pybhc" to="z60i:~Toolkit" resolve="Toolkit" />
+            </node>
+            <node concept="liA8E" id="12YYiosQy8S" role="2OqNvi">
+              <ref role="37wK5l" to="z60i:~Toolkit.getSystemClipboard()" resolve="getSystemClipboard" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="12YYiosQxeW" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosQxCT" role="3clF45">
+        <ref role="3uigEE" to="kt01:~Clipboard" resolve="Clipboard" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosJ3v7" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="12YYiosxYgq">
+    <property role="TrG5h" value="TableData" />
+    <property role="3GE5qa" value="tableData2D" />
+    <node concept="2tJIrI" id="12YYiosxYhL" role="jymVt" />
+    <node concept="312cEg" id="12YYiosxYiG" role="jymVt">
+      <property role="TrG5h" value="content" />
+      <node concept="3Tm6S6" id="12YYiosxYi9" role="1B3o_S" />
+      <node concept="_YKpA" id="12YYiosxYin" role="1tU5fm">
+        <node concept="_YKpA" id="12YYiosxYi$" role="_ZDj9">
+          <node concept="16syzq" id="12YYiosxYiA" role="_ZDj9">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosxYj3" role="jymVt" />
+    <node concept="3clFbW" id="12YYiosxYju" role="jymVt">
+      <node concept="3cqZAl" id="12YYiosxYjv" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosxYjx" role="3clF47">
+        <node concept="3clFbF" id="12YYiosxYka" role="3cqZAp">
+          <node concept="37vLTI" id="12YYiosxZ$W" role="3clFbG">
+            <node concept="2ShNRf" id="12YYiosxZHs" role="37vLTx">
+              <node concept="Tc6Ow" id="12YYiosxZOU" role="2ShVmc">
+                <node concept="_YKpA" id="12YYiosxZXg" role="HW$YZ">
+                  <node concept="16syzq" id="12YYiosy00F" role="_ZDj9">
+                    <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="12YYiosxYk9" role="37vLTJ">
+              <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosxYjg" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosy034" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosy0aH" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3clFbS" id="12YYiosy0aK" role="3clF47">
+        <node concept="3clFbF" id="12YYiosy0ed" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiosy0ec" role="3clFbG">
+            <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosy07W" role="1B3o_S" />
+      <node concept="_YKpA" id="12YYiosy0aq" role="3clF45">
+        <node concept="_YKpA" id="12YYiosy0a_" role="_ZDj9">
+          <node concept="16syzq" id="12YYiosy0aB" role="_ZDj9">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosy0id" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosy0qw" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3clFbS" id="12YYiosy0qz" role="3clF47">
+        <node concept="3clFbF" id="12YYiosy4ZN" role="3cqZAp">
+          <node concept="1y4W85" id="12YYiosy3tX" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosy3$v" role="1y58nS">
+              <ref role="3cqZAo" node="12YYiosy0_s" resolve="colIndex" />
+            </node>
+            <node concept="1y4W85" id="12YYiosy29n" role="1y566C">
+              <node concept="37vLTw" id="12YYiosy2vf" role="1y58nS">
+                <ref role="3cqZAo" node="12YYiosy0vq" resolve="rowindex" />
+              </node>
+              <node concept="37vLTw" id="12YYiosy0RO" role="1y566C">
+                <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosy0mh" role="1B3o_S" />
+      <node concept="16syzq" id="12YYiosy0qm" role="3clF45">
+        <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+      </node>
+      <node concept="37vLTG" id="12YYiosy0vq" role="3clF46">
+        <property role="TrG5h" value="rowindex" />
+        <node concept="10Oyi0" id="12YYiosy0vp" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosy0_s" role="3clF46">
+        <property role="TrG5h" value="colIndex" />
+        <node concept="10Oyi0" id="12YYiosy0Ed" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosyb2R" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosy85F" role="jymVt">
+      <property role="TrG5h" value="isEmpty" />
+      <node concept="3clFbS" id="12YYiosy85I" role="3clF47">
+        <node concept="3clFbF" id="12YYiosy8ef" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosy9yC" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosy8ee" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+            </node>
+            <node concept="1v1jN8" id="12YYiosya8q" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosy7Xs" role="1B3o_S" />
+      <node concept="10P_77" id="12YYiosy85x" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosy4x8" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosy4Ny" role="jymVt">
+      <property role="TrG5h" value="rowSize" />
+      <node concept="3clFbS" id="12YYiosy4N_" role="3clF47">
+        <node concept="3clFbF" id="12YYiosy57i" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosy6pJ" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosy57h" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+            </node>
+            <node concept="34oBXx" id="12YYiosy6X_" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosy4Bg" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosy4Hp" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosy75P" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosy7lC" role="jymVt">
+      <property role="TrG5h" value="columnSize" />
+      <node concept="3clFbS" id="12YYiosy7lF" role="3clF47">
+        <node concept="3clFbJ" id="12YYiosy7_e" role="3cqZAp">
+          <node concept="1rXfSq" id="12YYiosyahK" role="3clFbw">
+            <ref role="37wK5l" node="12YYiosy85F" resolve="isEmpty" />
+          </node>
+          <node concept="3clFbS" id="12YYiosy7_g" role="3clFbx">
+            <node concept="3cpWs6" id="12YYiosyasA" role="3cqZAp">
+              <node concept="3cmrfG" id="12YYiosyaAD" role="3cqZAk">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosyboc" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosydyl" role="3clFbG">
+            <node concept="2OqwBi" id="12YYiosybTu" role="2Oq$k0">
+              <node concept="37vLTw" id="12YYiosyboa" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+              </node>
+              <node concept="1uHKPH" id="12YYiosycdp" role="2OqNvi" />
+            </node>
+            <node concept="34oBXx" id="12YYiosyeaO" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosy7dD" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosy7lu" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosy7Hm" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosyeJw" role="jymVt">
+      <property role="TrG5h" value="addData" />
+      <node concept="3clFbS" id="12YYiosyeJz" role="3clF47">
+        <node concept="3clFbJ" id="12YYiosygim" role="3cqZAp">
+          <node concept="1rXfSq" id="12YYiosyguI" role="3clFbw">
+            <ref role="37wK5l" node="12YYiosy85F" resolve="isEmpty" />
+          </node>
+          <node concept="3clFbS" id="12YYiosygio" role="3clFbx">
+            <node concept="3clFbF" id="12YYiosyhl9" role="3cqZAp">
+              <node concept="1rXfSq" id="12YYiosyhl8" role="3clFbG">
+                <ref role="37wK5l" node="12YYiosyh7q" resolve="addRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosyhOn" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosykK3" role="3clFbG">
+            <node concept="2OqwBi" id="12YYiosyiXT" role="2Oq$k0">
+              <node concept="37vLTw" id="12YYiosyhOl" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+              </node>
+              <node concept="1yVyf7" id="12YYiosyjCZ" role="2OqNvi" />
+            </node>
+            <node concept="TSZUe" id="12YYiosylrY" role="2OqNvi">
+              <node concept="37vLTw" id="12YYiosylHg" role="25WWJ7">
+                <ref role="3cqZAo" node="12YYiosyeVZ" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosyez2" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosyeJf" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosyeVZ" role="3clF46">
+        <property role="TrG5h" value="element" />
+        <node concept="16syzq" id="12YYiosyeVY" role="1tU5fm">
+          <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosygG$" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosyh7q" role="jymVt">
+      <property role="TrG5h" value="addRow" />
+      <node concept="3clFbS" id="12YYiosyh7t" role="3clF47">
+        <node concept="3clFbF" id="12YYiosylWM" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosymm7" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosylWL" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+            </node>
+            <node concept="TSZUe" id="12YYiosymJt" role="2OqNvi">
+              <node concept="2ShNRf" id="12YYiosynT4" role="25WWJ7">
+                <node concept="2Jqq0_" id="12YYiosyohf" role="2ShVmc">
+                  <node concept="16syzq" id="12YYiosyoyY" role="HW$YZ">
+                    <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosygTK" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosyh6X" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosyoOs" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosypCB" role="jymVt">
+      <property role="TrG5h" value="forEach" />
+      <node concept="3clFbS" id="12YYiosypCE" role="3clF47">
+        <node concept="3clFbF" id="12YYiosyM$P" role="3cqZAp">
+          <node concept="1rXfSq" id="12YYiosyM$O" role="3clFbG">
+            <ref role="37wK5l" node="12YYiosyq_Y" resolve="forEach" />
+            <node concept="3cmrfG" id="12YYiosyNz5" role="37wK5m">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="3cmrfG" id="12YYiosyPe4" role="37wK5m">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="12YYiosyPII" role="37wK5m">
+              <ref role="3cqZAo" node="12YYiosypVy" resolve="elementConsumer" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosyplq" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosypC2" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosypVy" role="3clF46">
+        <property role="TrG5h" value="elementConsumer" />
+        <node concept="1ajhzC" id="12YYiosypVw" role="1tU5fm">
+          <node concept="3cqZAl" id="12YYiosyqrS" role="1ajl9A" />
+          <node concept="16syzq" id="12YYiosyqe6" role="1ajw0F">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+          <node concept="10Oyi0" id="12YYiosyqiF" role="1ajw0F" />
+          <node concept="10Oyi0" id="12YYiosyqo$" role="1ajw0F" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosyrgZ" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosyq_Y" role="jymVt">
+      <property role="TrG5h" value="forEach" />
+      <node concept="3clFbS" id="12YYiosyq_Z" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosyt0X" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosyt10" role="3cpWs9">
+            <property role="TrG5h" value="row" />
+            <node concept="10Oyi0" id="12YYiosyt0W" role="1tU5fm" />
+            <node concept="37vLTw" id="12YYiosytK7" role="33vP2m">
+              <ref role="3cqZAo" node="12YYiosyrLd" resolve="rowOffset" />
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="12YYiosyuve" role="3cqZAp">
+          <node concept="2GrKxI" id="12YYiosyuvg" role="2Gsz3X">
+            <property role="TrG5h" value="rowData" />
+          </node>
+          <node concept="1rXfSq" id="12YYiosyxaA" role="2GsD0m">
+            <ref role="37wK5l" node="12YYiosy0aH" resolve="get" />
+          </node>
+          <node concept="3clFbS" id="12YYiosyuvk" role="2LFqv$">
+            <node concept="3cpWs8" id="12YYiosyxGM" role="3cqZAp">
+              <node concept="3cpWsn" id="12YYiosyxGP" role="3cpWs9">
+                <property role="TrG5h" value="col" />
+                <node concept="10Oyi0" id="12YYiosyxGL" role="1tU5fm" />
+                <node concept="37vLTw" id="12YYiosyyyk" role="33vP2m">
+                  <ref role="3cqZAo" node="12YYiosyskM" resolve="colOffset" />
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="12YYiosyznN" role="3cqZAp">
+              <node concept="2GrKxI" id="12YYiosyznP" role="2Gsz3X">
+                <property role="TrG5h" value="element" />
+              </node>
+              <node concept="2GrUjf" id="12YYiosyAiT" role="2GsD0m">
+                <ref role="2Gs0qQ" node="12YYiosyuvg" resolve="rowData" />
+              </node>
+              <node concept="3clFbS" id="12YYiosyznT" role="2LFqv$">
+                <node concept="3clFbF" id="12YYiosyAJ9" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosyBs4" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosyAJ8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosyqA2" resolve="elementConsumer" />
+                    </node>
+                    <node concept="1Bd96e" id="12YYiosyC02" role="2OqNvi">
+                      <node concept="2GrUjf" id="12YYiosyCFH" role="1BdPVh">
+                        <ref role="2Gs0qQ" node="12YYiosyznP" resolve="element" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiosyDRu" role="1BdPVh">
+                        <ref role="3cqZAo" node="12YYiosyt10" resolve="row" />
+                      </node>
+                      <node concept="37vLTw" id="12YYiosyEr$" role="1BdPVh">
+                        <ref role="3cqZAo" node="12YYiosyxGP" resolve="col" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="12YYiosyFrl" role="3cqZAp">
+                  <node concept="3uNrnE" id="12YYiosyIrk" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosyIrm" role="2$L3a6">
+                      <ref role="3cqZAo" node="12YYiosyxGP" resolve="col" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="12YYiosyKBz" role="3cqZAp">
+              <node concept="3uNrnE" id="12YYiosyKYb" role="3clFbG">
+                <node concept="37vLTw" id="12YYiosyKYd" role="2$L3a6">
+                  <ref role="3cqZAo" node="12YYiosyt10" resolve="row" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosyqA0" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYiosyqA1" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosyrLd" role="3clF46">
+        <property role="TrG5h" value="rowOffset" />
+        <node concept="10Oyi0" id="12YYiosys6Y" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosyskM" role="3clF46">
+        <property role="TrG5h" value="colOffset" />
+        <node concept="10Oyi0" id="12YYiosysEz" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosyqA2" role="3clF46">
+        <property role="TrG5h" value="elementConsumer" />
+        <node concept="1ajhzC" id="12YYiosyqA3" role="1tU5fm">
+          <node concept="3cqZAl" id="12YYiosyqA4" role="1ajl9A" />
+          <node concept="16syzq" id="12YYiosyqA5" role="1ajw0F">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+          <node concept="10Oyi0" id="12YYiosyqA6" role="1ajw0F" />
+          <node concept="10Oyi0" id="12YYiosyqA7" role="1ajw0F" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYioszCl7" role="jymVt" />
+    <node concept="3clFb_" id="12YYioszEw1" role="jymVt">
+      <property role="TrG5h" value="collect" />
+      <node concept="3clFbS" id="12YYioszEw4" role="3clF47">
+        <node concept="1Dw8fO" id="12YYioszJmD" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYioszJmE" role="1Duv9x">
+            <property role="TrG5h" value="rowIndex" />
+            <node concept="10Oyi0" id="12YYioszK7T" role="1tU5fm" />
+            <node concept="2OqwBi" id="12YYioszNFr" role="33vP2m">
+              <node concept="37vLTw" id="12YYioszMDw" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYioszFtq" resolve="box" />
+              </node>
+              <node concept="liA8E" id="6hm_9jpCf37" role="2OqNvi">
+                <ref role="37wK5l" to="9p8b:6hm_9jpLkQq" resolve="getStartRow" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYioszJmF" role="2LFqv$">
+            <node concept="3clFbF" id="12YYiosL0Ty" role="3cqZAp">
+              <node concept="2OqwBi" id="12YYiosL1MK" role="3clFbG">
+                <node concept="Xjq3P" id="12YYiosL0Tx" role="2Oq$k0" />
+                <node concept="liA8E" id="12YYiosL2Vs" role="2OqNvi">
+                  <ref role="37wK5l" node="12YYiosyh7q" resolve="addRow" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Dw8fO" id="12YYiosL4JI" role="3cqZAp">
+              <node concept="3clFbS" id="12YYiosL4JK" role="2LFqv$">
+                <node concept="3clFbF" id="12YYiosLlj5" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosLmdI" role="3clFbG">
+                    <node concept="Xjq3P" id="12YYiosLlj3" role="2Oq$k0" />
+                    <node concept="liA8E" id="12YYiosLnr3" role="2OqNvi">
+                      <ref role="37wK5l" node="12YYiosyeJw" resolve="addData" />
+                      <node concept="2OqwBi" id="12YYiosLqdH" role="37wK5m">
+                        <node concept="37vLTw" id="12YYiosLoqW" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYioszGkX" resolve="elementCollector" />
+                        </node>
+                        <node concept="1Bd96e" id="12YYiosLrMc" role="2OqNvi">
+                          <node concept="37vLTw" id="12YYiosLsMg" role="1BdPVh">
+                            <ref role="3cqZAo" node="12YYioszJmE" resolve="rowIndex" />
+                          </node>
+                          <node concept="37vLTw" id="12YYiosLuEG" role="1BdPVh">
+                            <ref role="3cqZAo" node="12YYiosL4JL" resolve="colIndex" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWsn" id="12YYiosL4JL" role="1Duv9x">
+                <property role="TrG5h" value="colIndex" />
+                <node concept="10Oyi0" id="12YYiosL5Km" role="1tU5fm" />
+                <node concept="2OqwBi" id="12YYiosL9bS" role="33vP2m">
+                  <node concept="37vLTw" id="12YYiosL8wv" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYioszFtq" resolve="box" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jpKyXX" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:6hm_9jpLkQx" resolve="getStartColumn" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2dkUwp" id="12YYiosLcrR" role="1Dwp0S">
+                <node concept="2OqwBi" id="12YYiosLesA" role="3uHU7w">
+                  <node concept="37vLTw" id="12YYiosLdx9" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYioszFtq" resolve="box" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jpKtnd" role="2OqNvi">
+                    <ref role="37wK5l" to="9p8b:6hm_9jpLkQJ" resolve="getEndColumn" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="12YYiosLbwr" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosL4JL" resolve="colIndex" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="12YYiosLjW_" role="1Dwrff">
+                <node concept="37vLTw" id="12YYiosLjWB" role="2$L3a6">
+                  <ref role="3cqZAo" node="12YYiosL4JL" resolve="colIndex" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2dkUwp" id="12YYiosKU7A" role="1Dwp0S">
+            <node concept="2OqwBi" id="12YYiosKX6A" role="3uHU7w">
+              <node concept="37vLTw" id="12YYiosKUYs" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYioszFtq" resolve="box" />
+              </node>
+              <node concept="liA8E" id="6hm_9jpCkfo" role="2OqNvi">
+                <ref role="37wK5l" to="9p8b:6hm_9jpLkQC" resolve="getEndRow" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="12YYiosKQZP" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYioszJmE" resolve="rowIndex" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="12YYiosKZBG" role="1Dwrff">
+            <node concept="37vLTw" id="12YYiosKZBI" role="2$L3a6">
+              <ref role="3cqZAo" node="12YYioszJmE" resolve="rowIndex" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosLx2Z" role="3cqZAp">
+          <node concept="Xjq3P" id="12YYiosLx2X" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYioszDid" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosLy7m" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="16syzq" id="12YYiosL$78" role="11_B2D">
+          <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYioszFtq" role="3clF46">
+        <property role="TrG5h" value="box" />
+        <node concept="3uibUv" id="12YYioszFtp" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:12YYioszPcw" resolve="UndirectedTableRange" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYioszGkX" role="3clF46">
+        <property role="TrG5h" value="elementCollector" />
+        <node concept="1ajhzC" id="12YYioszH0q" role="1tU5fm">
+          <node concept="16syzq" id="12YYioszIhH" role="1ajl9A">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+          <node concept="10Oyi0" id="12YYioszHji" role="1ajw0F" />
+          <node concept="10Oyi0" id="12YYioszHWl" role="1ajw0F" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosL_1E" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosLCDH" role="jymVt">
+      <property role="TrG5h" value="map" />
+      <node concept="3clFbS" id="12YYiosLCDK" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosLM1K" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosLM1L" role="3cpWs9">
+            <property role="TrG5h" value="mappedTable" />
+            <node concept="3uibUv" id="12YYiosLM1I" role="1tU5fm">
+              <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+              <node concept="16syzq" id="12YYiosLN27" role="11_B2D">
+                <ref role="16sUi3" node="12YYiosLE31" resolve="D" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="12YYiosLPhr" role="33vP2m">
+              <node concept="1pGfFk" id="12YYiosLQrZ" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="12YYiosxYju" resolve="TableData" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="12YYiosLSvR" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiosLSvT" role="2LFqv$">
+            <node concept="3cpWs8" id="12YYiosMdLD" role="3cqZAp">
+              <node concept="3KEzu6" id="12YYiosMdLA" role="3cpWs9">
+                <property role="TrG5h" value="row" />
+                <node concept="PeGgZ" id="12YYiosMdLB" role="1tU5fm" />
+                <node concept="2OqwBi" id="12YYiosMj$U" role="33vP2m">
+                  <node concept="1rXfSq" id="12YYiosMhhK" role="2Oq$k0">
+                    <ref role="37wK5l" node="12YYiosy0aH" resolve="get" />
+                  </node>
+                  <node concept="34jXtK" id="12YYiosMmBm" role="2OqNvi">
+                    <node concept="37vLTw" id="12YYiosMnTZ" role="25WWJ7">
+                      <ref role="3cqZAo" node="12YYiosLSvU" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="12YYiosMqhe" role="3cqZAp">
+              <node concept="2GrKxI" id="12YYiosMqhg" role="2Gsz3X">
+                <property role="TrG5h" value="element" />
+              </node>
+              <node concept="37vLTw" id="12YYiosMwrZ" role="2GsD0m">
+                <ref role="3cqZAo" node="12YYiosMdLA" resolve="row" />
+              </node>
+              <node concept="3clFbS" id="12YYiosMqhk" role="2LFqv$">
+                <node concept="3clFbF" id="12YYiosMxFl" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosMz1j" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosMxFk" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosLM1L" resolve="mappedTable" />
+                    </node>
+                    <node concept="liA8E" id="12YYiosM$vz" role="2OqNvi">
+                      <ref role="37wK5l" node="12YYiosyeJw" resolve="addData" />
+                      <node concept="2OqwBi" id="12YYiosMCFn" role="37wK5m">
+                        <node concept="37vLTw" id="12YYiosMAJ1" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiosLGgC" resolve="mapElementFun" />
+                        </node>
+                        <node concept="liA8E" id="12YYiosMEor" role="2OqNvi">
+                          <ref role="37wK5l" to="82uw:~Function.apply(java.lang.Object)" resolve="apply" />
+                          <node concept="2GrUjf" id="12YYiosMG80" role="37wK5m">
+                            <ref role="2Gs0qQ" node="12YYiosMqhg" resolve="element" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="12YYiosMIN6" role="3cqZAp">
+              <node concept="3clFbS" id="12YYiosMIN8" role="3clFbx">
+                <node concept="3clFbF" id="12YYiosN43x" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosN5w5" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosN43v" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosLM1L" resolve="mappedTable" />
+                    </node>
+                    <node concept="liA8E" id="12YYiosN73f" role="2OqNvi">
+                      <ref role="37wK5l" node="12YYiosyh7q" resolve="addRow" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOVzh" id="12YYiosMRvf" role="3clFbw">
+                <node concept="3cpWsd" id="12YYiosN2Cx" role="3uHU7w">
+                  <node concept="3cmrfG" id="12YYiosN2HB" role="3uHU7w">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosMW5Y" role="3uHU7B">
+                    <node concept="37vLTw" id="12YYiosMSKW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+                    </node>
+                    <node concept="34oBXx" id="12YYiosMZow" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="12YYiosMKcG" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosLSvU" resolve="i" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="12YYiosLSvU" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="12YYiosLTCj" role="1tU5fm" />
+            <node concept="3cmrfG" id="12YYiosLWLo" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="12YYiosM3rp" role="1Dwp0S">
+            <node concept="2OqwBi" id="12YYiosM7ZN" role="3uHU7w">
+              <node concept="37vLTw" id="12YYiosM4Yv" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+              </node>
+              <node concept="34oBXx" id="12YYiosMaV6" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="12YYiosM1M7" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosLSvU" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="12YYiosMcAC" role="1Dwrff">
+            <node concept="37vLTw" id="12YYiosMcAE" role="2$L3a6">
+              <ref role="3cqZAo" node="12YYiosLSvU" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosN9Og" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiosN9Oe" role="3clFbG">
+            <ref role="3cqZAo" node="12YYiosLM1L" resolve="mappedTable" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosLADh" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosLC2i" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="16syzq" id="12YYiosLF1b" role="11_B2D">
+          <ref role="16sUi3" node="12YYiosLE31" resolve="D" />
+        </node>
+      </node>
+      <node concept="16euLQ" id="12YYiosLE31" role="16eVyc">
+        <property role="TrG5h" value="D" />
+      </node>
+      <node concept="37vLTG" id="12YYiosLGgC" role="3clF46">
+        <property role="TrG5h" value="mapElementFun" />
+        <node concept="3uibUv" id="12YYiosLGgB" role="1tU5fm">
+          <ref role="3uigEE" to="82uw:~Function" resolve="Function" />
+          <node concept="16syzq" id="12YYiosLHHC" role="11_B2D">
+            <ref role="16sUi3" node="12YYiosxYhx" resolve="T" />
+          </node>
+          <node concept="16syzq" id="12YYiosLIDB" role="11_B2D">
+            <ref role="16sUi3" node="12YYiosLE31" resolve="D" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosNbjJ" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosNg8b" role="jymVt">
+      <property role="TrG5h" value="toFlatString" />
+      <node concept="3clFbS" id="12YYiosNg8e" role="3clF47">
+        <node concept="3clFbF" id="12YYiosNlmt" role="3cqZAp">
+          <node concept="1rXfSq" id="12YYiosNlms" role="3clFbG">
+            <ref role="37wK5l" node="12YYiosNAxJ" resolve="toFlatString" />
+            <node concept="2OqwBi" id="12YYiosNUdj" role="37wK5m">
+              <node concept="37vLTw" id="12YYiosNmIE" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosNi0X" resolve="separator" />
+              </node>
+              <node concept="2S8uIT" id="12YYiosNWXG" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJcgn" resolve="element" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="12YYiosNrmD" role="37wK5m">
+              <node concept="37vLTw" id="12YYiosNptz" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosNi0X" resolve="separator" />
+              </node>
+              <node concept="2S8uIT" id="12YYiosNuij" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJbTg" resolve="line" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosNdqP" role="1B3o_S" />
+      <node concept="17QB3L" id="12YYiosNfxW" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosNi0X" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="12YYiosNi0W" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosJ9Cy" resolve="TableDataSeparator" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosNv$k" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosNAxJ" role="jymVt">
+      <property role="TrG5h" value="toFlatString" />
+      <node concept="3clFbS" id="12YYiosNAxM" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosO0sm" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosO0sn" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="12YYiosO0so" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="12YYiosO7no" role="33vP2m">
+              <node concept="1pGfFk" id="12YYiosO8SS" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="12YYiosObE0" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiosObE2" role="2LFqv$">
+            <node concept="3cpWs8" id="12YYiosOzbQ" role="3cqZAp">
+              <node concept="3KEzu6" id="12YYiosOzbN" role="3cpWs9">
+                <property role="TrG5h" value="row" />
+                <node concept="PeGgZ" id="12YYiosOzbO" role="1tU5fm" />
+                <node concept="2OqwBi" id="12YYiosOBy3" role="33vP2m">
+                  <node concept="1rXfSq" id="12YYiosOA3X" role="2Oq$k0">
+                    <ref role="37wK5l" node="12YYiosy0aH" resolve="get" />
+                  </node>
+                  <node concept="34jXtK" id="12YYiosODby" role="2OqNvi">
+                    <node concept="37vLTw" id="12YYiosOEP7" role="25WWJ7">
+                      <ref role="3cqZAo" node="12YYiosObE3" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="12YYiosOHTP" role="3cqZAp">
+              <node concept="2OqwBi" id="12YYiosOJJ5" role="3clFbG">
+                <node concept="37vLTw" id="12YYiosOHTN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosO0sn" resolve="builder" />
+                </node>
+                <node concept="liA8E" id="12YYiosOMqM" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                  <node concept="2OqwBi" id="12YYiosPxd7" role="37wK5m">
+                    <node concept="2OqwBi" id="12YYiosOWYN" role="2Oq$k0">
+                      <node concept="2OqwBi" id="12YYiosORIS" role="2Oq$k0">
+                        <node concept="37vLTw" id="12YYiosOOdn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="12YYiosOzbN" resolve="row" />
+                        </node>
+                        <node concept="1l$wjB" id="12YYiosOUSM" role="2OqNvi" />
+                      </node>
+                      <node concept="liA8E" id="12YYiosOZtK" role="2OqNvi">
+                        <ref role="37wK5l" to="1ctc:~Stream.map(java.util.function.Function)" resolve="map" />
+                        <node concept="1bVj0M" id="12YYiosP1oM" role="37wK5m">
+                          <node concept="gl6BB" id="12YYiosP1p5" role="1bW2Oz">
+                            <property role="TrG5h" value="element" />
+                            <node concept="2jxLKc" id="12YYiosP1p6" role="1tU5fm" />
+                          </node>
+                          <node concept="3clFbS" id="12YYiosP1qP" role="1bW5cS">
+                            <node concept="3clFbJ" id="12YYiosP7DG" role="3cqZAp">
+                              <node concept="2ZW3vV" id="12YYiosPcmX" role="3clFbw">
+                                <node concept="3uibUv" id="12YYiosPeaz" role="2ZW6by">
+                                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                                </node>
+                                <node concept="37vLTw" id="12YYiosPa0Y" role="2ZW6bz">
+                                  <ref role="3cqZAo" node="12YYiosP1p5" resolve="element" />
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="12YYiosP7DI" role="3clFbx">
+                                <node concept="3cpWs6" id="12YYiosPgCt" role="3cqZAp">
+                                  <node concept="2OqwBi" id="12YYiosPkHu" role="3cqZAk">
+                                    <node concept="1eOMI4" id="12YYiosPi$o" role="2Oq$k0">
+                                      <node concept="10QFUN" id="12YYiosPi$l" role="1eOMHV">
+                                        <node concept="3uibUv" id="12YYiosPi$q" role="10QFUM">
+                                          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                                        </node>
+                                        <node concept="37vLTw" id="12YYiosPi$r" role="10QFUP">
+                                          <ref role="3cqZAo" node="12YYiosP1p5" resolve="element" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="12YYiosPm_M" role="2OqNvi">
+                                      <ref role="37wK5l" to="mhbf:~SNode.getPresentation()" resolve="getPresentation" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="12YYiosPqn$" role="3cqZAp">
+                              <node concept="2YIFZM" id="12YYiosPs6n" role="3clFbG">
+                                <ref role="37wK5l" to="33ny:~Objects.toString(java.lang.Object)" resolve="toString" />
+                                <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                                <node concept="37vLTw" id="12YYiosPutN" role="37wK5m">
+                                  <ref role="3cqZAo" node="12YYiosP1p5" resolve="element" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="12YYiosP$cP" role="2OqNvi">
+                      <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                      <node concept="2YIFZM" id="12YYiosPCMv" role="37wK5m">
+                        <ref role="37wK5l" to="1ctc:~Collectors.joining(java.lang.CharSequence)" resolve="joining" />
+                        <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                        <node concept="37vLTw" id="12YYiosPHnj" role="37wK5m">
+                          <ref role="3cqZAo" node="12YYiosNCHX" resolve="elementSeparator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="12YYiosPLGb" role="3cqZAp">
+              <node concept="3clFbS" id="12YYiosPLGd" role="3clFbx">
+                <node concept="3clFbF" id="12YYiosQ5Iy" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosQ7Hh" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosQ5Iw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosO0sn" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="12YYiosQaL4" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="37vLTw" id="12YYiosQcI0" role="37wK5m">
+                        <ref role="3cqZAo" node="12YYiosNFi7" resolve="lineSeparator" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOVzh" id="12YYiosPSn4" role="3clFbw">
+                <node concept="3cpWsd" id="12YYiosQ3Cf" role="3uHU7w">
+                  <node concept="3cmrfG" id="12YYiosQ3Ht" role="3uHU7w">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosPXEV" role="3uHU7B">
+                    <node concept="37vLTw" id="12YYiosPUhY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+                    </node>
+                    <node concept="34oBXx" id="12YYiosQ1_S" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="12YYiosPNXB" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYiosObE3" resolve="i" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="12YYiosObE3" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="12YYiosOd8Z" role="1tU5fm" />
+            <node concept="3cmrfG" id="12YYiosOh$9" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="12YYiosOn07" role="1Dwp0S">
+            <node concept="2OqwBi" id="12YYiosOrWN" role="3uHU7w">
+              <node concept="37vLTw" id="12YYiosOoKi" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosxYiG" resolve="content" />
+              </node>
+              <node concept="34oBXx" id="12YYiosOveG" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="12YYiosOj4K" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosObE3" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="12YYiosOxpX" role="1Dwrff">
+            <node concept="37vLTw" id="12YYiosOxpZ" role="2$L3a6">
+              <ref role="3cqZAo" node="12YYiosObE3" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosQiti" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosQlDE" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosQitg" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosO0sn" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="12YYiosQpdC" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="12YYiosNzHx" role="1B3o_S" />
+      <node concept="17QB3L" id="12YYiosN_Tt" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosNCHX" role="3clF46">
+        <property role="TrG5h" value="elementSeparator" />
+        <node concept="17QB3L" id="12YYiosNCHW" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosNFi7" role="3clF46">
+        <property role="TrG5h" value="lineSeparator" />
+        <node concept="17QB3L" id="12YYiosNHSe" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosxYgr" role="1B3o_S" />
+    <node concept="16euLQ" id="12YYiosxYhx" role="16eVyc">
+      <property role="TrG5h" value="T" />
+    </node>
+  </node>
+  <node concept="Qs71p" id="12YYiosJ9Cy">
+    <property role="TrG5h" value="TableDataSeparator" />
+    <property role="3GE5qa" value="tableData2D" />
+    <node concept="QsSxf" id="12YYiosJ9FV" role="Qtgdg">
+      <property role="TrG5h" value="TAB" />
+      <ref role="37wK5l" node="12YYiosJa45" resolve="TableDataSeparator" />
+      <node concept="Xl_RD" id="12YYiosJcpQ" role="37wK5m">
+        <property role="Xl_RC" value="\t" />
+      </node>
+      <node concept="Xl_RD" id="12YYiosJcuc" role="37wK5m">
+        <property role="Xl_RC" value="tab-separated" />
+      </node>
+    </node>
+    <node concept="QsSxf" id="12YYiosJ9Ix" role="Qtgdg">
+      <property role="TrG5h" value="SPACE" />
+      <ref role="37wK5l" node="12YYiosJa45" resolve="TableDataSeparator" />
+      <node concept="Xl_RD" id="12YYiosJcwZ" role="37wK5m">
+        <property role="Xl_RC" value=" " />
+      </node>
+      <node concept="Xl_RD" id="12YYiosJcEg" role="37wK5m">
+        <property role="Xl_RC" value="space-separated" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosJ9Cz" role="1B3o_S" />
+    <node concept="3clFbW" id="12YYiosJa45" role="jymVt">
+      <node concept="3cqZAl" id="12YYiosJa46" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosJa48" role="3clF47">
+        <node concept="3clFbF" id="4GSZoZk$2XW" role="3cqZAp">
+          <node concept="37vLTI" id="4GSZoZk$8uH" role="3clFbG">
+            <node concept="37vLTw" id="4GSZoZk$cJP" role="37vLTx">
+              <ref role="3cqZAo" node="12YYiosJapK" resolve="separator" />
+            </node>
+            <node concept="2OqwBi" id="4GSZoZk$48x" role="37vLTJ">
+              <node concept="Xjq3P" id="4GSZoZk$2XV" role="2Oq$k0" />
+              <node concept="2S8uIT" id="4GSZoZk$7aL" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJcgn" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GSZoZk$eP2" role="3cqZAp">
+          <node concept="37vLTI" id="4GSZoZk$eZK" role="3clFbG">
+            <node concept="Xl_RD" id="4GSZoZk$fdK" role="37vLTx">
+              <property role="Xl_RC" value="\n" />
+            </node>
+            <node concept="2OqwBi" id="4GSZoZk$ePF" role="37vLTJ">
+              <node concept="Xjq3P" id="4GSZoZk$eP0" role="2Oq$k0" />
+              <node concept="2S8uIT" id="4GSZoZk$eUt" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJbTg" resolve="line" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GSZoZk$gBb" role="3cqZAp">
+          <node concept="37vLTI" id="4GSZoZk$kto" role="3clFbG">
+            <node concept="37vLTw" id="4GSZoZk$kHH" role="37vLTx">
+              <ref role="3cqZAo" node="12YYiosJarA" resolve="description" />
+            </node>
+            <node concept="2OqwBi" id="4GSZoZk$hMv" role="37vLTJ">
+              <node concept="Xjq3P" id="4GSZoZk$gB9" role="2Oq$k0" />
+              <node concept="2S8uIT" id="4GSZoZk$j8H" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJcic" resolve="description" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYiosJapK" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="17QB3L" id="12YYiosJapJ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosJarA" role="3clF46">
+        <property role="TrG5h" value="description" />
+        <node concept="17QB3L" id="12YYiosJaJ$" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosJaWM" role="jymVt" />
+    <node concept="2RhdJD" id="12YYiosJbTg" role="jymVt">
+      <property role="2RkwnN" value="line" />
+      <node concept="3Tm1VV" id="12YYiosJbTh" role="1B3o_S" />
+      <node concept="2RoN1w" id="12YYiosJbTi" role="2RnVtd">
+        <node concept="3wEZqW" id="12YYiosJbTj" role="3wFrgM" />
+        <node concept="3xqBd$" id="12YYiosJbTk" role="3xrYvX">
+          <node concept="3Tm6S6" id="12YYiosJbTl" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="12YYiosJcd9" role="2RkE6I" />
+    </node>
+    <node concept="2RhdJD" id="12YYiosJcgn" role="jymVt">
+      <property role="2RkwnN" value="element" />
+      <node concept="3Tm1VV" id="12YYiosJcgo" role="1B3o_S" />
+      <node concept="2RoN1w" id="12YYiosJcgp" role="2RnVtd">
+        <node concept="3wEZqW" id="12YYiosJcgq" role="3wFrgM" />
+        <node concept="3xqBd$" id="12YYiosJcgr" role="3xrYvX">
+          <node concept="3Tm6S6" id="12YYiosJcgs" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="12YYiosJcgt" role="2RkE6I" />
+    </node>
+    <node concept="2RhdJD" id="12YYiosJcic" role="jymVt">
+      <property role="2RkwnN" value="description" />
+      <node concept="3Tm1VV" id="12YYiosJcid" role="1B3o_S" />
+      <node concept="2RoN1w" id="12YYiosJcie" role="2RnVtd">
+        <node concept="3wEZqW" id="12YYiosJcif" role="3wFrgM" />
+        <node concept="3xqBd$" id="12YYiosJcig" role="3xrYvX">
+          <node concept="3Tm6S6" id="12YYiosJcih" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="17QB3L" id="12YYiosJcii" role="2RkE6I" />
+    </node>
+  </node>
+  <node concept="312cEu" id="12YYiosJj0X">
+    <property role="3GE5qa" value="tableData2D" />
+    <property role="TrG5h" value="TableDataParser" />
+    <node concept="2RhdJD" id="12YYiosJj4R" role="jymVt">
+      <property role="2RkwnN" value="separator" />
+      <node concept="3Tm1VV" id="12YYiosJj4S" role="1B3o_S" />
+      <node concept="2RoN1w" id="12YYiosJj4T" role="2RnVtd">
+        <node concept="3wEZqW" id="12YYiosJj4U" role="3wFrgM" />
+        <node concept="3xqBd$" id="12YYiosJj4V" role="3xrYvX">
+          <node concept="3Tm6S6" id="12YYiosJj4W" role="3xqFEP" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="12YYiosJj86" role="2RkE6I">
+        <ref role="3uigEE" node="12YYiosJ9Cy" resolve="TableDataSeparator" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosJj8u" role="jymVt" />
+    <node concept="3clFbW" id="12YYiosJjev" role="jymVt">
+      <node concept="3cqZAl" id="12YYiosJjew" role="3clF45" />
+      <node concept="3clFbS" id="12YYiosJjey" role="3clF47">
+        <node concept="3clFbF" id="12YYiosJjyN" role="3cqZAp">
+          <node concept="37vLTI" id="12YYiosJkZE" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosJl0F" role="37vLTx">
+              <ref role="3cqZAo" node="12YYiosJjhR" resolve="separator" />
+            </node>
+            <node concept="2OqwBi" id="12YYiosJjEf" role="37vLTJ">
+              <node concept="Xjq3P" id="12YYiosJjyM" role="2Oq$k0" />
+              <node concept="2S8uIT" id="12YYiosJjNB" role="2OqNvi">
+                <ref role="2S8YL0" node="12YYiosJj4R" resolve="separator" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosJjez" role="1B3o_S" />
+      <node concept="37vLTG" id="12YYiosJjhR" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="12YYiosJjhQ" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosJ9Cy" resolve="TableDataSeparator" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosJlHE" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosJmoN" role="jymVt">
+      <property role="TrG5h" value="fromString" />
+      <node concept="3clFbS" id="12YYiosJmoQ" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosJmLE" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosJmLF" role="3cpWs9">
+            <property role="TrG5h" value="table" />
+            <node concept="3uibUv" id="12YYiosJmLC" role="1tU5fm">
+              <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+              <node concept="17QB3L" id="12YYiosJn4q" role="11_B2D" />
+            </node>
+            <node concept="2ShNRf" id="12YYiosJnah" role="33vP2m">
+              <node concept="1pGfFk" id="12YYiosJnlk" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" node="12YYiosxYju" resolve="TableData" />
+                <node concept="17QB3L" id="12YYiosJnC$" role="1pMfVU" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosJnEg" role="3cqZAp" />
+        <node concept="3cpWs8" id="12YYiosJnZj" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosJnZm" role="3cpWs9">
+            <property role="TrG5h" value="lines" />
+            <node concept="10Q1$e" id="12YYiosJo6Z" role="1tU5fm">
+              <node concept="17QB3L" id="12YYiosJnZh" role="10Q1$1" />
+            </node>
+            <node concept="2OqwBi" id="12YYiosJpsE" role="33vP2m">
+              <node concept="37vLTw" id="12YYiosJob3" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiosJmFr" resolve="rawString" />
+              </node>
+              <node concept="liA8E" id="12YYiosJqOH" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                <node concept="2OqwBi" id="12YYiosJrTC" role="37wK5m">
+                  <node concept="338YkY" id="12YYiosJqSU" role="2Oq$k0">
+                    <ref role="338YkT" node="12YYiosJj4R" resolve="separator" />
+                  </node>
+                  <node concept="2S8uIT" id="12YYiosJtfx" role="2OqNvi">
+                    <ref role="2S8YL0" node="12YYiosJbTg" resolve="line" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="12YYiosJtpi" role="3cqZAp">
+          <node concept="2GrKxI" id="12YYiosJtpk" role="2Gsz3X">
+            <property role="TrG5h" value="line" />
+          </node>
+          <node concept="37vLTw" id="12YYiosJtAN" role="2GsD0m">
+            <ref role="3cqZAo" node="12YYiosJnZm" resolve="lines" />
+          </node>
+          <node concept="3clFbS" id="12YYiosJtpo" role="2LFqv$">
+            <node concept="3clFbF" id="12YYiosJtHk" role="3cqZAp">
+              <node concept="2OqwBi" id="12YYiosJtW9" role="3clFbG">
+                <node concept="37vLTw" id="12YYiosJtHj" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosJmLF" resolve="table" />
+                </node>
+                <node concept="liA8E" id="12YYiosJum5" role="2OqNvi">
+                  <ref role="37wK5l" node="12YYiosyh7q" resolve="addRow" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="12YYiosJuSd" role="3cqZAp">
+              <node concept="3cpWsn" id="12YYiosJuSg" role="3cpWs9">
+                <property role="TrG5h" value="elements" />
+                <node concept="10Q1$e" id="12YYiosJv2B" role="1tU5fm">
+                  <node concept="17QB3L" id="12YYiosJuSb" role="10Q1$1" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosJwB5" role="33vP2m">
+                  <node concept="2GrUjf" id="12YYiosJvkN" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="12YYiosJtpk" resolve="line" />
+                  </node>
+                  <node concept="liA8E" id="12YYiosJy3z" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                    <node concept="2OqwBi" id="12YYiosJzdV" role="37wK5m">
+                      <node concept="338YkY" id="12YYiosJyaF" role="2Oq$k0">
+                        <ref role="338YkT" node="12YYiosJj4R" resolve="separator" />
+                      </node>
+                      <node concept="2S8uIT" id="12YYiosJ$BA" role="2OqNvi">
+                        <ref role="2S8YL0" node="12YYiosJcgn" resolve="element" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="12YYiosJ$UJ" role="3cqZAp">
+              <node concept="2GrKxI" id="12YYiosJ$UL" role="2Gsz3X">
+                <property role="TrG5h" value="element" />
+              </node>
+              <node concept="37vLTw" id="12YYiosJ_zt" role="2GsD0m">
+                <ref role="3cqZAo" node="12YYiosJuSg" resolve="elements" />
+              </node>
+              <node concept="3clFbS" id="12YYiosJ$UP" role="2LFqv$">
+                <node concept="3clFbF" id="12YYiosJ_Hz" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYiosJA15" role="3clFbG">
+                    <node concept="37vLTw" id="12YYiosJ_Hy" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYiosJmLF" resolve="table" />
+                    </node>
+                    <node concept="liA8E" id="12YYiosJAu_" role="2OqNvi">
+                      <ref role="37wK5l" node="12YYiosyeJw" resolve="addData" />
+                      <node concept="2OqwBi" id="12YYiosJCtz" role="37wK5m">
+                        <node concept="2GrUjf" id="12YYiosJB1o" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="12YYiosJ$UL" resolve="element" />
+                        </node>
+                        <node concept="17S1cR" id="12YYiosJDZ$" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosJE8L" role="3cqZAp" />
+        <node concept="3clFbF" id="12YYiosJETP" role="3cqZAp">
+          <node concept="37vLTw" id="12YYiosJETN" role="3clFbG">
+            <ref role="3cqZAo" node="12YYiosJmLF" resolve="table" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosJlZY" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosJm3G" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="17QB3L" id="12YYiosJmok" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="12YYiosJmFr" role="3clF46">
+        <property role="TrG5h" value="rawString" />
+        <node concept="17QB3L" id="12YYiosJmFq" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosJj0Y" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="12YYiosJFef">
+    <property role="3GE5qa" value="dataTransformation" />
+    <property role="TrG5h" value="TableTransformationManager" />
+    <node concept="2tJIrI" id="12YYiosJFf1" role="jymVt" />
+    <node concept="2YIFZL" id="1vOmbReyRjH" role="jymVt">
+      <property role="TrG5h" value="dataToNode" />
+      <node concept="3clFbS" id="1vOmbReyRjK" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosJR8E" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosJR8F" role="3cpWs9">
+            <property role="TrG5h" value="transformers" />
+            <node concept="_YKpA" id="12YYiosJY5g" role="1tU5fm">
+              <node concept="3uibUv" id="12YYiosJY5h" role="_ZDj9">
+                <ref role="3uigEE" node="12YYiosJH84" resolve="DataTransformer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="12YYiosJZ_V" role="33vP2m">
+              <node concept="2OqwBi" id="12YYiosJR8H" role="2Oq$k0">
+                <node concept="2OqwBi" id="1vOmbRez3zP" role="2Oq$k0">
+                  <node concept="2OqwBi" id="12YYiosJR8I" role="2Oq$k0">
+                    <node concept="2O5UvJ" id="12YYiosJR8J" role="2Oq$k0">
+                      <ref role="2O5UnU" node="12YYiosJH7W" resolve="DataTransformation" />
+                    </node>
+                    <node concept="SfwO_" id="12YYiosJR8K" role="2OqNvi" />
+                  </node>
+                  <node concept="3zZkjj" id="1vOmbRez4Di" role="2OqNvi">
+                    <node concept="1bVj0M" id="1vOmbRez4Dk" role="23t8la">
+                      <node concept="3clFbS" id="1vOmbRez4Dl" role="1bW5cS">
+                        <node concept="3clFbF" id="1vOmbRez54_" role="3cqZAp">
+                          <node concept="2OqwBi" id="1vOmbRez5mm" role="3clFbG">
+                            <node concept="37vLTw" id="1vOmbRez54$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1vOmbRez4Dm" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="1vOmbRez7wz" role="2OqNvi">
+                              <ref role="37wK5l" node="1vOmbReyvyU" resolve="isApplicable" />
+                              <node concept="37vLTw" id="2CQc9DOyvva" role="37wK5m">
+                                <ref role="3cqZAo" node="1vOmbReyWy1" resolve="tableNode" />
+                              </node>
+                              <node concept="37vLTw" id="6hm_9jpQTLV" role="37wK5m">
+                                <ref role="3cqZAo" node="6hm_9jpQQAk" resolve="editorContext" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="1vOmbRez4Dm" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="1vOmbRez4Dn" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2S7cBI" id="12YYiosJR8L" role="2OqNvi">
+                  <node concept="1nlBCl" id="12YYiosJX$L" role="2S7zOq" />
+                  <node concept="1bVj0M" id="12YYiosJR8N" role="23t8la">
+                    <node concept="3clFbS" id="12YYiosJR8O" role="1bW5cS">
+                      <node concept="3clFbF" id="12YYiosJR8P" role="3cqZAp">
+                        <node concept="2OqwBi" id="12YYiosJR8Q" role="3clFbG">
+                          <node concept="37vLTw" id="12YYiosJR8R" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosJR8T" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="12YYiosJR8S" role="2OqNvi">
+                            <ref role="37wK5l" node="12YYiosJHkp" resolve="getPriority" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="12YYiosJR8T" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="12YYiosJR8U" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="12YYiosK0Xl" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYiosJRO3" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiosJRO5" role="3clFbx">
+            <node concept="YS8fn" id="12YYiosKu_M" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYiosKuTe" role="YScLw">
+                <node concept="1pGfFk" id="12YYiosKvm1" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="33ny:~NoSuchElementException.&lt;init&gt;(java.lang.String)" resolve="NoSuchElementException" />
+                  <node concept="Xl_RD" id="12YYiosKvWY" role="37wK5m">
+                    <property role="Xl_RC" value="No table data transformer found" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="12YYiosJSyb" role="3clFbw">
+            <node concept="10Nm6u" id="12YYiosJSQd" role="3uHU7w" />
+            <node concept="37vLTw" id="12YYiosJScd" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosJR8F" resolve="transformers" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosJTST" role="3cqZAp" />
+        <node concept="2Gpval" id="12YYiosKg8Z" role="3cqZAp">
+          <node concept="2GrKxI" id="12YYiosKg91" role="2Gsz3X">
+            <property role="TrG5h" value="transformer" />
+          </node>
+          <node concept="37vLTw" id="12YYiosKiZY" role="2GsD0m">
+            <ref role="3cqZAo" node="12YYiosJR8F" resolve="transformers" />
+          </node>
+          <node concept="3clFbS" id="12YYiosKg95" role="2LFqv$">
+            <node concept="3clFbF" id="1vOmbRe_2du" role="3cqZAp">
+              <node concept="2OqwBi" id="1vOmbRe_2yL" role="3clFbG">
+                <node concept="2GrUjf" id="1vOmbRe_2ds" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="12YYiosKg91" resolve="transformer" />
+                </node>
+                <node concept="liA8E" id="1vOmbRe_3cJ" role="2OqNvi">
+                  <ref role="37wK5l" node="1vOmbRey$ha" resolve="setTable" />
+                  <node concept="37vLTw" id="1vOmbRe_3LG" role="37wK5m">
+                    <ref role="3cqZAo" node="1vOmbReyWy1" resolve="tableNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="12YYiosK7yC" role="3cqZAp">
+              <node concept="3cpWsn" id="12YYiosK7yD" role="3cpWs9">
+                <property role="TrG5h" value="parsedNode" />
+                <node concept="3Tqbb2" id="12YYiosKcAt" role="1tU5fm" />
+                <node concept="2OqwBi" id="12YYiosK7yE" role="33vP2m">
+                  <node concept="2GrUjf" id="12YYiosKkAL" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="12YYiosKg91" resolve="transformer" />
+                  </node>
+                  <node concept="liA8E" id="12YYiosK7yG" role="2OqNvi">
+                    <ref role="37wK5l" node="12YYiosJH$E" resolve="fromString" />
+                    <node concept="37vLTw" id="12YYiosK9HS" role="37wK5m">
+                      <ref role="3cqZAo" node="1vOmbReyVV6" resolve="data" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="12YYiosKmiZ" role="3cqZAp">
+              <node concept="3clFbS" id="12YYiosKmj1" role="3clFbx">
+                <node concept="3cpWs6" id="12YYiosKo64" role="3cqZAp">
+                  <node concept="37vLTw" id="12YYiosKopV" role="3cqZAk">
+                    <ref role="3cqZAo" node="12YYiosK7yD" resolve="parsedNode" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="12YYiosKmZc" role="3clFbw">
+                <node concept="37vLTw" id="12YYiosKm_G" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosK7yD" resolve="parsedNode" />
+                </node>
+                <node concept="3x8VRR" id="12YYiosKnrb" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosKoC1" role="3cqZAp" />
+        <node concept="3cpWs6" id="12YYiosKp_F" role="3cqZAp">
+          <node concept="10Nm6u" id="12YYiosKpZz" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1vOmbReAW5V" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1vOmbReyRhR" role="3clF45" />
+      <node concept="37vLTG" id="1vOmbReyWy1" role="3clF46">
+        <property role="TrG5h" value="tableNode" />
+        <node concept="3Tqbb2" id="1vOmbReyWQT" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1vOmbReyVV6" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="17QB3L" id="1vOmbReyVV5" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQQAk" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQR6s" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbRe_ggm" role="jymVt" />
+    <node concept="2YIFZL" id="1vOmbRe_nkb" role="jymVt">
+      <property role="TrG5h" value="nodeToData" />
+      <node concept="3clFbS" id="1vOmbRe_nke" role="3clF47">
+        <node concept="3cpWs8" id="7NamNJXARdV" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXARdW" role="3cpWs9">
+            <property role="TrG5h" value="tableNode" />
+            <node concept="3Tqbb2" id="7NamNJXATiZ" role="1tU5fm" />
+            <node concept="2OqwBi" id="7NamNJXEwm6" role="33vP2m">
+              <node concept="2OqwBi" id="7NamNJXEt_l" role="2Oq$k0">
+                <node concept="37vLTw" id="7NamNJXEsB3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXEpQM" resolve="selection" />
+                </node>
+                <node concept="liA8E" id="7NamNJXEuGm" role="2OqNvi">
+                  <ref role="37wK5l" to="9p8b:630t2b85S9Y" resolve="getTable" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7NamNJXEyip" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getSNode()" resolve="getSNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiosKsNi" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosKsNj" role="3cpWs9">
+            <property role="TrG5h" value="transformer" />
+            <node concept="2OqwBi" id="12YYiosKsNm" role="33vP2m">
+              <node concept="2OqwBi" id="12YYiosKsNn" role="2Oq$k0">
+                <node concept="2OqwBi" id="1vOmbRe_Hyx" role="2Oq$k0">
+                  <node concept="2OqwBi" id="12YYiosKsNo" role="2Oq$k0">
+                    <node concept="2O5UvJ" id="12YYiosKsNp" role="2Oq$k0">
+                      <ref role="2O5UnU" node="12YYiosJH7W" resolve="DataTransformation" />
+                    </node>
+                    <node concept="SfwO_" id="12YYiosKsNq" role="2OqNvi" />
+                  </node>
+                  <node concept="3zZkjj" id="1vOmbRe_IAQ" role="2OqNvi">
+                    <node concept="1bVj0M" id="1vOmbRe_IAS" role="23t8la">
+                      <node concept="3clFbS" id="1vOmbRe_IAT" role="1bW5cS">
+                        <node concept="3clFbF" id="1vOmbRe_J3v" role="3cqZAp">
+                          <node concept="2OqwBi" id="1vOmbRe_Jlr" role="3clFbG">
+                            <node concept="37vLTw" id="1vOmbRe_J3u" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1vOmbRe_IAU" resolve="it" />
+                            </node>
+                            <node concept="liA8E" id="1vOmbRe_JPN" role="2OqNvi">
+                              <ref role="37wK5l" node="1vOmbReyvyU" resolve="isApplicable" />
+                              <node concept="37vLTw" id="2CQc9DOywOo" role="37wK5m">
+                                <ref role="3cqZAo" node="7NamNJXARdW" resolve="tableNode" />
+                              </node>
+                              <node concept="37vLTw" id="6hm_9jpQUKY" role="37wK5m">
+                                <ref role="3cqZAo" node="7NamNJWMaZ$" resolve="editorContext" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="1vOmbRe_IAU" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="1vOmbRe_IAV" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2S7cBI" id="12YYiosKsNr" role="2OqNvi">
+                  <node concept="1nlBCl" id="12YYiosKsNs" role="2S7zOq" />
+                  <node concept="1bVj0M" id="12YYiosKsNt" role="23t8la">
+                    <node concept="3clFbS" id="12YYiosKsNu" role="1bW5cS">
+                      <node concept="3clFbF" id="12YYiosKsNv" role="3cqZAp">
+                        <node concept="2OqwBi" id="12YYiosKsNw" role="3clFbG">
+                          <node concept="37vLTw" id="12YYiosKsNx" role="2Oq$k0">
+                            <ref role="3cqZAo" node="12YYiosKsNz" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="12YYiosKsNy" role="2OqNvi">
+                            <ref role="37wK5l" node="12YYiosJHkp" resolve="getPriority" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="12YYiosKsNz" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="12YYiosKsN$" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1yVyf7" id="12YYiosK$6R" role="2OqNvi" />
+            </node>
+            <node concept="3uibUv" id="12YYiosK$Kw" role="1tU5fm">
+              <ref role="3uigEE" node="12YYiosJH84" resolve="DataTransformer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYiosKEwb" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiosKEwc" role="3clFbx">
+            <node concept="3clFbJ" id="7NamNJXTgC8" role="3cqZAp">
+              <node concept="2OqwBi" id="7NamNJXTgC9" role="3clFbw">
+                <node concept="37vLTw" id="7NamNJXTgCa" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1vOmbRe_tj9" resolve="node" />
+                </node>
+                <node concept="3w_OXm" id="7NamNJXTgCb" role="2OqNvi" />
+              </node>
+              <node concept="3clFbS" id="7NamNJXTgCc" role="3clFbx">
+                <node concept="3cpWs6" id="7NamNJXTgCd" role="3cqZAp">
+                  <node concept="Xl_RD" id="7NamNJXTgCe" role="3cqZAk">
+                    <property role="Xl_RC" value="" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7NamNJXTgCf" role="3cqZAp" />
+            <node concept="3cpWs8" id="7NamNJXTgCg" role="3cqZAp">
+              <node concept="3cpWsn" id="7NamNJXTgCh" role="3cpWs9">
+                <property role="TrG5h" value="nodeCell" />
+                <node concept="3uibUv" id="7NamNJXTgCi" role="1tU5fm">
+                  <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                </node>
+                <node concept="2OqwBi" id="7NamNJXTgCj" role="33vP2m">
+                  <node concept="2OqwBi" id="7NamNJXTgCk" role="2Oq$k0">
+                    <node concept="37vLTw" id="7NamNJXTgCl" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7NamNJXEpQM" resolve="selection" />
+                    </node>
+                    <node concept="liA8E" id="7NamNJXTgCm" role="2OqNvi">
+                      <ref role="37wK5l" to="9p8b:6Y0V2RJiAgN" resolve="getSelectedGridCells" />
+                    </node>
+                  </node>
+                  <node concept="1z4cxt" id="7NamNJXTgCn" role="2OqNvi">
+                    <node concept="1bVj0M" id="7NamNJXTgCo" role="23t8la">
+                      <node concept="3clFbS" id="7NamNJXTgCp" role="1bW5cS">
+                        <node concept="3cpWs8" id="2CQc9DOu_$y" role="3cqZAp">
+                          <node concept="3cpWsn" id="2CQc9DOu_$z" role="3cpWs9">
+                            <property role="TrG5h" value="gridNode" />
+                            <node concept="3Tqbb2" id="2CQc9DOuD69" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2CQc9DOu_$$" role="33vP2m">
+                              <node concept="37vLTw" id="2CQc9DOu_$_" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7NamNJXTgCw" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="2CQc9DOu_$A" role="2OqNvi">
+                                <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="2CQc9DOuB1Y" role="3cqZAp">
+                          <node concept="2OqwBi" id="2CQc9DOuGrI" role="3clFbG">
+                            <node concept="2OqwBi" id="2CQc9DOuBWf" role="2Oq$k0">
+                              <node concept="37vLTw" id="2CQc9DOuB1W" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2CQc9DOu_$z" resolve="gridNode" />
+                              </node>
+                              <node concept="2Rf3mk" id="2CQc9DOuDz$" role="2OqNvi">
+                                <node concept="1xIGOp" id="2CQc9DOvgZE" role="1xVPHs" />
+                              </node>
+                            </node>
+                            <node concept="2HwmR7" id="2CQc9DOuJ76" role="2OqNvi">
+                              <node concept="1bVj0M" id="2CQc9DOuJ78" role="23t8la">
+                                <node concept="3clFbS" id="2CQc9DOuJ79" role="1bW5cS">
+                                  <node concept="3clFbF" id="2CQc9DOuK05" role="3cqZAp">
+                                    <node concept="2YFouu" id="2CQc9DOuKVq" role="3clFbG">
+                                      <node concept="37vLTw" id="2CQc9DOuLo9" role="3uHU7B">
+                                        <ref role="3cqZAo" node="2CQc9DOuJ7a" resolve="it" />
+                                      </node>
+                                      <node concept="37vLTw" id="2CQc9DOuMIw" role="3uHU7w">
+                                        <ref role="3cqZAo" node="1vOmbRe_tj9" resolve="node" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="gl6BB" id="2CQc9DOuJ7a" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="2CQc9DOuJ7b" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="7NamNJXTgCw" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7NamNJXTgCx" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2CQc9DOucbq" role="3cqZAp">
+              <node concept="3clFbS" id="2CQc9DOucbr" role="3clFbx">
+                <node concept="3SKdUt" id="2CQc9DOucbs" role="3cqZAp">
+                  <node concept="1PaTwC" id="2CQc9DOucbt" role="1aUNEU">
+                    <node concept="3oM_SD" id="2CQc9DOucbu" role="1PaTwD">
+                      <property role="3oM_SC" value="fall" />
+                    </node>
+                    <node concept="3oM_SD" id="2CQc9DOucbv" role="1PaTwD">
+                      <property role="3oM_SC" value="back" />
+                    </node>
+                    <node concept="3oM_SD" id="2CQc9DOucbw" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="2CQc9DOucbx" role="1PaTwD">
+                      <property role="3oM_SC" value="string" />
+                    </node>
+                    <node concept="3oM_SD" id="2CQc9DOucby" role="1PaTwD">
+                      <property role="3oM_SC" value="representation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="2CQc9DOucbz" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CQc9DOucb$" role="3cqZAk">
+                    <node concept="37vLTw" id="2CQc9DOucb_" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1vOmbRe_tj9" resolve="node" />
+                    </node>
+                    <node concept="2qgKlT" id="2CQc9DOucbA" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="2CQc9DOucbB" role="3clFbw">
+                <node concept="10Nm6u" id="2CQc9DOucbC" role="3uHU7w" />
+                <node concept="37vLTw" id="2CQc9DOucbD" role="3uHU7B">
+                  <ref role="3cqZAo" node="7NamNJXTgCh" resolve="nodeCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7NamNJXTgCy" role="3cqZAp" />
+            <node concept="3cpWs8" id="7NamNJXTgCz" role="3cqZAp">
+              <node concept="3cpWsn" id="7NamNJXTgC$" role="3cpWs9">
+                <property role="TrG5h" value="text" />
+                <node concept="17QB3L" id="7NamNJXTgC_" role="1tU5fm" />
+                <node concept="2OqwBi" id="7NamNJXTgCA" role="33vP2m">
+                  <node concept="2OqwBi" id="7NamNJXTgCB" role="2Oq$k0">
+                    <node concept="37vLTw" id="7NamNJXTgCC" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7NamNJXTgCh" resolve="nodeCell" />
+                    </node>
+                    <node concept="liA8E" id="7NamNJXTgCD" role="2OqNvi">
+                      <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7NamNJXTgCE" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~TextBuilder.getText()" resolve="getText" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="7NamNJXTgCF" role="3cqZAp">
+              <node concept="37vLTw" id="7NamNJXTgCG" role="3cqZAk">
+                <ref role="3cqZAo" node="7NamNJXTgC$" resolve="text" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="12YYiosKEwh" role="3clFbw">
+            <node concept="10Nm6u" id="12YYiosKEwi" role="3uHU7w" />
+            <node concept="37vLTw" id="12YYiosKEwj" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosKsNj" resolve="transformer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosKsNH" role="3cqZAp" />
+        <node concept="3clFbF" id="1vOmbReCdKE" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReCefJ" role="3clFbG">
+            <node concept="37vLTw" id="1vOmbReCdKC" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosKsNj" resolve="transformer" />
+            </node>
+            <node concept="liA8E" id="1vOmbReCeEz" role="2OqNvi">
+              <ref role="37wK5l" node="1vOmbRey$ha" resolve="setTable" />
+              <node concept="37vLTw" id="1vOmbReCf7$" role="37wK5m">
+                <ref role="3cqZAo" node="7NamNJXARdW" resolve="tableNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosKG85" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosKGwR" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosKG83" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosKsNj" resolve="transformer" />
+            </node>
+            <node concept="liA8E" id="12YYiosKH4u" role="2OqNvi">
+              <ref role="37wK5l" node="12YYiosJIb5" resolve="asString" />
+              <node concept="37vLTw" id="7NamNJXCysY" role="37wK5m">
+                <ref role="3cqZAo" node="7NamNJXEpQM" resolve="selection" />
+              </node>
+              <node concept="37vLTw" id="12YYiosKHrX" role="37wK5m">
+                <ref role="3cqZAo" node="1vOmbRe_tj9" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="7NamNJWMepi" role="37wK5m">
+                <ref role="3cqZAo" node="7NamNJWMaZ$" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1vOmbReAWDO" role="1B3o_S" />
+      <node concept="17QB3L" id="1vOmbRe_nir" role="3clF45" />
+      <node concept="37vLTG" id="7NamNJXEpQM" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="7NamNJXEqRr" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1vOmbRe_tj9" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1vOmbRe_tBJ" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7NamNJWMaZ$" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="7NamNJWMbzy" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosKJyE" role="jymVt" />
+    <node concept="2YIFZL" id="12YYiosKLX8" role="jymVt">
+      <property role="TrG5h" value="stringDataToNodeData" />
+      <node concept="3clFbS" id="12YYiosKLXb" role="3clF47">
+        <node concept="3clFbF" id="12YYiosKN4Q" role="3cqZAp">
+          <node concept="2OqwBi" id="12YYiosKN$9" role="3clFbG">
+            <node concept="37vLTw" id="12YYiosKN4P" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosKM$6" resolve="tableData" />
+            </node>
+            <node concept="liA8E" id="12YYiosR602" role="2OqNvi">
+              <ref role="37wK5l" node="12YYiosLCDH" resolve="map" />
+              <node concept="1bVj0M" id="1vOmbReze8E" role="37wK5m">
+                <node concept="gl6BB" id="1vOmbReze8Y" role="1bW2Oz">
+                  <property role="TrG5h" value="data" />
+                  <node concept="2jxLKc" id="1vOmbReze8Z" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="1vOmbReze94" role="1bW5cS">
+                  <node concept="3clFbF" id="1vOmbRezeNN" role="3cqZAp">
+                    <node concept="1rXfSq" id="1vOmbRezeNM" role="3clFbG">
+                      <ref role="37wK5l" node="1vOmbReyRjH" resolve="dataToNode" />
+                      <node concept="37vLTw" id="1vOmbRezxIG" role="37wK5m">
+                        <ref role="3cqZAo" node="1vOmbReztXk" resolve="table" />
+                      </node>
+                      <node concept="37vLTw" id="1vOmbRezy2a" role="37wK5m">
+                        <ref role="3cqZAo" node="1vOmbReze8Y" resolve="data" />
+                      </node>
+                      <node concept="37vLTw" id="6hm_9jpQXer" role="37wK5m">
+                        <ref role="3cqZAo" node="6hm_9jpQWzm" resolve="editorContext" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosKKVC" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosKLPu" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="12YYiosKLX5" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="1vOmbReztXk" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="1vOmbRezuoE" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYiosKM$6" role="3clF46">
+        <property role="TrG5h" value="tableData" />
+        <node concept="3uibUv" id="12YYiosKM$5" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+          <node concept="17QB3L" id="12YYiosKMXn" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQWzm" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQWJe" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbRe_4sc" role="jymVt" />
+    <node concept="2YIFZL" id="1vOmbRe_boa" role="jymVt">
+      <property role="TrG5h" value="nodeDataToStringData" />
+      <node concept="3clFbS" id="1vOmbRe_bod" role="3clF47">
+        <node concept="3clFbF" id="1vOmbRe_ONv" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRe_ONw" role="3clFbG">
+            <node concept="37vLTw" id="1vOmbRe_ONx" role="2Oq$k0">
+              <ref role="3cqZAo" node="1vOmbRe_fUB" resolve="tableData" />
+            </node>
+            <node concept="liA8E" id="1vOmbRe_ONy" role="2OqNvi">
+              <ref role="37wK5l" node="12YYiosLCDH" resolve="map" />
+              <node concept="1bVj0M" id="1vOmbRe_ONz" role="37wK5m">
+                <node concept="gl6BB" id="1vOmbRe_ON$" role="1bW2Oz">
+                  <property role="TrG5h" value="data" />
+                  <node concept="2jxLKc" id="1vOmbRe_ON_" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="1vOmbRe_ONA" role="1bW5cS">
+                  <node concept="3clFbF" id="1vOmbRe_ONB" role="3cqZAp">
+                    <node concept="1rXfSq" id="1vOmbRe_ONC" role="3clFbG">
+                      <ref role="37wK5l" node="1vOmbRe_nkb" resolve="nodeToData" />
+                      <node concept="37vLTw" id="1vOmbRe_OND" role="37wK5m">
+                        <ref role="3cqZAo" node="7NamNJXAWGj" resolve="selection" />
+                      </node>
+                      <node concept="37vLTw" id="1vOmbRe_ONE" role="37wK5m">
+                        <ref role="3cqZAo" node="1vOmbRe_ON$" resolve="data" />
+                      </node>
+                      <node concept="37vLTw" id="7NamNJWMfDr" role="37wK5m">
+                        <ref role="3cqZAo" node="6hm_9jpQXBl" resolve="editorContext" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1vOmbRe_7n1" role="1B3o_S" />
+      <node concept="3uibUv" id="1vOmbRe_QGG" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="17QB3L" id="1vOmbRe_RLS" role="11_B2D" />
+      </node>
+      <node concept="37vLTG" id="7NamNJXAWGj" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="7NamNJXAWS5" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1vOmbRe_fUB" role="3clF46">
+        <property role="TrG5h" value="tableData" />
+        <node concept="3uibUv" id="1vOmbRe_fUD" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+          <node concept="3Tqbb2" id="1vOmbRe_OKZ" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQXBl" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQXNc" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="12YYiosJFeg" role="1B3o_S" />
+  </node>
+  <node concept="vrV6u" id="12YYiosJH7W">
+    <property role="3GE5qa" value="dataTransformation" />
+    <property role="TrG5h" value="DataTransformation" />
+    <node concept="3uibUv" id="12YYiosJKxM" role="luc8K">
+      <ref role="3uigEE" node="12YYiosJH84" resolve="DataTransformer" />
+    </node>
+  </node>
+  <node concept="3HP615" id="12YYiosJH84">
+    <property role="3GE5qa" value="dataTransformation" />
+    <property role="TrG5h" value="DataTransformer" />
+    <node concept="3clFb_" id="12YYiosJHkp" role="jymVt">
+      <property role="TrG5h" value="getPriority" />
+      <node concept="3clFbS" id="12YYiosJHks" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosJHkt" role="1B3o_S" />
+      <node concept="10Oyi0" id="12YYiosJHkf" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosJHkQ" role="jymVt" />
+    <node concept="3clFb_" id="1vOmbReyvyU" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3clFbS" id="1vOmbReyvyV" role="3clF47" />
+      <node concept="3Tm1VV" id="1vOmbReyvyW" role="1B3o_S" />
+      <node concept="10P_77" id="2CQc9DOyphQ" role="3clF45" />
+      <node concept="37vLTG" id="2CQc9DOypU3" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="2CQc9DOypU2" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQNAS" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQNNe" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbRey$h8" role="jymVt" />
+    <node concept="3clFb_" id="1vOmbRey$ha" role="jymVt">
+      <property role="TrG5h" value="setTable" />
+      <node concept="3clFbS" id="1vOmbRey$hb" role="3clF47" />
+      <node concept="3Tm1VV" id="1vOmbRey$hc" role="1B3o_S" />
+      <node concept="3cqZAl" id="1vOmbRey$hd" role="3clF45" />
+      <node concept="37vLTG" id="1vOmbRey$he" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3Tqbb2" id="1vOmbRey$hf" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1vOmbReyvyT" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosJH$E" role="jymVt">
+      <property role="TrG5h" value="fromString" />
+      <node concept="3clFbS" id="12YYiosJH$H" role="3clF47" />
+      <node concept="3Tm1VV" id="12YYiosJH$I" role="1B3o_S" />
+      <node concept="3Tqbb2" id="12YYiosJH$f" role="3clF45" />
+      <node concept="37vLTG" id="12YYiosJHQV" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="17QB3L" id="12YYiosJHQU" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosJJ71" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosJIb5" role="jymVt">
+      <property role="TrG5h" value="asString" />
+      <node concept="3clFbS" id="12YYiosJIb8" role="3clF47">
+        <node concept="3clFbJ" id="1vOmbRe$uwi" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRe$uwj" role="3clFbw">
+            <node concept="37vLTw" id="1vOmbRe$uwk" role="2Oq$k0">
+              <ref role="3cqZAo" node="12YYiosJIr_" resolve="node" />
+            </node>
+            <node concept="3w_OXm" id="1vOmbRe$uwl" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="1vOmbRe$uwm" role="3clFbx">
+            <node concept="3cpWs6" id="1vOmbRe$uwn" role="3cqZAp">
+              <node concept="Xl_RD" id="1vOmbRe$uwo" role="3cqZAk">
+                <property role="Xl_RC" value="" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1vOmbRe$uwp" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXCvY_" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXCvYA" role="3cpWs9">
+            <property role="TrG5h" value="nodeCell" />
+            <node concept="3uibUv" id="7NamNJXCvYB" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+            <node concept="2OqwBi" id="7NamNJXCvYC" role="33vP2m">
+              <node concept="2OqwBi" id="7NamNJXCvYD" role="2Oq$k0">
+                <node concept="37vLTw" id="7NamNJXCvYE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXCwKq" resolve="selection" />
+                </node>
+                <node concept="liA8E" id="7NamNJXEAxu" role="2OqNvi">
+                  <ref role="37wK5l" to="9p8b:6Y0V2RJiAgN" resolve="getSelectedGridCells" />
+                </node>
+              </node>
+              <node concept="1z4cxt" id="7NamNJXEChN" role="2OqNvi">
+                <node concept="1bVj0M" id="7NamNJXEChP" role="23t8la">
+                  <node concept="3clFbS" id="7NamNJXEChQ" role="1bW5cS">
+                    <node concept="3cpWs8" id="2CQc9DOuOxK" role="3cqZAp">
+                      <node concept="3cpWsn" id="2CQc9DOuOxL" role="3cpWs9">
+                        <property role="TrG5h" value="gridNode" />
+                        <node concept="3Tqbb2" id="2CQc9DOuOxM" role="1tU5fm" />
+                        <node concept="2OqwBi" id="2CQc9DOuOxN" role="33vP2m">
+                          <node concept="37vLTw" id="2CQc9DOuOxO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7NamNJXEChR" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="2CQc9DOuOxP" role="2OqNvi">
+                            <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="2CQc9DOuOxQ" role="3cqZAp">
+                      <node concept="2OqwBi" id="2CQc9DOuOxR" role="3clFbG">
+                        <node concept="2OqwBi" id="2CQc9DOuOxS" role="2Oq$k0">
+                          <node concept="37vLTw" id="2CQc9DOuOxT" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2CQc9DOuOxL" resolve="gridNode" />
+                          </node>
+                          <node concept="2Rf3mk" id="2CQc9DOuOxU" role="2OqNvi">
+                            <node concept="1xIGOp" id="2CQc9DOvcJw" role="1xVPHs" />
+                          </node>
+                        </node>
+                        <node concept="2HwmR7" id="2CQc9DOuOxV" role="2OqNvi">
+                          <node concept="1bVj0M" id="2CQc9DOuOxW" role="23t8la">
+                            <node concept="3clFbS" id="2CQc9DOuOxX" role="1bW5cS">
+                              <node concept="3clFbF" id="2CQc9DOuOxY" role="3cqZAp">
+                                <node concept="2YFouu" id="2CQc9DOuOxZ" role="3clFbG">
+                                  <node concept="37vLTw" id="2CQc9DOuOy0" role="3uHU7B">
+                                    <ref role="3cqZAo" node="2CQc9DOuOy2" resolve="gridNode" />
+                                  </node>
+                                  <node concept="37vLTw" id="2CQc9DOuOy1" role="3uHU7w">
+                                    <ref role="3cqZAo" node="12YYiosJIr_" resolve="node" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="2CQc9DOuOy2" role="1bW2Oz">
+                              <property role="TrG5h" value="gridNode" />
+                              <node concept="2jxLKc" id="2CQc9DOuOy3" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="7NamNJXEChR" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="7NamNJXEChS" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2CQc9DOu80X" role="3cqZAp">
+          <node concept="3clFbS" id="2CQc9DOu80Z" role="3clFbx">
+            <node concept="3SKdUt" id="2CQc9DOu8PI" role="3cqZAp">
+              <node concept="1PaTwC" id="2CQc9DOu8PJ" role="1aUNEU">
+                <node concept="3oM_SD" id="2CQc9DOu8VQ" role="1PaTwD">
+                  <property role="3oM_SC" value="fall" />
+                </node>
+                <node concept="3oM_SD" id="2CQc9DOu8VR" role="1PaTwD">
+                  <property role="3oM_SC" value="back" />
+                </node>
+                <node concept="3oM_SD" id="2CQc9DOu8VS" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="2CQc9DOu8VT" role="1PaTwD">
+                  <property role="3oM_SC" value="string" />
+                </node>
+                <node concept="3oM_SD" id="2CQc9DOu8VU" role="1PaTwD">
+                  <property role="3oM_SC" value="representation" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2CQc9DOu9wF" role="3cqZAp">
+              <node concept="2OqwBi" id="2CQc9DOuacz" role="3cqZAk">
+                <node concept="37vLTw" id="2CQc9DOu9SW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosJIr_" resolve="node" />
+                </node>
+                <node concept="2qgKlT" id="2CQc9DOuauM" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="2CQc9DOu8sB" role="3clFbw">
+            <node concept="10Nm6u" id="2CQc9DOu8_q" role="3uHU7w" />
+            <node concept="37vLTw" id="2CQc9DOu8dc" role="3uHU7B">
+              <ref role="3cqZAo" node="7NamNJXCvYA" resolve="nodeCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2CQc9DOu7BI" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXCvYI" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXCvYJ" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="7NamNJXCvYK" role="1tU5fm" />
+            <node concept="2OqwBi" id="7NamNJXCvYL" role="33vP2m">
+              <node concept="2OqwBi" id="7NamNJXCvYM" role="2Oq$k0">
+                <node concept="37vLTw" id="7NamNJXCvYN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXCvYA" resolve="nodeCell" />
+                </node>
+                <node concept="liA8E" id="7NamNJXCvYO" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7NamNJXCvYP" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~TextBuilder.getText()" resolve="getText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7NamNJXCvYQ" role="3cqZAp">
+          <node concept="37vLTw" id="7NamNJXCvYR" role="3cqZAk">
+            <ref role="3cqZAo" node="7NamNJXCvYJ" resolve="text" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosJIb9" role="1B3o_S" />
+      <node concept="17QB3L" id="12YYiosJIam" role="3clF45" />
+      <node concept="37vLTG" id="7NamNJXCwKq" role="3clF46">
+        <property role="TrG5h" value="selection" />
+        <node concept="3uibUv" id="7NamNJXEzwP" role="1tU5fm">
+          <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYiosJIr_" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="12YYiosJIr$" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6hm_9jpQMyj" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="6hm_9jpQMQL" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="2JFqV2" id="1vOmbRe$rdC" role="2frcjj" />
+    </node>
+    <node concept="3Tm1VV" id="12YYiosJH85" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="12YYiosVWpM">
+    <property role="3GE5qa" value="copyPaste" />
+    <property role="TrG5h" value="TableCopyStorage" />
+    <property role="1EXbeo" value="true" />
+    <node concept="2tJIrI" id="5LghDpmwD05" role="jymVt" />
+    <node concept="Wx3nA" id="1Yhk3kSSLgO" role="jymVt">
+      <property role="TrG5h" value="INSTANCE" />
+      <node concept="3Tm6S6" id="1Yhk3kSSJi_" role="1B3o_S" />
+      <node concept="3uibUv" id="1Yhk3kSSLdW" role="1tU5fm">
+        <ref role="3uigEE" node="12YYiosVWpM" resolve="TableCopyStorage" />
+      </node>
+      <node concept="2ShNRf" id="1Yhk3kSSLoZ" role="33vP2m">
+        <node concept="HV5vD" id="1Yhk3kSSM7Z" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="HV5vE" node="12YYiosVWpM" resolve="TableCopyStorage" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1Yhk3kSSM8N" role="jymVt" />
+    <node concept="312cEg" id="1Yhk3kSSMBo" role="jymVt">
+      <property role="TrG5h" value="storage" />
+      <node concept="3uibUv" id="1Yhk3kSSMBr" role="1tU5fm">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="1Yhk3kSSMBs" role="11_B2D" />
+      </node>
+      <node concept="3Tm6S6" id="1Yhk3kSSMBt" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosVXj2" role="jymVt" />
+    <node concept="2YIFZL" id="5LghDpmwUBv" role="jymVt">
+      <property role="TrG5h" value="getInstance" />
+      <node concept="3clFbS" id="5LghDpmwUBy" role="3clF47">
+        <node concept="3clFbF" id="1Yhk3kSSMKi" role="3cqZAp">
+          <node concept="37vLTw" id="1Yhk3kSSMKh" role="3clFbG">
+            <ref role="3cqZAo" node="1Yhk3kSSLgO" resolve="INSTANCE" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5LghDpmwU7u" role="1B3o_S" />
+      <node concept="3uibUv" id="5LghDpmwUB1" role="3clF45">
+        <ref role="3uigEE" node="12YYiosVWpM" resolve="TableCopyStorage" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5LghDpmwTJr" role="jymVt" />
+    <node concept="3clFb_" id="5LghDpmwTyC" role="jymVt">
+      <property role="TrG5h" value="put" />
+      <node concept="3clFbS" id="5LghDpmwTyE" role="3clF47">
+        <node concept="3clFbF" id="5LghDpmwTyF" role="3cqZAp">
+          <node concept="37vLTI" id="5LghDpmwTyG" role="3clFbG">
+            <node concept="37vLTw" id="5LghDpmwTyH" role="37vLTx">
+              <ref role="3cqZAo" node="5LghDpmwTyK" resolve="data" />
+            </node>
+            <node concept="37vLTw" id="5LghDpmwTyI" role="37vLTJ">
+              <ref role="3cqZAo" node="1Yhk3kSSMBo" resolve="storage" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="5LghDpmwTyJ" role="3clF45" />
+      <node concept="37vLTG" id="5LghDpmwTyK" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="3uibUv" id="5LghDpmwTyL" role="1tU5fm">
+          <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+          <node concept="3Tqbb2" id="5LghDpmwTyM" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5LghDpmwTyN" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosVYMx" role="jymVt" />
+    <node concept="3clFb_" id="5LghDpmwTpN" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <node concept="3clFbS" id="5LghDpmwTpP" role="3clF47">
+        <node concept="3clFbF" id="5LghDpmwTpQ" role="3cqZAp">
+          <node concept="37vLTw" id="5LghDpmwTpR" role="3clFbG">
+            <ref role="3cqZAo" node="1Yhk3kSSMBo" resolve="storage" />
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5LghDpmwTpS" role="3clF45">
+        <ref role="3uigEE" node="12YYiosxYgq" resolve="TableData" />
+        <node concept="3Tqbb2" id="5LghDpmwTpT" role="11_B2D" />
+      </node>
+      <node concept="3Tm1VV" id="5LghDpmwTpU" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2CQc9DOtOCm" role="jymVt" />
+    <node concept="3clFb_" id="2CQc9DOtRU6" role="jymVt">
+      <property role="TrG5h" value="clear" />
+      <node concept="3clFbS" id="2CQc9DOtRU9" role="3clF47">
+        <node concept="3clFbF" id="2CQc9DOtS2P" role="3cqZAp">
+          <node concept="37vLTI" id="2CQc9DOtSjT" role="3clFbG">
+            <node concept="10Nm6u" id="2CQc9DOtSwm" role="37vLTx" />
+            <node concept="37vLTw" id="2CQc9DOtS2O" role="37vLTJ">
+              <ref role="3cqZAo" node="1Yhk3kSSMBo" resolve="storage" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2CQc9DOtP10" role="1B3o_S" />
+      <node concept="3cqZAl" id="2CQc9DOtRTS" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosVZGY" role="jymVt" />
+    <node concept="3clFb_" id="5LghDpmwT98" role="jymVt">
+      <property role="TrG5h" value="isPresent" />
+      <node concept="3clFbS" id="5LghDpmwT9a" role="3clF47">
+        <node concept="3clFbF" id="5LghDpmwT9b" role="3cqZAp">
+          <node concept="3y3z36" id="5LghDpmwT9c" role="3clFbG">
+            <node concept="10Nm6u" id="5LghDpmwT9d" role="3uHU7w" />
+            <node concept="37vLTw" id="5LghDpmwT9e" role="3uHU7B">
+              <ref role="3cqZAo" node="1Yhk3kSSMBo" resolve="storage" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="5LghDpmwT9f" role="3clF45" />
+      <node concept="3Tm1VV" id="5LghDpmwT9g" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="12YYiosVWpN" role="1B3o_S" />
+    <node concept="3UR2Jj" id="5LghDpmjaG2" role="lGtFl">
+      <node concept="TZ5HA" id="5LghDpmjaG3" role="TZ5H$">
+        <node concept="1dT_AC" id="5LghDpmjaG4" role="1dT_Ay">
+          <property role="1dT_AB" value="Storage holding the last copied table cells statically. The data is saved globally and will be lost on MPS exit." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="5LghDpmjaHY" role="TZ5H$">
+        <node concept="1dT_AC" id="5LghDpmjaHZ" role="1dT_Ay">
+          <property role="1dT_AB" value="The storage enables copying and pasting nodes between tables." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2uRRBC" id="2CQc9DOsVYB">
+    <property role="TrG5h" value="ClipboardListener" />
+    <node concept="2BZ0e9" id="2CQc9DOsVYC" role="2uRRBG">
+      <property role="TrG5h" value="listener" />
+      <node concept="3Tm6S6" id="2CQc9DOsVYD" role="1B3o_S" />
+      <node concept="3uibUv" id="2CQc9DOt3oT" role="1tU5fm">
+        <ref role="3uigEE" to="jbqa:~CopyPasteManager$ContentChangedListener" resolve="CopyPasteManager.ContentChangedListener" />
+      </node>
+      <node concept="2ShNRf" id="2CQc9DOt3pt" role="33vP2m">
+        <node concept="YeOm9" id="2CQc9DOtbGk" role="2ShVmc">
+          <node concept="1Y3b0j" id="2CQc9DOtbGn" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <property role="373rjd" value="true" />
+            <ref role="1Y3XeK" to="jbqa:~CopyPasteManager$ContentChangedListener" resolve="CopyPasteManager.ContentChangedListener" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <node concept="3Tm1VV" id="2CQc9DOtbGo" role="1B3o_S" />
+            <node concept="3clFb_" id="2CQc9DOtbGB" role="jymVt">
+              <property role="TrG5h" value="contentChanged" />
+              <node concept="3Tm1VV" id="2CQc9DOtbGC" role="1B3o_S" />
+              <node concept="3cqZAl" id="2CQc9DOtbGE" role="3clF45" />
+              <node concept="37vLTG" id="2CQc9DOtbGF" role="3clF46">
+                <property role="TrG5h" value="oldTransferable" />
+                <node concept="3uibUv" id="2CQc9DOtbGG" role="1tU5fm">
+                  <ref role="3uigEE" to="kt01:~Transferable" resolve="Transferable" />
+                </node>
+                <node concept="2AHcQZ" id="2CQc9DOtbGH" role="2AJF6D">
+                  <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                </node>
+              </node>
+              <node concept="37vLTG" id="2CQc9DOtbGI" role="3clF46">
+                <property role="TrG5h" value="newTransferable" />
+                <node concept="3uibUv" id="2CQc9DOtbGJ" role="1tU5fm">
+                  <ref role="3uigEE" to="kt01:~Transferable" resolve="Transferable" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="2CQc9DOtbGK" role="3clF47">
+                <node concept="3clFbF" id="2CQc9DOtNED" role="3cqZAp">
+                  <node concept="2OqwBi" id="2CQc9DOtNVg" role="3clFbG">
+                    <node concept="2YIFZM" id="2CQc9DOtNK3" role="2Oq$k0">
+                      <ref role="37wK5l" node="5LghDpmwUBv" resolve="getInstance" />
+                      <ref role="1Pybhc" node="12YYiosVWpM" resolve="TableCopyStorage" />
+                    </node>
+                    <node concept="liA8E" id="2CQc9DOtT09" role="2OqNvi">
+                      <ref role="37wK5l" node="2CQc9DOtRU6" resolve="clear" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="2CQc9DOtbGM" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2uRRBj" id="2CQc9DOt2Wj" role="2uRRBE">
+      <node concept="3clFbS" id="2CQc9DOt2Wk" role="2VODD2">
+        <node concept="3clFbH" id="2CQc9DOt$Gn" role="3cqZAp" />
+        <node concept="3clFbF" id="2CQc9DOt32K" role="3cqZAp">
+          <node concept="2OqwBi" id="2CQc9DOt3bF" role="3clFbG">
+            <node concept="2YIFZM" id="2CQc9DOt347" role="2Oq$k0">
+              <ref role="37wK5l" to="jbqa:~CopyPasteManager.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="jbqa:~CopyPasteManager" resolve="CopyPasteManager" />
+            </node>
+            <node concept="liA8E" id="2CQc9DOt3kU" role="2OqNvi">
+              <ref role="37wK5l" to="jbqa:~CopyPasteManager.addContentChangedListener(com.intellij.openapi.ide.CopyPasteManager$ContentChangedListener,com.intellij.openapi.Disposable)" resolve="addContentChangedListener" />
+              <node concept="2OqwBi" id="2CQc9DOtf$C" role="37wK5m">
+                <node concept="2WthIp" id="2CQc9DOtf$F" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="2CQc9DOtf$H" role="2OqNvi">
+                  <ref role="2WH_rO" node="2CQc9DOsVYC" resolve="listener" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="2CQc9DOtip6" role="37wK5m">
+                <ref role="37wK5l" to="zn9m:~Disposer.newDisposable()" resolve="newDisposable" />
+                <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2uRRBI" id="2CQc9DOtiqG" role="2uRRBF">
+      <node concept="3clFbS" id="2CQc9DOtiqH" role="2VODD2">
+        <node concept="3clFbF" id="2CQc9DOtiyP" role="3cqZAp">
+          <node concept="2OqwBi" id="2CQc9DOtj4S" role="3clFbG">
+            <node concept="2YIFZM" id="2CQc9DOtiTj" role="2Oq$k0">
+              <ref role="37wK5l" to="jbqa:~CopyPasteManager.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="jbqa:~CopyPasteManager" resolve="CopyPasteManager" />
+            </node>
+            <node concept="liA8E" id="2CQc9DOtjep" role="2OqNvi">
+              <ref role="37wK5l" to="jbqa:~CopyPasteManager.removeContentChangedListener(com.intellij.openapi.ide.CopyPasteManager$ContentChangedListener)" resolve="removeContentChangedListener" />
+              <node concept="2OqwBi" id="2CQc9DOtjqM" role="37wK5m">
+                <node concept="2WthIp" id="2CQc9DOtjfL" role="2Oq$k0" />
+                <node concept="2BZ7hE" id="2CQc9DOtjUe" role="2OqNvi">
+                  <ref role="2WH_rO" node="2CQc9DOsVYC" resolve="listener" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/selection.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/selection.mps
@@ -3,6 +3,11 @@
   <persistence version="9" />
   <languages>
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
+    <use id="515552c7-fcc0-4ab4-9789-2f3c49344e85" name="jetbrains.mps.baseLanguage.varVariable" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -16,9 +21,23 @@
     <import index="sse1" ref="r:caea7020-da0a-4ba8-aff6-69334bbc9e02(de.slisson.mps.tables.runtime.simplegrid)" />
     <import index="6dpw" ref="r:ea653f2d-c829-4182-b311-a544ef1f4c1f(de.slisson.mps.tables.runtime.gridmodel)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="nlpl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.commands(MPS.Editor/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1239360506533" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleDeclaration" flags="ng" index="2fD8I5">
+        <child id="1239529553065" name="component" index="2pHZQ9" />
+      </concept>
+      <concept id="1239462176079" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleComponentDeclaration" flags="ng" index="2lGYhJ">
+        <child id="1239462974287" name="type" index="2lK19J" />
+      </concept>
+      <concept id="1239576519914" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleComponentAccessOperation" flags="nn" index="2sxana">
+        <reference id="1239576542472" name="component" index="2sxfKC" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
         <child id="1224071154657" name="classifierType" index="0kSFW" />
@@ -66,6 +85,9 @@
       <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
         <child id="1164991057263" name="throwable" index="YScLw" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -80,6 +102,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -116,14 +141,20 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -131,9 +162,11 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+        <child id="1107880067339" name="method" index="3MN40a" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
@@ -164,8 +197,40 @@
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
     </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
       <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
@@ -179,6 +244,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -248,6 +316,7 @@
         <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
       </node>
     </node>
+    <node concept="2tJIrI" id="7NamNJX38Ue" role="jymVt" />
     <node concept="312cEg" id="6Y0V2RJh5le" role="jymVt">
       <property role="TrG5h" value="myStartColumn" />
       <node concept="3Tm6S6" id="6Y0V2RJh5lf" role="1B3o_S" />
@@ -476,14 +545,15 @@
         </node>
         <node concept="3clFbF" id="6Y0V2RJhwAU" role="3cqZAp">
           <node concept="37vLTI" id="6Y0V2RJhwAV" role="3clFbG">
-            <node concept="2YIFZM" id="6Y0V2RJhwAW" role="37vLTx">
+            <node concept="2YIFZM" id="6hm_9jp_Nyc" role="37vLTx">
               <ref role="37wK5l" to="b8lf:~SelectionInfoImpl$Util.getIntProperty(java.util.Map,java.lang.String)" resolve="getIntProperty" />
               <ref role="1Pybhc" to="b8lf:~SelectionInfoImpl$Util" resolve="SelectionInfoImpl.Util" />
-              <node concept="37vLTw" id="6Y0V2RJhwAX" role="37wK5m">
+              <node concept="37vLTw" id="6hm_9jp_Nyd" role="37wK5m">
                 <ref role="3cqZAo" node="1laD9eY9cE2" resolve="properties" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJhxoA" role="37wK5m">
-                <ref role="3cqZAo" node="6Y0V2RJhuB6" resolve="PROPERTY_END_COLUMN" />
+              <node concept="10M0yZ" id="6hm_9jqP5Er" role="37wK5m">
+                <ref role="3cqZAo" node="6Y0V2RJhuee" resolve="PROPERTY_START_COLUMN" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
             </node>
             <node concept="37vLTw" id="6Y0V2RJhxaG" role="37vLTJ">
@@ -493,14 +563,15 @@
         </node>
         <node concept="3clFbF" id="2_D0AvWRGDD" role="3cqZAp">
           <node concept="37vLTI" id="2_D0AvWRGDZ" role="3clFbG">
-            <node concept="2YIFZM" id="2_D0AvWRGE3" role="37vLTx">
+            <node concept="2YIFZM" id="6hm_9jp_Nyf" role="37vLTx">
               <ref role="37wK5l" to="b8lf:~SelectionInfoImpl$Util.getIntProperty(java.util.Map,java.lang.String)" resolve="getIntProperty" />
               <ref role="1Pybhc" to="b8lf:~SelectionInfoImpl$Util" resolve="SelectionInfoImpl.Util" />
-              <node concept="37vLTw" id="2_D0AvWRGE4" role="37wK5m">
+              <node concept="37vLTw" id="6hm_9jp_Nyg" role="37wK5m">
                 <ref role="3cqZAo" node="1laD9eY9cE2" resolve="properties" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJhwk3" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jp_XJn" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJht08" resolve="PROPERTY_START_ROW" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
             </node>
             <node concept="37vLTw" id="6Y0V2RJhw3j" role="37vLTJ">
@@ -510,14 +581,15 @@
         </node>
         <node concept="3clFbF" id="6Y0V2RJhwPs" role="3cqZAp">
           <node concept="37vLTI" id="6Y0V2RJhwPt" role="3clFbG">
-            <node concept="2YIFZM" id="6Y0V2RJhwPu" role="37vLTx">
+            <node concept="2YIFZM" id="6hm_9jp_Nyi" role="37vLTx">
               <ref role="37wK5l" to="b8lf:~SelectionInfoImpl$Util.getIntProperty(java.util.Map,java.lang.String)" resolve="getIntProperty" />
               <ref role="1Pybhc" to="b8lf:~SelectionInfoImpl$Util" resolve="SelectionInfoImpl.Util" />
-              <node concept="37vLTw" id="6Y0V2RJhwPv" role="37wK5m">
+              <node concept="37vLTw" id="6hm_9jp_Nyj" role="37wK5m">
                 <ref role="3cqZAo" node="1laD9eY9cE2" resolve="properties" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJhybu" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jp_ZzM" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJhuB6" resolve="PROPERTY_END_COLUMN" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
             </node>
             <node concept="37vLTw" id="6Y0V2RJhxX$" role="37vLTJ">
@@ -527,14 +599,15 @@
         </node>
         <node concept="3clFbF" id="6Y0V2RJhwHs" role="3cqZAp">
           <node concept="37vLTI" id="6Y0V2RJhwHt" role="3clFbG">
-            <node concept="2YIFZM" id="6Y0V2RJhwHu" role="37vLTx">
+            <node concept="2YIFZM" id="6hm_9jp_Nyl" role="37vLTx">
               <ref role="37wK5l" to="b8lf:~SelectionInfoImpl$Util.getIntProperty(java.util.Map,java.lang.String)" resolve="getIntProperty" />
               <ref role="1Pybhc" to="b8lf:~SelectionInfoImpl$Util" resolve="SelectionInfoImpl.Util" />
-              <node concept="37vLTw" id="6Y0V2RJhwHv" role="37wK5m">
+              <node concept="37vLTw" id="6hm_9jp_Nym" role="37wK5m">
                 <ref role="3cqZAo" node="1laD9eY9cE2" resolve="properties" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJhxJA" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jpA10D" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJhuqS" resolve="PROPERTY_END_ROW" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
             </node>
             <node concept="37vLTw" id="6Y0V2RJhxA_" role="37vLTJ">
@@ -573,8 +646,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="6Y0V2RJgRip" role="jymVt" />
-    <node concept="2tJIrI" id="630t2b85PBz" role="jymVt" />
-    <node concept="2tJIrI" id="630t2b85Qse" role="jymVt" />
     <node concept="3clFb_" id="6Y0V2RJiAgN" role="jymVt">
       <property role="TrG5h" value="getSelectedGridCells" />
       <node concept="_YKpA" id="6Y0V2RJiG$V" role="3clF45">
@@ -682,11 +753,11 @@
                 <node concept="2YIFZM" id="6Y0V2RJitUl" role="33vP2m">
                   <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
                   <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                  <node concept="37vLTw" id="6Y0V2RJiuYx" role="37wK5m">
-                    <ref role="3cqZAo" node="6Y0V2RJh4bV" resolve="myStartRow" />
+                  <node concept="1rXfSq" id="6hm_9jpCzt2" role="37wK5m">
+                    <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
                   </node>
-                  <node concept="37vLTw" id="6Y0V2RJivhR" role="37wK5m">
-                    <ref role="3cqZAo" node="6Y0V2RJh6qd" resolve="myEndRow" />
+                  <node concept="1rXfSq" id="6hm_9jpC$St" role="37wK5m">
+                    <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
                   </node>
                 </node>
               </node>
@@ -694,11 +765,11 @@
                 <node concept="2YIFZM" id="6Y0V2RJitUp" role="3uHU7w">
                   <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
                   <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-                  <node concept="37vLTw" id="6Y0V2RJiv_d" role="37wK5m">
-                    <ref role="3cqZAo" node="6Y0V2RJh4bV" resolve="myStartRow" />
+                  <node concept="1rXfSq" id="6hm_9jpCxAa" role="37wK5m">
+                    <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
                   </node>
-                  <node concept="37vLTw" id="6Y0V2RJivIr" role="37wK5m">
-                    <ref role="3cqZAo" node="6Y0V2RJh6qd" resolve="myEndRow" />
+                  <node concept="1rXfSq" id="6hm_9jpCKma" role="37wK5m">
+                    <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
                   </node>
                 </node>
                 <node concept="37vLTw" id="6Y0V2RJitUs" role="3uHU7B">
@@ -719,11 +790,11 @@
             <node concept="2YIFZM" id="6Y0V2RJiseD" role="33vP2m">
               <ref role="37wK5l" to="wyt6:~Math.min(int,int)" resolve="min" />
               <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-              <node concept="37vLTw" id="6Y0V2RJisfa" role="37wK5m">
-                <ref role="3cqZAo" node="6Y0V2RJh5le" resolve="myStartColumn" />
+              <node concept="1rXfSq" id="6hm_9jpD2UD" role="37wK5m">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJisx3" role="37wK5m">
-                <ref role="3cqZAo" node="6Y0V2RJh6qa" resolve="myEndColumn" />
+              <node concept="1rXfSq" id="6hm_9jpCVeq" role="37wK5m">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
               </node>
             </node>
           </node>
@@ -731,11 +802,11 @@
             <node concept="2YIFZM" id="6Y0V2RJitcD" role="3uHU7w">
               <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
               <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
-              <node concept="37vLTw" id="6Y0V2RJiteD" role="37wK5m">
-                <ref role="3cqZAo" node="6Y0V2RJh5le" resolve="myStartColumn" />
+              <node concept="1rXfSq" id="6hm_9jpDg1v" role="37wK5m">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
               </node>
-              <node concept="37vLTw" id="6Y0V2RJitpW" role="37wK5m">
-                <ref role="3cqZAo" node="6Y0V2RJh6qa" resolve="myEndColumn" />
+              <node concept="1rXfSq" id="6hm_9jpDpL8" role="37wK5m">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
               </node>
             </node>
             <node concept="37vLTw" id="6Y0V2RJisMl" role="3uHU7B">
@@ -820,22 +891,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6Y0V2RJhDPT" role="3cqZAp">
-          <node concept="2OqwBi" id="6Y0V2RJhDPU" role="3clFbG">
-            <node concept="2OqwBi" id="6Y0V2RJhDPV" role="2Oq$k0">
-              <node concept="37vLTw" id="6Y0V2RJhDPW" role="2Oq$k0">
+        <node concept="3clFbF" id="6hm_9jpA1IQ" role="3cqZAp">
+          <node concept="2OqwBi" id="6hm_9jpA1IR" role="3clFbG">
+            <node concept="2OqwBi" id="6hm_9jpA1IS" role="2Oq$k0">
+              <node concept="37vLTw" id="6hm_9jpA1IT" role="2Oq$k0">
                 <ref role="3cqZAo" node="1laD9eY9cqe" resolve="selectionInfo" />
               </node>
-              <node concept="liA8E" id="6Y0V2RJhDPX" role="2OqNvi">
+              <node concept="liA8E" id="6hm_9jpA1IU" role="2OqNvi">
                 <ref role="37wK5l" to="b8lf:~SelectionInfoImpl.getPropertiesMap()" resolve="getPropertiesMap" />
               </node>
             </node>
-            <node concept="liA8E" id="6Y0V2RJhDPY" role="2OqNvi">
+            <node concept="liA8E" id="6hm_9jpA1IV" role="2OqNvi">
               <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
-              <node concept="37vLTw" id="6Y0V2RJhGE9" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jpAey7" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJhuee" resolve="PROPERTY_START_COLUMN" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
-              <node concept="2YIFZM" id="6Y0V2RJhDQ0" role="37wK5m">
+              <node concept="2YIFZM" id="6hm_9jpA1IW" role="37wK5m">
                 <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
                 <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
                 <node concept="37vLTw" id="6Y0V2RJhHwJ" role="37wK5m">
@@ -845,22 +917,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1laD9eY9cqE" role="3cqZAp">
-          <node concept="2OqwBi" id="1laD9eY9cqF" role="3clFbG">
-            <node concept="2OqwBi" id="1laD9eY9cqG" role="2Oq$k0">
-              <node concept="37vLTw" id="1laD9eY9cqH" role="2Oq$k0">
+        <node concept="3clFbF" id="6hm_9jpA1IY" role="3cqZAp">
+          <node concept="2OqwBi" id="6hm_9jpA1IZ" role="3clFbG">
+            <node concept="2OqwBi" id="6hm_9jpA1J0" role="2Oq$k0">
+              <node concept="37vLTw" id="6hm_9jpA1J1" role="2Oq$k0">
                 <ref role="3cqZAo" node="1laD9eY9cqe" resolve="selectionInfo" />
               </node>
-              <node concept="liA8E" id="1laD9eY9cqI" role="2OqNvi">
+              <node concept="liA8E" id="6hm_9jpA1J2" role="2OqNvi">
                 <ref role="37wK5l" to="b8lf:~SelectionInfoImpl.getPropertiesMap()" resolve="getPropertiesMap" />
               </node>
             </node>
-            <node concept="liA8E" id="1laD9eY9cqJ" role="2OqNvi">
+            <node concept="liA8E" id="6hm_9jpA1J3" role="2OqNvi">
               <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
-              <node concept="37vLTw" id="6Y0V2RJhDz7" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jpAhw0" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJht08" resolve="PROPERTY_START_ROW" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
-              <node concept="2YIFZM" id="1laD9eY9cqL" role="37wK5m">
+              <node concept="2YIFZM" id="6hm_9jpA1J4" role="37wK5m">
                 <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
                 <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
                 <node concept="37vLTw" id="6Y0V2RJhDFN" role="37wK5m">
@@ -870,22 +943,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6Y0V2RJhETQ" role="3cqZAp">
-          <node concept="2OqwBi" id="6Y0V2RJhETR" role="3clFbG">
-            <node concept="2OqwBi" id="6Y0V2RJhETS" role="2Oq$k0">
-              <node concept="37vLTw" id="6Y0V2RJhETT" role="2Oq$k0">
+        <node concept="3clFbF" id="6hm_9jpA1J6" role="3cqZAp">
+          <node concept="2OqwBi" id="6hm_9jpA1J7" role="3clFbG">
+            <node concept="2OqwBi" id="6hm_9jpA1J8" role="2Oq$k0">
+              <node concept="37vLTw" id="6hm_9jpA1J9" role="2Oq$k0">
                 <ref role="3cqZAo" node="1laD9eY9cqe" resolve="selectionInfo" />
               </node>
-              <node concept="liA8E" id="6Y0V2RJhETU" role="2OqNvi">
+              <node concept="liA8E" id="6hm_9jpA1Ja" role="2OqNvi">
                 <ref role="37wK5l" to="b8lf:~SelectionInfoImpl.getPropertiesMap()" resolve="getPropertiesMap" />
               </node>
             </node>
-            <node concept="liA8E" id="6Y0V2RJhETV" role="2OqNvi">
+            <node concept="liA8E" id="6hm_9jpA1Jb" role="2OqNvi">
               <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
-              <node concept="37vLTw" id="6Y0V2RJhH2X" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jpAnUQ" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJhuB6" resolve="PROPERTY_END_COLUMN" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
-              <node concept="2YIFZM" id="6Y0V2RJhETX" role="37wK5m">
+              <node concept="2YIFZM" id="6hm_9jpA1Jc" role="37wK5m">
                 <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
                 <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
                 <node concept="37vLTw" id="6Y0V2RJhHUf" role="37wK5m">
@@ -895,22 +969,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6Y0V2RJhEm3" role="3cqZAp">
-          <node concept="2OqwBi" id="6Y0V2RJhEm4" role="3clFbG">
-            <node concept="2OqwBi" id="6Y0V2RJhEm5" role="2Oq$k0">
-              <node concept="37vLTw" id="6Y0V2RJhEm6" role="2Oq$k0">
+        <node concept="3clFbF" id="6hm_9jpA1Je" role="3cqZAp">
+          <node concept="2OqwBi" id="6hm_9jpA1Jf" role="3clFbG">
+            <node concept="2OqwBi" id="6hm_9jpA1Jg" role="2Oq$k0">
+              <node concept="37vLTw" id="6hm_9jpA1Jh" role="2Oq$k0">
                 <ref role="3cqZAo" node="1laD9eY9cqe" resolve="selectionInfo" />
               </node>
-              <node concept="liA8E" id="6Y0V2RJhEm7" role="2OqNvi">
+              <node concept="liA8E" id="6hm_9jpA1Ji" role="2OqNvi">
                 <ref role="37wK5l" to="b8lf:~SelectionInfoImpl.getPropertiesMap()" resolve="getPropertiesMap" />
               </node>
             </node>
-            <node concept="liA8E" id="6Y0V2RJhEm8" role="2OqNvi">
+            <node concept="liA8E" id="6hm_9jpA1Jj" role="2OqNvi">
               <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
-              <node concept="37vLTw" id="6Y0V2RJhGRO" role="37wK5m">
+              <node concept="10M0yZ" id="6hm_9jpAqSn" role="37wK5m">
                 <ref role="3cqZAo" node="6Y0V2RJhuqS" resolve="PROPERTY_END_ROW" />
+                <ref role="1PxDUh" node="6Y0V2RJgPcd" resolve="TableRangeSelection" />
               </node>
-              <node concept="2YIFZM" id="6Y0V2RJhEma" role="37wK5m">
+              <node concept="2YIFZM" id="6hm_9jpA1Jk" role="37wK5m">
                 <ref role="37wK5l" to="wyt6:~Integer.toString(int)" resolve="toString" />
                 <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
                 <node concept="37vLTw" id="6Y0V2RJhHHv" role="37wK5m">
@@ -930,7 +1005,138 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="6Y0V2RJh8_j" role="jymVt" />
+    <node concept="2tJIrI" id="12YYiosU$dk" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosUGf3" role="jymVt">
+      <property role="TrG5h" value="toUndirectedRange" />
+      <node concept="3clFbS" id="12YYiosUGf5" role="3clF47">
+        <node concept="3cpWs8" id="12YYiosUGf6" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGf7" role="3cpWs9">
+            <property role="TrG5h" value="leftToRight" />
+            <node concept="10P_77" id="12YYiosUGf8" role="1tU5fm" />
+            <node concept="2dkUwp" id="12YYiosUGf9" role="33vP2m">
+              <node concept="1rXfSq" id="6hm_9jpDC4S" role="3uHU7B">
+                <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEjVQ" role="3uHU7w">
+                <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiosUGfg" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGfh" role="3cpWs9">
+            <property role="TrG5h" value="startRow" />
+            <node concept="10Oyi0" id="12YYiosUGfi" role="1tU5fm" />
+            <node concept="3K4zz7" id="12YYiosUGfj" role="33vP2m">
+              <node concept="37vLTw" id="12YYiosUGfq" role="3K4Cdx">
+                <ref role="3cqZAo" node="12YYiosUGf7" resolve="leftToRight" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpE8N0" role="3K4E3e">
+                <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEllE" role="3K4GZi">
+                <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiosUGfr" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGfs" role="3cpWs9">
+            <property role="TrG5h" value="endRow" />
+            <node concept="10Oyi0" id="12YYiosUGft" role="1tU5fm" />
+            <node concept="3K4zz7" id="12YYiosUGfu" role="33vP2m">
+              <node concept="37vLTw" id="12YYiosUGf_" role="3K4Cdx">
+                <ref role="3cqZAo" node="12YYiosUGf7" resolve="leftToRight" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEf4N" role="3K4E3e">
+                <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEdE_" role="3K4GZi">
+                <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosUGfA" role="3cqZAp" />
+        <node concept="3cpWs8" id="12YYiosUGfB" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGfC" role="3cpWs9">
+            <property role="TrG5h" value="topToBottom" />
+            <node concept="10P_77" id="12YYiosUGfD" role="1tU5fm" />
+            <node concept="2dkUwp" id="12YYiosUGfE" role="33vP2m">
+              <node concept="1rXfSq" id="6hm_9jpEmJk" role="3uHU7B">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
+              </node>
+              <node concept="1rXfSq" id="7NamNJX7Q1M" role="3uHU7w">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiosUGfL" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGfM" role="3cpWs9">
+            <property role="TrG5h" value="startCol" />
+            <node concept="10Oyi0" id="12YYiosUGfN" role="1tU5fm" />
+            <node concept="3K4zz7" id="12YYiosUGfO" role="33vP2m">
+              <node concept="37vLTw" id="12YYiosUGfV" role="3K4Cdx">
+                <ref role="3cqZAo" node="12YYiosUGfC" resolve="topToBottom" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEr_Z" role="3K4E3e">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpE_kI" role="3K4GZi">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiosUGfW" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiosUGfX" role="3cpWs9">
+            <property role="TrG5h" value="endCol" />
+            <node concept="10Oyi0" id="12YYiosUGfY" role="1tU5fm" />
+            <node concept="3K4zz7" id="12YYiosUGfZ" role="33vP2m">
+              <node concept="37vLTw" id="12YYiosUGg6" role="3K4Cdx">
+                <ref role="3cqZAo" node="12YYiosUGfC" resolve="topToBottom" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEsZr" role="3K4GZi">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
+              </node>
+              <node concept="1rXfSq" id="6hm_9jpEAHu" role="3K4E3e">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="12YYiosUGg7" role="3cqZAp" />
+        <node concept="3clFbF" id="12YYiosUGg8" role="3cqZAp">
+          <node concept="2ShNRf" id="12YYiosUGg9" role="3clFbG">
+            <node concept="1pGfFk" id="12YYiosUGga" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="12YYios$3q7" resolve="UndirectedTableRange" />
+              <node concept="1rXfSq" id="7NamNJXo9Mv" role="37wK5m">
+                <ref role="37wK5l" node="630t2b85S9Y" resolve="getTable" />
+              </node>
+              <node concept="37vLTw" id="12YYiosUGgb" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosUGfh" resolve="startRow" />
+              </node>
+              <node concept="37vLTw" id="12YYiosUGgc" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosUGfs" resolve="endRow" />
+              </node>
+              <node concept="37vLTw" id="12YYiosUGgd" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosUGfM" resolve="startCol" />
+              </node>
+              <node concept="37vLTw" id="12YYiosUGge" role="37wK5m">
+                <ref role="3cqZAo" node="12YYiosUGfX" resolve="endCol" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="12YYiosUGgg" role="3clF45">
+        <ref role="3uigEE" node="12YYioszPcw" resolve="UndirectedTableRange" />
+      </node>
+      <node concept="3Tm1VV" id="12YYiosUGgf" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="12YYiosU$dl" role="jymVt" />
     <node concept="3clFb_" id="6Y0V2RJgQdw" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="isSame" />
@@ -1015,12 +1221,12 @@
               <node concept="37vLTw" id="6Y0V2RJidol" role="2Oq$k0">
                 <ref role="3cqZAo" node="6Y0V2RJidod" resolve="that" />
               </node>
-              <node concept="2OwXpG" id="6Y0V2RJidom" role="2OqNvi">
-                <ref role="2Oxat5" node="6Y0V2RJh6qa" resolve="myEndColumn" />
+              <node concept="liA8E" id="7NamNJX82FL" role="2OqNvi">
+                <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
               </node>
             </node>
-            <node concept="37vLTw" id="6Y0V2RJidon" role="3uHU7B">
-              <ref role="3cqZAo" node="6Y0V2RJh6qa" resolve="myEndColumn" />
+            <node concept="1rXfSq" id="6hm_9jpEU$c" role="3uHU7B">
+              <ref role="37wK5l" node="630t2b85S9S" resolve="getEndColumn" />
             </node>
           </node>
           <node concept="3clFbS" id="6Y0V2RJidoo" role="3clFbx">
@@ -1037,12 +1243,12 @@
               <node concept="37vLTw" id="6Y0V2RJidou" role="2Oq$k0">
                 <ref role="3cqZAo" node="6Y0V2RJidod" resolve="that" />
               </node>
-              <node concept="2OwXpG" id="6Y0V2RJidov" role="2OqNvi">
-                <ref role="2Oxat5" node="6Y0V2RJh6qd" resolve="myEndRow" />
+              <node concept="liA8E" id="7NamNJX7rgt" role="2OqNvi">
+                <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
               </node>
             </node>
-            <node concept="37vLTw" id="6Y0V2RJidow" role="3uHU7B">
-              <ref role="3cqZAo" node="6Y0V2RJh6qd" resolve="myEndRow" />
+            <node concept="1rXfSq" id="6hm_9jpEZgi" role="3uHU7B">
+              <ref role="37wK5l" node="630t2b85S9M" resolve="getEndRow" />
             </node>
           </node>
           <node concept="3clFbS" id="6Y0V2RJidox" role="3clFbx">
@@ -1059,12 +1265,12 @@
               <node concept="37vLTw" id="6Y0V2RJidoB" role="2Oq$k0">
                 <ref role="3cqZAo" node="6Y0V2RJidod" resolve="that" />
               </node>
-              <node concept="2OwXpG" id="6Y0V2RJidoC" role="2OqNvi">
-                <ref role="2Oxat5" node="6Y0V2RJh5le" resolve="myStartColumn" />
+              <node concept="liA8E" id="6hm_9jpFm5M" role="2OqNvi">
+                <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
               </node>
             </node>
-            <node concept="37vLTw" id="6Y0V2RJidoD" role="3uHU7B">
-              <ref role="3cqZAo" node="6Y0V2RJh5le" resolve="myStartColumn" />
+            <node concept="1rXfSq" id="6hm_9jpFdkw" role="3uHU7B">
+              <ref role="37wK5l" node="630t2b85S9G" resolve="getStartColumn" />
             </node>
           </node>
           <node concept="3clFbS" id="6Y0V2RJidoE" role="3clFbx">
@@ -1081,12 +1287,12 @@
               <node concept="37vLTw" id="6Y0V2RJidoK" role="2Oq$k0">
                 <ref role="3cqZAo" node="6Y0V2RJidod" resolve="that" />
               </node>
-              <node concept="2OwXpG" id="6Y0V2RJidoL" role="2OqNvi">
-                <ref role="2Oxat5" node="6Y0V2RJh4bV" resolve="myStartRow" />
+              <node concept="liA8E" id="6hm_9jpFzN7" role="2OqNvi">
+                <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
               </node>
             </node>
-            <node concept="37vLTw" id="6Y0V2RJidoM" role="3uHU7B">
-              <ref role="3cqZAo" node="6Y0V2RJh4bV" resolve="myStartRow" />
+            <node concept="1rXfSq" id="6hm_9jpFulz" role="3uHU7B">
+              <ref role="37wK5l" node="630t2b85S9A" resolve="getStartRow" />
             </node>
           </node>
           <node concept="3clFbS" id="6Y0V2RJidoN" role="3clFbx">
@@ -1154,54 +1360,59 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="7NamNJX5$YE" role="jymVt" />
     <node concept="3clFb_" id="630t2b85S9A" role="jymVt">
       <property role="TrG5h" value="getStartRow" />
       <node concept="10Oyi0" id="630t2b85S9B" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b85S9C" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b85S9D" role="3clF47">
-        <node concept="3clFbF" id="630t2b85S9E" role="3cqZAp">
-          <node concept="37vLTw" id="630t2b85S9_" role="3clFbG">
+        <node concept="3clFbF" id="6hm_9jpJIFa" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpJIF9" role="3clFbG">
             <ref role="3cqZAo" node="6Y0V2RJh4bV" resolve="myStartRow" />
           </node>
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="RhZZFy$$jR" role="jymVt" />
     <node concept="3clFb_" id="630t2b85S9G" role="jymVt">
       <property role="TrG5h" value="getStartColumn" />
       <node concept="10Oyi0" id="630t2b85S9H" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b85S9I" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b85S9J" role="3clF47">
-        <node concept="3clFbF" id="630t2b85S9K" role="3cqZAp">
-          <node concept="37vLTw" id="630t2b85S9F" role="3clFbG">
+        <node concept="3clFbF" id="6hm_9jpJPYJ" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpJPYI" role="3clFbG">
             <ref role="3cqZAo" node="6Y0V2RJh5le" resolve="myStartColumn" />
           </node>
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="RhZZFy$_KI" role="jymVt" />
     <node concept="3clFb_" id="630t2b85S9M" role="jymVt">
       <property role="TrG5h" value="getEndRow" />
       <node concept="10Oyi0" id="630t2b85S9N" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b85S9O" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b85S9P" role="3clF47">
-        <node concept="3clFbF" id="630t2b85S9Q" role="3cqZAp">
-          <node concept="37vLTw" id="630t2b85S9L" role="3clFbG">
+        <node concept="3clFbF" id="6hm_9jpJW9o" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpJW9n" role="3clFbG">
             <ref role="3cqZAo" node="6Y0V2RJh6qd" resolve="myEndRow" />
           </node>
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="RhZZFy$Bd_" role="jymVt" />
     <node concept="3clFb_" id="630t2b85S9S" role="jymVt">
       <property role="TrG5h" value="getEndColumn" />
       <node concept="10Oyi0" id="630t2b85S9T" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b85S9U" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b85S9V" role="3clF47">
-        <node concept="3clFbF" id="630t2b85S9W" role="3cqZAp">
-          <node concept="37vLTw" id="630t2b85S9R" role="3clFbG">
+        <node concept="3clFbF" id="6hm_9jpK8RZ" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpK8RY" role="3clFbG">
             <ref role="3cqZAo" node="6Y0V2RJh6qa" resolve="myEndColumn" />
           </node>
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="RhZZFy$CEs" role="jymVt" />
     <node concept="3clFb_" id="630t2b85S9Y" role="jymVt">
       <property role="TrG5h" value="getTable" />
       <node concept="3uibUv" id="630t2b85S9Z" role="3clF45">
@@ -1212,6 +1423,887 @@
         <node concept="3clFbF" id="630t2b85Sa2" role="3cqZAp">
           <node concept="37vLTw" id="630t2b85S9X" role="3clFbG">
             <ref role="3cqZAo" node="6Y0V2RJgZML" resolve="myTable" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="RhZZFy$SQ0" role="jymVt" />
+    <node concept="3clFb_" id="RhZZFy$IUW" role="jymVt">
+      <property role="TrG5h" value="canExecuteAction" />
+      <node concept="3Tm1VV" id="RhZZFy$IUX" role="1B3o_S" />
+      <node concept="10P_77" id="RhZZFy$IUZ" role="3clF45" />
+      <node concept="37vLTG" id="RhZZFy$IV0" role="3clF46">
+        <property role="TrG5h" value="type" />
+        <node concept="3uibUv" id="RhZZFy$IV1" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~CellActionType" resolve="CellActionType" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="RhZZFy$IV2" role="3clF47">
+        <node concept="3cpWs8" id="12YYiorU20$" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiorU20_" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3uibUv" id="12YYiorTU2d" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~CellAction" resolve="CellAction" />
+            </node>
+            <node concept="2OqwBi" id="12YYiorU20A" role="33vP2m">
+              <node concept="1rXfSq" id="12YYiorU20B" role="2Oq$k0">
+                <ref role="37wK5l" node="630t2b85S9Y" resolve="getTable" />
+              </node>
+              <node concept="liA8E" id="12YYiorU20C" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getAction(jetbrains.mps.openapi.editor.cells.CellActionType)" resolve="getAction" />
+                <node concept="37vLTw" id="12YYiorU20D" role="37wK5m">
+                  <ref role="3cqZAo" node="RhZZFy$IV0" resolve="type" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYiorU7BO" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiorU7BQ" role="3clFbx">
+            <node concept="3cpWs6" id="12YYiorUqS4" role="3cqZAp">
+              <node concept="2OqwBi" id="12YYiorQyWh" role="3cqZAk">
+                <node concept="37vLTw" id="12YYiorU20E" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiorU20_" resolve="action" />
+                </node>
+                <node concept="liA8E" id="12YYiorQ$Hy" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~CellAction.canExecute(jetbrains.mps.openapi.editor.EditorContext)" resolve="canExecute" />
+                  <node concept="2OqwBi" id="12YYiorQCAF" role="37wK5m">
+                    <node concept="1rXfSq" id="12YYiorQ_WA" role="2Oq$k0">
+                      <ref role="37wK5l" node="630t2b85S9Y" resolve="getTable" />
+                    </node>
+                    <node concept="liA8E" id="12YYiorQItU" role="2OqNvi">
+                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getContext()" resolve="getContext" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="12YYiorUdkX" role="3clFbw">
+            <node concept="37vLTw" id="12YYiorU8Rz" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiorU20_" resolve="action" />
+            </node>
+            <node concept="10Nm6u" id="12YYiorUe9Y" role="3uHU7w" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiort0Vg" role="3cqZAp">
+          <node concept="3nyPlj" id="12YYiort0Vh" role="3clFbG">
+            <ref role="37wK5l" to="b8lf:~AbstractMultipleSelection.canExecuteAction(jetbrains.mps.openapi.editor.cells.CellActionType)" resolve="canExecuteAction" />
+            <node concept="37vLTw" id="12YYiort0Vi" role="37wK5m">
+              <ref role="3cqZAo" node="RhZZFy$IV0" resolve="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="RhZZFy$IV3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiorfwkp" role="jymVt" />
+    <node concept="3clFb_" id="RhZZFy$IV7" role="jymVt">
+      <property role="TrG5h" value="executeAction" />
+      <node concept="3Tm1VV" id="RhZZFy$IV8" role="1B3o_S" />
+      <node concept="3cqZAl" id="RhZZFy$IVa" role="3clF45" />
+      <node concept="37vLTG" id="RhZZFy$IVb" role="3clF46">
+        <property role="TrG5h" value="type" />
+        <node concept="3uibUv" id="RhZZFy$IVc" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~CellActionType" resolve="CellActionType" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="RhZZFy$IVd" role="3clF47">
+        <node concept="3cpWs8" id="12YYiorUSqk" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiorUSql" role="3cpWs9">
+            <property role="TrG5h" value="table" />
+            <node concept="3uibUv" id="12YYiorURCN" role="1tU5fm">
+              <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+            </node>
+            <node concept="1rXfSq" id="12YYiorUSqm" role="33vP2m">
+              <ref role="37wK5l" node="630t2b85S9Y" resolve="getTable" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="12YYiorUzFd" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYiorUzFe" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3uibUv" id="12YYiorUyYQ" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~CellAction" resolve="CellAction" />
+            </node>
+            <node concept="2OqwBi" id="12YYiorUzFf" role="33vP2m">
+              <node concept="37vLTw" id="12YYiorUSqn" role="2Oq$k0">
+                <ref role="3cqZAo" node="12YYiorUSql" resolve="table" />
+              </node>
+              <node concept="liA8E" id="12YYiorUzFh" role="2OqNvi">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getAction(jetbrains.mps.openapi.editor.cells.CellActionType)" resolve="getAction" />
+                <node concept="37vLTw" id="12YYiorUzFi" role="37wK5m">
+                  <ref role="3cqZAo" node="RhZZFy$IVb" resolve="type" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYiorUDjZ" role="3cqZAp">
+          <node concept="3clFbS" id="12YYiorUDk1" role="3clFbx">
+            <node concept="3cpWs8" id="12YYiosh0nq" role="3cqZAp">
+              <node concept="3cpWsn" id="12YYiosh0nr" role="3cpWs9">
+                <property role="TrG5h" value="context" />
+                <node concept="3uibUv" id="12YYiosgZGz" role="1tU5fm">
+                  <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                </node>
+                <node concept="2OqwBi" id="12YYiosh0ns" role="33vP2m">
+                  <node concept="37vLTw" id="12YYiosh0nt" role="2Oq$k0">
+                    <ref role="3cqZAo" node="12YYiorUSql" resolve="table" />
+                  </node>
+                  <node concept="liA8E" id="12YYiosh0nu" role="2OqNvi">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getContext()" resolve="getContext" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1QHqEO" id="12YYiosgSJk" role="3cqZAp">
+              <node concept="1QHqEC" id="12YYiosgSJm" role="1QHqEI">
+                <node concept="3clFbS" id="12YYiosgSJo" role="1bW5cS">
+                  <node concept="3clFbF" id="12YYiorQOwq" role="3cqZAp">
+                    <node concept="2OqwBi" id="12YYiorQOwr" role="3clFbG">
+                      <node concept="37vLTw" id="12YYiorUzFj" role="2Oq$k0">
+                        <ref role="3cqZAo" node="12YYiorUzFe" resolve="action" />
+                      </node>
+                      <node concept="liA8E" id="12YYiorQOww" role="2OqNvi">
+                        <ref role="37wK5l" to="f4zo:~CellAction.execute(jetbrains.mps.openapi.editor.EditorContext)" resolve="execute" />
+                        <node concept="37vLTw" id="12YYiosh0nw" role="37wK5m">
+                          <ref role="3cqZAo" node="12YYiosh0nr" resolve="context" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="12YYiosh1Gx" role="ukAjM">
+                <node concept="37vLTw" id="12YYiosh0nv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="12YYiosh0nr" resolve="context" />
+                </node>
+                <node concept="liA8E" id="12YYiosh30H" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="12YYiorVcpt" role="3clFbw">
+            <node concept="37vLTw" id="12YYiorUEzV" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiorUzFe" resolve="action" />
+            </node>
+            <node concept="10Nm6u" id="12YYiorUKjc" role="3uHU7w" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="RhZZFy$IVe" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="12YYioszPcw">
+    <property role="TrG5h" value="UndirectedTableRange" />
+    <node concept="2tJIrI" id="12YYios$3jx" role="jymVt" />
+    <node concept="312cEg" id="6hm_9jpLLYN" role="jymVt">
+      <property role="TrG5h" value="table" />
+      <node concept="3Tm6S6" id="6hm_9jpLLYO" role="1B3o_S" />
+      <node concept="3uibUv" id="6hm_9jpLLYP" role="1tU5fm">
+        <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+      </node>
+    </node>
+    <node concept="312cEg" id="6hm_9jpL6Cz" role="jymVt">
+      <property role="TrG5h" value="startColumn" />
+      <node concept="3Tm6S6" id="6hm_9jpL6C$" role="1B3o_S" />
+      <node concept="10Oyi0" id="6hm_9jpL6C_" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="6hm_9jpL6CA" role="jymVt">
+      <property role="TrG5h" value="startRow" />
+      <node concept="3Tm6S6" id="6hm_9jpL6CB" role="1B3o_S" />
+      <node concept="10Oyi0" id="6hm_9jpL6CC" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="6hm_9jpL6CD" role="jymVt">
+      <property role="TrG5h" value="endColumn" />
+      <node concept="3Tm6S6" id="6hm_9jpL6CE" role="1B3o_S" />
+      <node concept="10Oyi0" id="6hm_9jpL6CF" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="6hm_9jpL6CG" role="jymVt">
+      <property role="TrG5h" value="endRow" />
+      <node concept="3Tm6S6" id="6hm_9jpL6CH" role="1B3o_S" />
+      <node concept="10Oyi0" id="6hm_9jpL6CI" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpLLYM" role="jymVt" />
+    <node concept="3clFbW" id="12YYios$3q7" role="jymVt">
+      <node concept="3cqZAl" id="12YYios$3q8" role="3clF45" />
+      <node concept="3clFbS" id="12YYios$3qa" role="3clF47">
+        <node concept="3clFbJ" id="12YYios$3vw" role="3cqZAp">
+          <node concept="3eOVzh" id="12YYios$7FV" role="3clFbw">
+            <node concept="37vLTw" id="12YYios$84R" role="3uHU7w">
+              <ref role="3cqZAo" node="12YYios$3qB" resolve="startRow" />
+            </node>
+            <node concept="37vLTw" id="12YYios$3xi" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYios$3rk" resolve="endRow" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYios$3vy" role="3clFbx">
+            <node concept="YS8fn" id="12YYios$8bW" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYios$8cY" role="YScLw">
+                <node concept="1pGfFk" id="12YYios$8rf" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalArgumentException.&lt;init&gt;(java.lang.String)" resolve="IllegalArgumentException" />
+                  <node concept="2YIFZM" id="12YYios$8xd" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="Xl_RD" id="12YYios$8zs" role="37wK5m">
+                      <property role="Xl_RC" value="End row %s is before start row %s" />
+                    </node>
+                    <node concept="37vLTw" id="12YYios$9gH" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYios$3rk" resolve="endRow" />
+                    </node>
+                    <node concept="37vLTw" id="12YYios$9Vf" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYios$3qB" resolve="startRow" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="12YYios$9Xi" role="3cqZAp">
+          <node concept="3eOVzh" id="12YYios$9Xj" role="3clFbw">
+            <node concept="37vLTw" id="12YYios$9Xk" role="3uHU7w">
+              <ref role="3cqZAo" node="12YYios$3sq" resolve="startColumn" />
+            </node>
+            <node concept="37vLTw" id="12YYios$9Xl" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYios$3tE" resolve="endColumn" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYios$9Xm" role="3clFbx">
+            <node concept="YS8fn" id="12YYios$9Xn" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYios$9Xo" role="YScLw">
+                <node concept="1pGfFk" id="12YYios$9Xp" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalArgumentException.&lt;init&gt;(java.lang.String)" resolve="IllegalArgumentException" />
+                  <node concept="2YIFZM" id="12YYios$9Xq" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="Xl_RD" id="12YYios$9Xr" role="37wK5m">
+                      <property role="Xl_RC" value="End column %s is before start column %s" />
+                    </node>
+                    <node concept="37vLTw" id="12YYios$9Xs" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYios$3rk" resolve="endRow" />
+                    </node>
+                    <node concept="37vLTw" id="12YYios$9Xt" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYios$3qB" resolve="startRow" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6hm_9jpMNTr" role="3cqZAp" />
+        <node concept="3clFbF" id="6hm_9jpNbO9" role="3cqZAp">
+          <node concept="37vLTI" id="6hm_9jpNu7Z" role="3clFbG">
+            <node concept="37vLTw" id="6hm_9jpNzfz" role="37vLTx">
+              <ref role="3cqZAo" node="7NamNJXah2e" resolve="table" />
+            </node>
+            <node concept="2OqwBi" id="6hm_9jpNcSH" role="37vLTJ">
+              <node concept="Xjq3P" id="6hm_9jpNbO7" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6hm_9jpNpP7" role="2OqNvi">
+                <ref role="2Oxat5" node="6hm_9jpLLYN" resolve="table" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6hm_9jpNFf4" role="3cqZAp">
+          <node concept="37vLTI" id="6hm_9jpNNxB" role="3clFbG">
+            <node concept="37vLTw" id="6hm_9jpNPWc" role="37vLTx">
+              <ref role="3cqZAo" node="12YYios$3sq" resolve="startColumn" />
+            </node>
+            <node concept="2OqwBi" id="6hm_9jpNGjZ" role="37vLTJ">
+              <node concept="Xjq3P" id="6hm_9jpNFf2" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6hm_9jpNIOQ" role="2OqNvi">
+                <ref role="2Oxat5" node="6hm_9jpL6Cz" resolve="startColumn" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6hm_9jpNVie" role="3cqZAp">
+          <node concept="37vLTI" id="6hm_9jpO3A_" role="3clFbG">
+            <node concept="37vLTw" id="6hm_9jpO61w" role="37vLTx">
+              <ref role="3cqZAo" node="12YYios$3qB" resolve="startRow" />
+            </node>
+            <node concept="2OqwBi" id="6hm_9jpNWnv" role="37vLTJ">
+              <node concept="Xjq3P" id="6hm_9jpNVic" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6hm_9jpNYT5" role="2OqNvi">
+                <ref role="2Oxat5" node="6hm_9jpL6CA" resolve="startRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6hm_9jpOydD" role="3cqZAp">
+          <node concept="37vLTI" id="6hm_9jpOGb5" role="3clFbG">
+            <node concept="37vLTw" id="6hm_9jpOIAG" role="37vLTx">
+              <ref role="3cqZAo" node="12YYios$3tE" resolve="endColumn" />
+            </node>
+            <node concept="2OqwBi" id="6hm_9jpOzjA" role="37vLTJ">
+              <node concept="Xjq3P" id="6hm_9jpOydB" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6hm_9jpOBsT" role="2OqNvi">
+                <ref role="2Oxat5" node="6hm_9jpL6CD" resolve="endColumn" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6hm_9jpOdpP" role="3cqZAp">
+          <node concept="37vLTI" id="6hm_9jpOqIQ" role="3clFbG">
+            <node concept="37vLTw" id="6hm_9jpOta7" role="37vLTx">
+              <ref role="3cqZAo" node="12YYios$3rk" resolve="endRow" />
+            </node>
+            <node concept="2OqwBi" id="6hm_9jpOevs" role="37vLTJ">
+              <node concept="Xjq3P" id="6hm_9jpOdpN" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6hm_9jpOjrZ" role="2OqNvi">
+                <ref role="2Oxat5" node="6hm_9jpL6CG" resolve="endRow" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYios$3qb" role="1B3o_S" />
+      <node concept="37vLTG" id="7NamNJXah2e" role="3clF46">
+        <property role="TrG5h" value="table" />
+        <node concept="3uibUv" id="7NamNJXah2f" role="1tU5fm">
+          <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="12YYios$3qB" role="3clF46">
+        <property role="TrG5h" value="startRow" />
+        <node concept="10Oyi0" id="12YYios$3qA" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYios$3rk" role="3clF46">
+        <property role="TrG5h" value="endRow" />
+        <node concept="10Oyi0" id="12YYios$3rO" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYios$3sq" role="3clF46">
+        <property role="TrG5h" value="startColumn" />
+        <node concept="10Oyi0" id="12YYios$3sU" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYios$3tE" role="3clF46">
+        <property role="TrG5h" value="endColumn" />
+        <node concept="10Oyi0" id="12YYios$3um" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpLvRT" role="jymVt" />
+    <node concept="3clFb_" id="6hm_9jpLkQq" role="jymVt">
+      <property role="TrG5h" value="getStartRow" />
+      <node concept="10Oyi0" id="6hm_9jpLkQr" role="3clF45" />
+      <node concept="3Tm1VV" id="6hm_9jpLkQs" role="1B3o_S" />
+      <node concept="3clFbS" id="6hm_9jpLkQt" role="3clF47">
+        <node concept="3clFbF" id="6hm_9jpLkQu" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpLkQv" role="3clFbG">
+            <ref role="3cqZAo" node="6hm_9jpL6CA" resolve="startRow" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpLkQw" role="jymVt" />
+    <node concept="3clFb_" id="6hm_9jpLkQx" role="jymVt">
+      <property role="TrG5h" value="getStartColumn" />
+      <node concept="10Oyi0" id="6hm_9jpLkQy" role="3clF45" />
+      <node concept="3Tm1VV" id="6hm_9jpLkQz" role="1B3o_S" />
+      <node concept="3clFbS" id="6hm_9jpLkQ$" role="3clF47">
+        <node concept="3clFbF" id="6hm_9jpLkQ_" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpLkQA" role="3clFbG">
+            <ref role="3cqZAo" node="6hm_9jpL6Cz" resolve="startColumn" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpLkQB" role="jymVt" />
+    <node concept="3clFb_" id="6hm_9jpLkQC" role="jymVt">
+      <property role="TrG5h" value="getEndRow" />
+      <node concept="10Oyi0" id="6hm_9jpLkQD" role="3clF45" />
+      <node concept="3Tm1VV" id="6hm_9jpLkQE" role="1B3o_S" />
+      <node concept="3clFbS" id="6hm_9jpLkQF" role="3clF47">
+        <node concept="3clFbF" id="6hm_9jpLkQG" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpLkQH" role="3clFbG">
+            <ref role="3cqZAo" node="6hm_9jpL6CG" resolve="endRow" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpLkQI" role="jymVt" />
+    <node concept="3clFb_" id="6hm_9jpLkQJ" role="jymVt">
+      <property role="TrG5h" value="getEndColumn" />
+      <node concept="10Oyi0" id="6hm_9jpLkQK" role="3clF45" />
+      <node concept="3Tm1VV" id="6hm_9jpLkQL" role="1B3o_S" />
+      <node concept="3clFbS" id="6hm_9jpLkQM" role="3clF47">
+        <node concept="3clFbF" id="6hm_9jpLkQN" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpLkQO" role="3clFbG">
+            <ref role="3cqZAo" node="6hm_9jpL6CD" resolve="endColumn" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6hm_9jpM7v6" role="jymVt" />
+    <node concept="3clFb_" id="6hm_9jpLZVE" role="jymVt">
+      <property role="TrG5h" value="getTable" />
+      <node concept="3uibUv" id="6hm_9jpLZVF" role="3clF45">
+        <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+      </node>
+      <node concept="3Tm1VV" id="6hm_9jpLZVG" role="1B3o_S" />
+      <node concept="3clFbS" id="6hm_9jpLZVH" role="3clF47">
+        <node concept="3clFbF" id="6hm_9jpLZVI" role="3cqZAp">
+          <node concept="37vLTw" id="6hm_9jpLZVJ" role="3clFbG">
+            <ref role="3cqZAo" node="6hm_9jpLLYN" resolve="table" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYios$mex" role="jymVt" />
+    <node concept="3Tm1VV" id="12YYioszPcx" role="1B3o_S" />
+    <node concept="3UR2Jj" id="12YYios$ngf" role="lGtFl">
+      <node concept="TZ5HA" id="12YYios$ngg" role="TZ5H$">
+        <node concept="1dT_AC" id="12YYios$ngh" role="1dT_Ay">
+          <property role="1dT_AB" value="The user selection can be performed from bottom to top and right to left." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="12YYios$noH" role="TZ5H$">
+        <node concept="1dT_AC" id="12YYios$noI" role="1dT_Ay">
+          <property role="1dT_AB" value="For cases where the direction doesn't matter e.g. copy and paste, this class can be used." />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="12YYios_2sr" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="12YYios_2ss" role="1B3o_S" />
+      <node concept="17QB3L" id="12YYios_lLs" role="3clF45" />
+      <node concept="3clFbS" id="12YYios_2sv" role="3clF47">
+        <node concept="3clFbF" id="12YYios_6Hn" role="3cqZAp">
+          <node concept="2YIFZM" id="12YYiosTd5k" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="12YYiosTd5l" role="37wK5m">
+              <property role="Xl_RC" value="%s [row,column] [%d,%d] to [%d,%d]" />
+            </node>
+            <node concept="2OqwBi" id="12YYiosTd5m" role="37wK5m">
+              <node concept="2OqwBi" id="12YYiosTd5n" role="2Oq$k0">
+                <node concept="Xjq3P" id="12YYiosTd5o" role="2Oq$k0" />
+                <node concept="liA8E" id="12YYiosTd5p" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                </node>
+              </node>
+              <node concept="liA8E" id="12YYiosTd5q" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Class.getSimpleName()" resolve="getSimpleName" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="6hm_9jpJ24M" role="37wK5m">
+              <ref role="37wK5l" node="6hm_9jpLkQq" resolve="getStartRow" />
+            </node>
+            <node concept="1rXfSq" id="6hm_9jpJfmf" role="37wK5m">
+              <ref role="37wK5l" node="6hm_9jpLkQx" resolve="getStartColumn" />
+            </node>
+            <node concept="1rXfSq" id="6hm_9jpJmRA" role="37wK5m">
+              <ref role="37wK5l" node="6hm_9jpLkQC" resolve="getEndRow" />
+            </node>
+            <node concept="1rXfSq" id="6hm_9jpJrMU" role="37wK5m">
+              <ref role="37wK5l" node="6hm_9jpLkQJ" resolve="getEndColumn" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="12YYios_2sw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYios_jqU" role="jymVt" />
+    <node concept="3clFb_" id="12YYios_kJJ" role="jymVt">
+      <property role="TrG5h" value="iterate" />
+      <node concept="3clFbS" id="12YYios_kJM" role="3clF47">
+        <node concept="1Dw8fO" id="12YYios_mcM" role="3cqZAp">
+          <node concept="3cpWsn" id="12YYios_mcN" role="1Duv9x">
+            <property role="TrG5h" value="rowIndex" />
+            <node concept="10Oyi0" id="12YYios_mv7" role="1tU5fm" />
+            <node concept="2OqwBi" id="12YYiosGpai" role="33vP2m">
+              <node concept="Xjq3P" id="12YYios_nFO" role="2Oq$k0" />
+              <node concept="liA8E" id="6hm_9jpGy4U" role="2OqNvi">
+                <ref role="37wK5l" node="6hm_9jpLkQq" resolve="getStartRow" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYios_mcO" role="2LFqv$">
+            <node concept="1Dw8fO" id="12YYios_$3U" role="3cqZAp">
+              <node concept="3cpWsn" id="12YYios_$3V" role="1Duv9x">
+                <property role="TrG5h" value="colIndex" />
+                <node concept="10Oyi0" id="12YYios_$no" role="1tU5fm" />
+                <node concept="2OqwBi" id="12YYios__VH" role="33vP2m">
+                  <node concept="Xjq3P" id="12YYios__CD" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpGJac" role="2OqNvi">
+                    <ref role="37wK5l" node="6hm_9jpLkQx" resolve="getStartColumn" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="12YYios_$3W" role="2LFqv$">
+                <node concept="3clFbF" id="12YYios_E9G" role="3cqZAp">
+                  <node concept="2OqwBi" id="12YYios_EHg" role="3clFbG">
+                    <node concept="37vLTw" id="12YYios_E9F" role="2Oq$k0">
+                      <ref role="3cqZAo" node="12YYios_lad" resolve="consumer" />
+                    </node>
+                    <node concept="1Bd96e" id="12YYios_FCh" role="2OqNvi">
+                      <node concept="37vLTw" id="12YYios_GnX" role="1BdPVh">
+                        <ref role="3cqZAo" node="12YYios_mcN" resolve="rowIndex" />
+                      </node>
+                      <node concept="37vLTw" id="12YYios_GRw" role="1BdPVh">
+                        <ref role="3cqZAo" node="12YYios_$3V" resolve="colIndex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2dkUwp" id="12YYios_BJE" role="1Dwp0S">
+                <node concept="2OqwBi" id="12YYios_CHN" role="3uHU7w">
+                  <node concept="Xjq3P" id="12YYios_C7W" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpGqpY" role="2OqNvi">
+                    <ref role="37wK5l" node="6hm_9jpLkQJ" resolve="getEndColumn" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="12YYios_B21" role="3uHU7B">
+                  <ref role="3cqZAo" node="12YYios_$3V" resolve="colIndex" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="12YYios_DGw" role="1Dwrff">
+                <node concept="37vLTw" id="12YYios_DGy" role="2$L3a6">
+                  <ref role="3cqZAo" node="12YYios_$3V" resolve="colIndex" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2dkUwp" id="12YYios_uAn" role="1Dwp0S">
+            <node concept="2OqwBi" id="12YYios_vxE" role="3uHU7w">
+              <node concept="Xjq3P" id="12YYios_uWE" role="2Oq$k0" />
+              <node concept="liA8E" id="6hm_9jpGh_I" role="2OqNvi">
+                <ref role="37wK5l" node="6hm_9jpLkQC" resolve="getEndRow" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="12YYios_tTR" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYios_mcN" resolve="rowIndex" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="12YYios_zIl" role="1Dwrff">
+            <node concept="37vLTw" id="12YYios_zIn" role="2$L3a6">
+              <ref role="3cqZAo" node="12YYios_mcN" resolve="rowIndex" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYios_kkq" role="1B3o_S" />
+      <node concept="3cqZAl" id="12YYios_kIz" role="3clF45" />
+      <node concept="37vLTG" id="12YYios_lad" role="3clF46">
+        <property role="TrG5h" value="consumer" />
+        <node concept="1ajhzC" id="12YYios_lab" role="1tU5fm">
+          <node concept="3cqZAl" id="12YYios_lCc" role="1ajl9A" />
+          <node concept="10Oyi0" id="12YYios_lr5" role="1ajw0F" />
+          <node concept="10Oyi0" id="12YYios_lzo" role="1ajw0F" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYios_HdR" role="jymVt" />
+    <node concept="3clFb_" id="12YYios_Li$" role="jymVt">
+      <property role="TrG5h" value="withOffset" />
+      <node concept="3clFbS" id="12YYios_LiB" role="3clF47">
+        <node concept="3clFbF" id="12YYios_N13" role="3cqZAp">
+          <node concept="2ShNRf" id="12YYios_N11" role="3clFbG">
+            <node concept="1pGfFk" id="12YYios_NLu" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="12YYios$3q7" resolve="UndirectedTableRange" />
+              <node concept="1rXfSq" id="7NamNJXcXc5" role="37wK5m">
+                <ref role="37wK5l" node="6hm_9jpLZVE" resolve="getTable" />
+              </node>
+              <node concept="2YIFZM" id="12YYios_OxN" role="37wK5m">
+                <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="3cmrfG" id="12YYios_P9d" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="3cpWs3" id="12YYiosAweT" role="37wK5m">
+                  <node concept="37vLTw" id="12YYiosAw$d" role="3uHU7w">
+                    <ref role="3cqZAo" node="12YYios_LVO" resolve="rowOffset" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosGVyK" role="3uHU7B">
+                    <node concept="Xjq3P" id="12YYiosGVyL" role="2Oq$k0" />
+                    <node concept="liA8E" id="6hm_9jpGSw4" role="2OqNvi">
+                      <ref role="37wK5l" node="6hm_9jpLkQq" resolve="getStartRow" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2YIFZM" id="12YYios_V_S" role="37wK5m">
+                <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="3cmrfG" id="12YYios_Weh" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="3cpWs3" id="12YYiosA0Yf" role="37wK5m">
+                  <node concept="37vLTw" id="12YYiosA1mG" role="3uHU7w">
+                    <ref role="3cqZAo" node="12YYios_LVO" resolve="rowOffset" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosHLmc" role="3uHU7B">
+                    <node concept="Xjq3P" id="12YYiosHLmd" role="2Oq$k0" />
+                    <node concept="liA8E" id="6hm_9jpGXzq" role="2OqNvi">
+                      <ref role="37wK5l" node="6hm_9jpLkQC" resolve="getEndRow" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2YIFZM" id="12YYiosA4hB" role="37wK5m">
+                <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="3cmrfG" id="12YYiosA59H" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="3cpWs3" id="12YYiosAbQb" role="37wK5m">
+                  <node concept="37vLTw" id="12YYiosAcHn" role="3uHU7w">
+                    <ref role="3cqZAo" node="12YYios_Mhz" resolve="colOffset" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosHT_8" role="3uHU7B">
+                    <node concept="Xjq3P" id="12YYiosHT_9" role="2Oq$k0" />
+                    <node concept="liA8E" id="6hm_9jpH7Uq" role="2OqNvi">
+                      <ref role="37wK5l" node="6hm_9jpLkQx" resolve="getStartColumn" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2YIFZM" id="12YYiosAgL_" role="37wK5m">
+                <ref role="37wK5l" to="wyt6:~Math.max(int,int)" resolve="max" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="3cmrfG" id="12YYiosAioC" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="3cpWs3" id="12YYiosAmB1" role="37wK5m">
+                  <node concept="37vLTw" id="12YYiosAnWW" role="3uHU7w">
+                    <ref role="3cqZAo" node="12YYios_Mhz" resolve="colOffset" />
+                  </node>
+                  <node concept="2OqwBi" id="12YYiosI1wH" role="3uHU7B">
+                    <node concept="Xjq3P" id="12YYiosI1wI" role="2Oq$k0" />
+                    <node concept="liA8E" id="6hm_9jpHfgO" role="2OqNvi">
+                      <ref role="37wK5l" node="6hm_9jpLkQJ" resolve="getEndColumn" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYios_Kzo" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYios_Lch" role="3clF45">
+        <ref role="3uigEE" node="12YYioszPcw" resolve="UndirectedTableRange" />
+      </node>
+      <node concept="37vLTG" id="12YYios_LVO" role="3clF46">
+        <property role="TrG5h" value="rowOffset" />
+        <node concept="10Oyi0" id="12YYios_LVN" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="12YYios_Mhz" role="3clF46">
+        <property role="TrG5h" value="colOffset" />
+        <node concept="10Oyi0" id="12YYios_MBn" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosAyTP" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosAC7t" role="jymVt">
+      <property role="TrG5h" value="withoutLeftColumns" />
+      <node concept="3clFbS" id="12YYiosAC7w" role="3clF47">
+        <node concept="3clFbJ" id="12YYiosAJnL" role="3cqZAp">
+          <node concept="3eOVzh" id="12YYiosATW2" role="3clFbw">
+            <node concept="3cmrfG" id="12YYiosAWBl" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="12YYiosALDN" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosAGZt" resolve="number" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYiosAJnN" role="3clFbx">
+            <node concept="YS8fn" id="12YYiosAYUr" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYiosAZgp" role="YScLw">
+                <node concept="1pGfFk" id="12YYiosB1Vt" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalArgumentException.&lt;init&gt;(java.lang.String)" resolve="IllegalArgumentException" />
+                  <node concept="2YIFZM" id="12YYiosB6$U" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="37vLTw" id="12YYiosBb97" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYiosAGZt" resolve="number" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosBi4q" role="3cqZAp">
+          <node concept="2ShNRf" id="12YYiosBi4m" role="3clFbG">
+            <node concept="1pGfFk" id="12YYiosBk_a" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="12YYios$3q7" resolve="UndirectedTableRange" />
+              <node concept="1rXfSq" id="7NamNJXdaXB" role="37wK5m">
+                <ref role="37wK5l" node="6hm_9jpLZVE" resolve="getTable" />
+              </node>
+              <node concept="2OqwBi" id="7NamNJXcsJi" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXcsJj" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpHsv6" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQq" resolve="getStartRow" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7NamNJXcxTW" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXcxTX" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpHAF0" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQC" resolve="getEndRow" />
+                </node>
+              </node>
+              <node concept="3cpWs3" id="12YYiosBBbL" role="37wK5m">
+                <node concept="37vLTw" id="12YYiosBDx3" role="3uHU7w">
+                  <ref role="3cqZAo" node="12YYiosAGZt" resolve="number" />
+                </node>
+                <node concept="2OqwBi" id="7NamNJXcB6u" role="3uHU7B">
+                  <node concept="Xjq3P" id="7NamNJXcB6v" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpHImk" role="2OqNvi">
+                    <ref role="37wK5l" node="6hm_9jpLkQx" resolve="getStartColumn" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7NamNJXcIWM" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXcIWN" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpHR1V" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQJ" resolve="getEndColumn" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosA_wx" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosAEIq" role="3clF45">
+        <ref role="3uigEE" node="12YYioszPcw" resolve="UndirectedTableRange" />
+      </node>
+      <node concept="37vLTG" id="12YYiosAGZt" role="3clF46">
+        <property role="TrG5h" value="number" />
+        <node concept="10Oyi0" id="12YYiosAGZs" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="12YYiosBKyY" role="jymVt" />
+    <node concept="3clFb_" id="12YYiosBU$o" role="jymVt">
+      <property role="TrG5h" value="withoutRightColumns" />
+      <node concept="3clFbS" id="12YYiosBU$r" role="3clF47">
+        <node concept="3clFbJ" id="12YYiosBZDr" role="3cqZAp">
+          <node concept="3eOVzh" id="12YYiosC4DY" role="3clFbw">
+            <node concept="3cmrfG" id="12YYiosC52R" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="12YYiosC1XA" role="3uHU7B">
+              <ref role="3cqZAo" node="12YYiosBXfT" resolve="number" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="12YYiosBZDt" role="3clFbx">
+            <node concept="YS8fn" id="12YYiosC7qR" role="3cqZAp">
+              <node concept="2ShNRf" id="12YYiosC9fu" role="YScLw">
+                <node concept="1pGfFk" id="12YYiosCbWF" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalArgumentException.&lt;init&gt;(java.lang.String)" resolve="IllegalArgumentException" />
+                  <node concept="2YIFZM" id="12YYiosClIC" role="37wK5m">
+                    <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="37vLTw" id="12YYiosCqnb" role="37wK5m">
+                      <ref role="3cqZAo" node="12YYiosBXfT" resolve="number" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="12YYiosCw_E" role="3cqZAp">
+          <node concept="2ShNRf" id="12YYiosCw_A" role="3clFbG">
+            <node concept="1pGfFk" id="12YYiosCziy" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="12YYios$3q7" resolve="UndirectedTableRange" />
+              <node concept="1rXfSq" id="7NamNJXdjJK" role="37wK5m">
+                <ref role="37wK5l" node="6hm_9jpLZVE" resolve="getTable" />
+              </node>
+              <node concept="2OqwBi" id="7NamNJXcvko" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXcvkp" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpHYzt" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQq" resolve="getStartRow" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7NamNJXc$vY" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXc$vZ" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpI5TC" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQC" resolve="getEndRow" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7NamNJXcDHs" role="37wK5m">
+                <node concept="Xjq3P" id="7NamNJXcDHt" role="2Oq$k0" />
+                <node concept="liA8E" id="6hm_9jpIgB1" role="2OqNvi">
+                  <ref role="37wK5l" node="6hm_9jpLkQx" resolve="getStartColumn" />
+                </node>
+              </node>
+              <node concept="3cpWsd" id="12YYiosCVAg" role="37wK5m">
+                <node concept="37vLTw" id="12YYiosCXYo" role="3uHU7w">
+                  <ref role="3cqZAo" node="12YYiosBXfT" resolve="number" />
+                </node>
+                <node concept="2OqwBi" id="7NamNJXcGkS" role="3uHU7B">
+                  <node concept="Xjq3P" id="7NamNJXcGkT" role="2Oq$k0" />
+                  <node concept="liA8E" id="6hm_9jpInuv" role="2OqNvi">
+                    <ref role="37wK5l" node="6hm_9jpLkQJ" resolve="getEndColumn" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="12YYiosBPTg" role="1B3o_S" />
+      <node concept="3uibUv" id="12YYiosBS$p" role="3clF45">
+        <ref role="3uigEE" node="12YYioszPcw" resolve="UndirectedTableRange" />
+      </node>
+      <node concept="37vLTG" id="12YYiosBXfT" role="3clF46">
+        <property role="TrG5h" value="number" />
+        <node concept="10Oyi0" id="12YYiosBXfS" role="1tU5fm" />
+      </node>
+    </node>
+  </node>
+  <node concept="2fD8I5" id="12YYios_MOO">
+    <property role="TrG5h" value="Interval" />
+    <node concept="2lGYhJ" id="12YYiosDR80" role="2pHZQ9">
+      <property role="TrG5h" value="start" />
+      <node concept="10Oyi0" id="12YYiosDR88" role="2lK19J" />
+    </node>
+    <node concept="2lGYhJ" id="12YYiosDR8a" role="2pHZQ9">
+      <property role="TrG5h" value="end" />
+      <node concept="10Oyi0" id="12YYiosDR8i" role="2lK19J" />
+    </node>
+    <node concept="3Tm1VV" id="12YYios_MOP" role="1B3o_S" />
+    <node concept="3clFb_" id="12YYiosFpgK" role="3MN40a">
+      <property role="TrG5h" value="toString" />
+      <node concept="17QB3L" id="12YYiosFppw" role="3clF45" />
+      <node concept="3Tm1VV" id="12YYiosFpgM" role="1B3o_S" />
+      <node concept="3clFbS" id="12YYiosFpgN" role="3clF47">
+        <node concept="3clFbF" id="12YYiosFpkR" role="3cqZAp">
+          <node concept="2YIFZM" id="12YYiosFprg" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="12YYiosFptT" role="37wK5m">
+              <property role="Xl_RC" value="[%d,%d]" />
+            </node>
+            <node concept="2OqwBi" id="12YYiosFrAb" role="37wK5m">
+              <node concept="Xjq3P" id="12YYiosFqTw" role="2Oq$k0" />
+              <node concept="2sxana" id="12YYiosFrOt" role="2OqNvi">
+                <ref role="2sxfKC" node="12YYiosDR80" resolve="start" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="12YYiosFtjg" role="37wK5m">
+              <node concept="Xjq3P" id="12YYiosFsK2" role="2Oq$k0" />
+              <node concept="2sxana" id="12YYiosFtxY" role="2OqNvi">
+                <ref role="2sxfKC" node="12YYiosDR8a" resolve="end" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
+++ b/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
@@ -7,6 +7,11 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
   </languages>
   <imports>
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
@@ -23,6 +28,16 @@
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="hro9" ref="r:f1c5f6f4-f735-4c95-8571-0c9b99e0bba3(de.slisson.mps.tables.demolang.plugin)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="cf47" ref="r:6b384ea8-f178-47ff-88f9-f7e02a20d230(de.slisson.mps.tables.demolang.behavior)" />
+    <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="sse1" ref="r:caea7020-da0a-4ba8-aff6-69334bbc9e02(de.slisson.mps.tables.runtime.simplegrid)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -52,9 +67,21 @@
       <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
         <reference id="4239542196496929559" name="action" index="1iFR8X" />
       </concept>
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
@@ -72,9 +99,16 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
@@ -92,6 +126,7 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -101,11 +136,15 @@
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068431790191" name="jetbrains.mps.baseLanguage.structure.Expression" flags="nn" index="33vP2n" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -134,6 +173,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -141,12 +181,14 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -173,6 +215,19 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare">
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
+    </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="1216130694486" name="jetbrains.mps.baseLanguage.unitTest.structure.ITestCase" flags="ngI" index="B2rLd">
         <property id="6427619394892729757" name="canNotRunInProcess" index="26Nn1l" />
@@ -184,6 +239,9 @@
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
       <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
         <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172028177041" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNull" flags="nn" index="3ykFI1">
+        <child id="1172028236559" name="expression" index="3ykU8v" />
       </concept>
     </language>
     <language id="2d56439e-634d-4d25-9d30-963e89ecda48" name="de.slisson.mps.tables.demolang">
@@ -234,10 +292,20 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -255,6 +323,9 @@
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
     </language>
   </registry>
   <node concept="2XOHcx" id="651tS80wVkO">
@@ -2813,6 +2884,1828 @@
           <node concept="2r1o01" id="2WnHFkwZiR" role="2r1o1s">
             <ref role="2r1o0d" node="2WnHFkwZiO" />
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2P8zLSgfFJ8">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="StateMachineCopyPaste" />
+    <node concept="2XrIbr" id="2P8zLSgi8aj" role="1qtyYc">
+      <property role="TrG5h" value="assertTransition" />
+      <node concept="3cqZAl" id="2P8zLSgi8kU" role="3clF45" />
+      <node concept="3clFbS" id="2P8zLSgi8al" role="3clF47">
+        <node concept="3cpWs8" id="1vOmbRexBSl" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbRexBSm" role="3cpWs9">
+            <property role="TrG5h" value="s" />
+            <node concept="3Tqbb2" id="1vOmbRexBOm" role="1tU5fm">
+              <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+            </node>
+            <node concept="2OqwBi" id="1vOmbRexJ$K" role="33vP2m">
+              <node concept="2OqwBi" id="1vOmbRexBSn" role="2Oq$k0">
+                <node concept="2OqwBi" id="1vOmbRexBSo" role="2Oq$k0">
+                  <node concept="2qgKlT" id="1vOmbRexBSp" role="2OqNvi">
+                    <ref role="37wK5l" to="cf47:2P8zLSgfHs1" resolve="getTransition" />
+                    <node concept="37vLTw" id="1vOmbRexBSq" role="37wK5m">
+                      <ref role="3cqZAo" node="2P8zLSgi8tP" resolve="event" />
+                    </node>
+                    <node concept="37vLTw" id="1vOmbRexBSr" role="37wK5m">
+                      <ref role="3cqZAo" node="2P8zLSgi8_9" resolve="state" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="1vOmbRexBSs" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2P8zLSgi8sn" resolve="stateMachine" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="1vOmbRexBSt" role="2OqNvi">
+                  <ref role="3Tt5mk" to="nnej:1dAqnm8uy$r" resolve="to" />
+                </node>
+              </node>
+              <node concept="1$rogu" id="1vOmbRexK70" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRexKkq" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRexMXA" role="3clFbG">
+            <node concept="2OqwBi" id="1vOmbRexKwm" role="2Oq$k0">
+              <node concept="37vLTw" id="1vOmbRexKko" role="2Oq$k0">
+                <ref role="3cqZAo" node="1vOmbRexBSm" resolve="s" />
+              </node>
+              <node concept="3Tsc0h" id="1vOmbRexKFS" role="2OqNvi">
+                <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="1vOmbRexPuc" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3GXo0L" id="2P8zLSgi9Y7" role="3cqZAp">
+          <node concept="37vLTw" id="1vOmbRexBSu" role="3tpDZA">
+            <ref role="3cqZAo" node="1vOmbRexBSm" resolve="s" />
+          </node>
+          <node concept="37vLTw" id="2P8zLSgiboT" role="3tpDZB">
+            <ref role="3cqZAo" node="2P8zLSgi9Hm" resolve="expectedState" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgi8sn" role="3clF46">
+        <property role="TrG5h" value="stateMachine" />
+        <node concept="3Tqbb2" id="2P8zLSgi8sm" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgi8tP" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3Tqbb2" id="2P8zLSgi8$z" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyl" resolve="Event" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgi8_9" role="3clF46">
+        <property role="TrG5h" value="state" />
+        <node concept="3Tqbb2" id="2P8zLSgi8FT" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSgi9Hm" role="3clF46">
+        <property role="TrG5h" value="expectedState" />
+        <node concept="3Tqbb2" id="2P8zLSgi9Wp" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="2P8zLSglRz5" role="1qtyYc">
+      <property role="TrG5h" value="assertTransitionIsNull" />
+      <node concept="3cqZAl" id="2P8zLSglRC5" role="3clF45" />
+      <node concept="3clFbS" id="2P8zLSglRz7" role="3clF47">
+        <node concept="3ykFI1" id="2P8zLSglTtD" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSglTtV" role="3ykU8v">
+            <node concept="2OqwBi" id="2P8zLSglTtW" role="2Oq$k0">
+              <node concept="2qgKlT" id="2P8zLSglTtX" role="2OqNvi">
+                <ref role="37wK5l" to="cf47:2P8zLSgfHs1" resolve="getTransition" />
+                <node concept="37vLTw" id="2P8zLSglTtY" role="37wK5m">
+                  <ref role="3cqZAo" node="2P8zLSglRV2" resolve="event" />
+                </node>
+                <node concept="37vLTw" id="2P8zLSglTtZ" role="37wK5m">
+                  <ref role="3cqZAo" node="2P8zLSglSkw" resolve="state" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="2P8zLSglTu0" role="2Oq$k0">
+                <ref role="3cqZAo" node="2P8zLSglRSY" resolve="stateMachine" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="2P8zLSglTu1" role="2OqNvi">
+              <ref role="3Tt5mk" to="nnej:1dAqnm8uy$r" resolve="to" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSglRSY" role="3clF46">
+        <property role="TrG5h" value="stateMachine" />
+        <node concept="3Tqbb2" id="2P8zLSglRSX" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyvB" resolve="StateMachine" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSglRV2" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3Tqbb2" id="2P8zLSglSiI" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyl" resolve="Event" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="2P8zLSglSkw" role="3clF46">
+        <property role="TrG5h" value="state" />
+        <node concept="3Tqbb2" id="2P8zLSglTqj" role="1tU5fm">
+          <ref role="ehGHo" to="nnej:1dAqnm8uyyE" resolve="State" />
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="7NamNJX_cHk" role="1qtyYc">
+      <property role="TrG5h" value="getTableEditor" />
+      <node concept="3uibUv" id="7NamNJX_d_z" role="3clF45">
+        <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+      </node>
+      <node concept="3clFbS" id="7NamNJX_cHm" role="3clF47">
+        <node concept="3clFbF" id="7NamNJX_dWJ" role="3cqZAp">
+          <node concept="2YIFZM" id="7NamNJX_dWL" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~CellFinderUtil.findChildByClass(jetbrains.mps.openapi.editor.cells.EditorCell,java.lang.Class,boolean)" resolve="findChildByClass" />
+            <ref role="1Pybhc" to="g51k:~CellFinderUtil" resolve="CellFinderUtil" />
+            <node concept="2OqwBi" id="7NamNJX_dWM" role="37wK5m">
+              <node concept="liA8E" id="7NamNJX_dWO" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorComponent.getRootCell()" resolve="getRootCell" />
+              </node>
+              <node concept="37vLTw" id="7NamNJX_eSj" role="2Oq$k0">
+                <ref role="3cqZAo" node="7NamNJX_dUR" resolve="editorComponent" />
+              </node>
+            </node>
+            <node concept="3VsKOn" id="7NamNJX_dWP" role="37wK5m">
+              <ref role="3VsUkX" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+            </node>
+            <node concept="3clFbT" id="7NamNJX_dWQ" role="37wK5m">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7NamNJX_dUR" role="3clF46">
+        <property role="TrG5h" value="editorComponent" />
+        <node concept="3uibUv" id="7NamNJX_dUQ" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2P8zLSgfG77" role="1SL9yI">
+      <property role="TrG5h" value="delete" />
+      <node concept="3cqZAl" id="2P8zLSgfG78" role="3clF45" />
+      <node concept="3clFbS" id="2P8zLSgfG7c" role="3clF47">
+        <node concept="3clFbF" id="2P8zLSgibHj" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgibHd" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgibHg" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgibHi" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgibNc" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgibXB" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi10k" resolve="tb1Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgicKl" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgicV5" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgid9d" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgid9e" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgid9f" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgid9g" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgid9h" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgid9i" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi17P" resolve="tb1Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgid9j" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgid9k" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgieoi" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgieoj" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgieok" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgieol" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgieom" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgieon" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi10k" resolve="tb1Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgieoo" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgieop" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgievH" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgievI" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgievJ" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgievK" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgievL" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgievM" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi17P" resolve="tb1Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgievN" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgievO" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2P8zLSgig$M" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXohnY" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXohnZ" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7NamNJXoho0" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7NamNJXohsv" role="33vP2m">
+              <node concept="1pGfFk" id="7NamNJXohI5" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="2OqwBi" id="7NamNJXoifZ" role="37wK5m">
+                  <node concept="1jxXqW" id="7NamNJXohK9" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJXoiWU" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7NamNJXojb1" role="3cqZAp">
+          <node concept="2OqwBi" id="7NamNJXok_9" role="3clFbG">
+            <node concept="37vLTw" id="7NamNJXojaZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="7NamNJXohnZ" resolve="component" />
+            </node>
+            <node concept="liA8E" id="7NamNJXomfp" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="3xONca" id="7NamNJXonor" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6hm_9jpQ355" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQ356" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="3uibUv" id="6hm_9jpQ357" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQ3a$" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQ4or" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQ4xl" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXohnZ" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQ4CT" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQ4CU" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQ4CV" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQ4CW" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXohnZ" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQ6xN" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQ8C6" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQ9QR" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQf4w" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQfMa" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQgi4" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQgmv" role="37wK5m">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQgr3" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7dKu$V$1f82" role="3cqZAp">
+          <node concept="3cpWsn" id="7dKu$V$1f83" role="3cpWs9">
+            <property role="TrG5h" value="copyPaste" />
+            <node concept="3uibUv" id="7dKu$V$1f84" role="1tU5fm">
+              <ref role="3uigEE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+            </node>
+            <node concept="2ShNRf" id="7dKu$V$1f85" role="33vP2m">
+              <node concept="HV5vD" id="7dKu$V$1f86" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7dKu$V$1f87" role="3cqZAp">
+          <node concept="2OqwBi" id="7dKu$V$1f88" role="3clFbG">
+            <node concept="37vLTw" id="7dKu$V$1f89" role="2Oq$k0">
+              <ref role="3cqZAo" node="7dKu$V$1f83" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="7dKu$V$1f8a" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiotbprz" resolve="setTableNode" />
+              <node concept="3xONca" id="7dKu$V$1f8b" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7dKu$V$1f8c" role="3cqZAp">
+          <node concept="2OqwBi" id="7dKu$V$1f8d" role="3clFbG">
+            <node concept="37vLTw" id="7dKu$V$1f8e" role="2Oq$k0">
+              <ref role="3cqZAo" node="7dKu$V$1f83" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="7dKu$V$1f8f" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiosZjAI" resolve="delete" />
+              <node concept="37vLTw" id="7dKu$V$1f8g" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpQ356" resolve="selection" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jqhBHq" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jqhAvW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXohnZ" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jqhDoC" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7dKu$V$1f8h" role="3cqZAp" />
+        <node concept="3clFbF" id="2P8zLSgigGA" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgigGB" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgigGC" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgigGD" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgigGE" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGF" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi10k" resolve="tb1Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGG" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgigGI" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgigGJ" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgigGK" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgigGL" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgigGM" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGN" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi17P" resolve="tb1Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGO" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1fm" resolve="tb1State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgigGQ" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgigGR" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgigGS" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgigGT" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgigGU" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGV" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi10k" resolve="tb1Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigGW" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgigGY" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgigGZ" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgigH0" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgigH1" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgigH2" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRP" resolve="table1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigH3" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi17P" resolve="tb1Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgigH4" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi1un" resolve="tb1State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2P8zLSgfG8D" role="1SL9yI">
+      <property role="TrG5h" value="cut" />
+      <node concept="3cqZAl" id="2P8zLSgfG8E" role="3clF45" />
+      <node concept="3clFbS" id="2P8zLSgfG8I" role="3clF47">
+        <node concept="3clFbF" id="2P8zLSgm4t8" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm4t9" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm4ta" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm4tb" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgm4tc" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4td" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4te" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tf" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm4tg" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm4th" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm4ti" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm4tj" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgm4tk" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tl" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tm" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tn" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm4to" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm4tp" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm4tq" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm4tr" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgm4ts" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tt" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tu" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tv" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm4tw" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm4tx" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm4ty" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm4tz" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgm4t$" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4t_" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tA" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm4tB" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2P8zLSgm45e" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXoGHu" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXoGHv" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7NamNJXoGHw" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7NamNJXoGHx" role="33vP2m">
+              <node concept="1pGfFk" id="7NamNJXoGHy" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="2OqwBi" id="7NamNJXoGHz" role="37wK5m">
+                  <node concept="1jxXqW" id="7NamNJXoGH$" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJXoGH_" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7NamNJXoGHA" role="3cqZAp">
+          <node concept="2OqwBi" id="7NamNJXoGHB" role="3clFbG">
+            <node concept="37vLTw" id="7NamNJXoGHC" role="2Oq$k0">
+              <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+            </node>
+            <node concept="liA8E" id="7NamNJXoGHD" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="3xONca" id="7NamNJXoGHE" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7NamNJXoG$i" role="3cqZAp" />
+        <node concept="3cpWs8" id="6hm_9jpQiGE" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQiGH" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="3uibUv" id="6hm_9jpQiGI" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQiGJ" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQiGK" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQiGL" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQiGM" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQiGN" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQiGO" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQiGP" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQiGQ" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQiGR" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQiGS" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jqLjJy" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQiGU" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQiGV" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQiGW" role="37wK5m">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQiGX" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7dKu$V$1f9n" role="3cqZAp">
+          <node concept="3cpWsn" id="7dKu$V$1f9o" role="3cpWs9">
+            <property role="TrG5h" value="copyPaste" />
+            <node concept="3uibUv" id="7dKu$V$1f9p" role="1tU5fm">
+              <ref role="3uigEE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+            </node>
+            <node concept="2ShNRf" id="7dKu$V$1f9q" role="33vP2m">
+              <node concept="HV5vD" id="7dKu$V$1f9r" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7dKu$V$1f9s" role="3cqZAp">
+          <node concept="2OqwBi" id="7dKu$V$1f9t" role="3clFbG">
+            <node concept="37vLTw" id="7dKu$V$1f9u" role="2Oq$k0">
+              <ref role="3cqZAo" node="7dKu$V$1f9o" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="7dKu$V$1f9v" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiotbprz" resolve="setTableNode" />
+              <node concept="3xONca" id="7dKu$V$1f9w" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LJsqfZ05o3" role="3cqZAp">
+          <node concept="3cpWsn" id="6LJsqfZ05o4" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="3uibUv" id="6LJsqfZ04Z2" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="6LJsqfZ04Z5" role="11_B2D" />
+            </node>
+            <node concept="2OqwBi" id="6LJsqfZ05o5" role="33vP2m">
+              <node concept="37vLTw" id="6LJsqfZ05o6" role="2Oq$k0">
+                <ref role="3cqZAo" node="7dKu$V$1f9o" resolve="copyPaste" />
+              </node>
+              <node concept="liA8E" id="6LJsqfZ05o7" role="2OqNvi">
+                <ref role="37wK5l" to="3bri:12YYiosI$_L" resolve="cut" />
+                <node concept="37vLTw" id="6LJsqfZ05o8" role="37wK5m">
+                  <ref role="3cqZAo" node="6hm_9jpQiGH" resolve="selection" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jqhFbh" role="37wK5m">
+                  <node concept="37vLTw" id="6hm_9jqhDTK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jqhH34" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5LghDpmxd5D" role="3cqZAp">
+          <node concept="2OqwBi" id="5LghDpmxdqR" role="3clFbG">
+            <node concept="2YIFZM" id="5LghDpmxdh0" role="2Oq$k0">
+              <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+              <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+            </node>
+            <node concept="liA8E" id="5LghDpmxd$T" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:5LghDpmwTyC" resolve="put" />
+              <node concept="37vLTw" id="5LghDpmxdA4" role="37wK5m">
+                <ref role="3cqZAo" node="6LJsqfZ05o4" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7dKu$V$1f9A" role="3cqZAp" />
+        <node concept="3clFbF" id="2P8zLSgm8Hl" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm8Hm" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm8Hn" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm8Ho" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgm8Hp" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8Hq" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8Hr" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm8Ht" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm8Hu" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm8Hv" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm8Hw" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgm8Hx" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8Hy" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8Hz" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm8H_" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm8HA" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm8HB" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm8HC" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgm8HD" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8HE" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8HF" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgm8HH" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgm8HI" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgm8HJ" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgm8HK" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSglRz5" resolve="assertTransitionIsNull" />
+              <node concept="3xONca" id="2P8zLSgm8HL" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8HM" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgm8HN" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7dKu$V$1f9Z" role="3cqZAp" />
+        <node concept="3cpWs8" id="6hm_9jpQje6" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQje9" role="3cpWs9">
+            <property role="TrG5h" value="selectionNew" />
+            <node concept="3uibUv" id="6hm_9jpQjea" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQjeb" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQjec" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQjed" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQjee" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQjef" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQjeg" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQjeh" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQjei" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQjej" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQjek" role="37wK5m">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQjel" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQjem" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQjen" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQjeo" role="37wK5m">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQjep" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7dKu$V$1fa9" role="3cqZAp">
+          <node concept="2OqwBi" id="7dKu$V$1faa" role="3clFbG">
+            <node concept="37vLTw" id="7dKu$V$1fab" role="2Oq$k0">
+              <ref role="3cqZAo" node="7dKu$V$1f9o" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="7dKu$V$1fac" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiosZjAz" resolve="paste" />
+              <node concept="37vLTw" id="7dKu$V$1fad" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpQje9" resolve="selectionNew" />
+              </node>
+              <node concept="2OqwBi" id="7dKu$V$1fae" role="37wK5m">
+                <node concept="2YIFZM" id="7dKu$V$1faf" role="2Oq$k0">
+                  <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+                </node>
+                <node concept="liA8E" id="7dKu$V$1fag" role="2OqNvi">
+                  <ref role="37wK5l" to="3bri:5LghDpmwTpN" resolve="get" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jq2THZ" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jq2SyF" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXoGHv" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jq2Vty" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7dKu$V$1fah" role="3cqZAp" />
+        <node concept="3clFbF" id="2P8zLSgmduV" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgmduW" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgmduX" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgmduY" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgmduZ" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdv0" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdv1" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdv2" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgmdv3" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgmdv4" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgmdv5" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgmdv6" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgmdv7" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdv8" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdv9" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdva" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgmdvb" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgmdvc" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgmdvd" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgmdve" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgmdvf" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvg" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvh" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvi" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSgmdvj" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSgmdvk" role="3clFbG">
+            <node concept="2WthIp" id="2P8zLSgmdvl" role="2Oq$k0" />
+            <node concept="2XshWL" id="2P8zLSgmdvm" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="2P8zLSgmdvn" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvo" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvp" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="2P8zLSgmdvq" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2P8zLSgfGb1" role="1SL9yI">
+      <property role="TrG5h" value="copy" />
+      <node concept="3cqZAl" id="2P8zLSgfGb2" role="3clF45" />
+      <node concept="3clFbS" id="2P8zLSgfGb6" role="3clF47">
+        <node concept="3clFbF" id="1vOmbRexZbQ" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRexZbR" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRexZbS" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRexZbT" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRexZbU" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZbV" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZbW" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZbX" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRexZbY" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRexZbZ" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRexZc0" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRexZc1" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRexZc2" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZc3" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZc4" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZc5" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRexZc6" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRexZc7" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRexZc8" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRexZc9" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRexZca" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZcb" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZcc" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZcd" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRexZce" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRexZcf" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRexZcg" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRexZch" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRexZci" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZcj" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZck" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRexZcl" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1vOmbRexYSH" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXoJqF" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXoJqG" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7NamNJXoJqH" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7NamNJXoJqI" role="33vP2m">
+              <node concept="1pGfFk" id="7NamNJXoJqJ" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="2OqwBi" id="7NamNJXoJqK" role="37wK5m">
+                  <node concept="1jxXqW" id="7NamNJXoJqL" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJXoJqM" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7NamNJXoJqN" role="3cqZAp">
+          <node concept="2OqwBi" id="7NamNJXoJqO" role="3clFbG">
+            <node concept="37vLTw" id="7NamNJXoJqP" role="2Oq$k0">
+              <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+            </node>
+            <node concept="liA8E" id="7NamNJXoJqQ" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="3xONca" id="7NamNJXoJqR" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7NamNJXoJjJ" role="3cqZAp" />
+        <node concept="3cpWs8" id="6hm_9jpQmyQ" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQmyT" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="3uibUv" id="6hm_9jpQmyU" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQmyV" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQmyW" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQmyX" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQmyY" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQmyZ" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQmz0" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQmz1" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQmz2" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQmz3" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQmz4" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jqLlaP" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQmz6" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQmz7" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQmz8" role="37wK5m">
+                      <property role="3cmrfH" value="3" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQmz9" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2P8zLSg5ny9" role="3cqZAp">
+          <node concept="3cpWsn" id="2P8zLSg5nya" role="3cpWs9">
+            <property role="TrG5h" value="copyPaste" />
+            <node concept="3uibUv" id="2P8zLSg5nyb" role="1tU5fm">
+              <ref role="3uigEE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+            </node>
+            <node concept="2ShNRf" id="2P8zLSg5nyc" role="33vP2m">
+              <node concept="HV5vD" id="2P8zLSg5nyd" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="hro9:2P8zLSga70b" resolve="StateMachineCopyPasteImpl" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSg5nye" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSg5nyf" role="3clFbG">
+            <node concept="37vLTw" id="2P8zLSg5nyg" role="2Oq$k0">
+              <ref role="3cqZAo" node="2P8zLSg5nya" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="2P8zLSg5nyh" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiotbprz" resolve="setTableNode" />
+              <node concept="3xONca" id="2P8zLSg5nyi" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6LJsqfZ05XA" role="3cqZAp">
+          <node concept="3cpWsn" id="6LJsqfZ05XB" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="3uibUv" id="6LJsqfZ04Wr" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="6LJsqfZ04Wu" role="11_B2D" />
+            </node>
+            <node concept="2OqwBi" id="6LJsqfZ05XC" role="33vP2m">
+              <node concept="37vLTw" id="6LJsqfZ05XD" role="2Oq$k0">
+                <ref role="3cqZAo" node="2P8zLSg5nya" resolve="copyPaste" />
+              </node>
+              <node concept="liA8E" id="6LJsqfZ05XE" role="2OqNvi">
+                <ref role="37wK5l" to="hro9:12YYiosZjAo" resolve="copy" />
+                <node concept="37vLTw" id="6LJsqfZ05XF" role="37wK5m">
+                  <ref role="3cqZAo" node="6hm_9jpQmyT" resolve="selection" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jqhIBB" role="37wK5m">
+                  <node concept="37vLTw" id="6hm_9jqhHmP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                  </node>
+                  <node concept="liA8E" id="6hm_9jqhKtX" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6LJsqfZ068l" role="3cqZAp">
+          <node concept="2OqwBi" id="6LJsqfZ068m" role="3clFbG">
+            <node concept="2YIFZM" id="6LJsqfZ068n" role="2Oq$k0">
+              <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+              <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+            </node>
+            <node concept="liA8E" id="6LJsqfZ068o" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:5LghDpmwTyC" resolve="put" />
+              <node concept="37vLTw" id="6LJsqfZ068p" role="37wK5m">
+                <ref role="3cqZAo" node="6LJsqfZ05XB" resolve="data" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2P8zLSg5nyo" role="3cqZAp" />
+        <node concept="3clFbF" id="1vOmbRey0GR" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey0GS" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey0GT" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey0GU" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey0GV" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0GW" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0GX" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0GY" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey0GZ" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey0H0" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey0H1" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey0H2" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey0H3" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0H4" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0H5" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0H6" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey0H7" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey0H8" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey0H9" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey0Ha" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey0Hb" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0Hc" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2aN" resolve="tb2Event1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0Hd" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0He" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey0Hf" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey0Hg" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey0Hh" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey0Hi" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey0Hj" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0Hk" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2m4" resolve="tb2Event2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0Hl" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey0Hm" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2P8zLSg5nyL" role="3cqZAp" />
+        <node concept="3cpWs8" id="6hm_9jpQn_n" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQn_q" role="3cpWs9">
+            <property role="TrG5h" value="selectionNew" />
+            <node concept="3uibUv" id="6hm_9jpQn_r" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQn_s" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQn_t" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQn_u" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQn_v" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQn_w" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQn_x" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQn_y" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQn_z" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQn_$" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQn__" role="37wK5m">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jqLngD" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQn_B" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQn_C" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQn_D" role="37wK5m">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQn_E" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSg5nyV" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSg5nyW" role="3clFbG">
+            <node concept="37vLTw" id="2P8zLSg5nyX" role="2Oq$k0">
+              <ref role="3cqZAo" node="2P8zLSg5nya" resolve="copyPaste" />
+            </node>
+            <node concept="liA8E" id="2P8zLSg5nyY" role="2OqNvi">
+              <ref role="37wK5l" to="hro9:12YYiosZjAz" resolve="paste" />
+              <node concept="37vLTw" id="2P8zLSg5nyZ" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpQn_q" resolve="selectionNew" />
+              </node>
+              <node concept="2OqwBi" id="2P8zLSg5nz0" role="37wK5m">
+                <node concept="2YIFZM" id="2P8zLSg5nz1" role="2Oq$k0">
+                  <ref role="37wK5l" to="3bri:5LghDpmwUBv" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3bri:12YYiosVWpM" resolve="TableCopyStorage" />
+                </node>
+                <node concept="liA8E" id="2P8zLSg5nz2" role="2OqNvi">
+                  <ref role="37wK5l" to="3bri:5LghDpmwTpN" resolve="get" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6hm_9jq2MRl" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jq2LAK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXoJqG" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jq2OGR" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2P8zLSg5nz3" role="3cqZAp" />
+        <node concept="3clFbF" id="1vOmbRey1CE" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey1CF" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey1CG" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey1CH" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey1CI" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CJ" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CK" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CL" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey1CM" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey1CN" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey1CO" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey1CP" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey1CQ" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CR" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CS" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CT" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey1CU" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey1CV" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey1CW" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey1CX" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey1CY" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1CZ" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1D0" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1D1" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRey1D2" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRey1D3" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbRey1D4" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbRey1D5" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbRey1D6" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1D7" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1D8" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbRey1D9" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1vOmbRey8XO" role="1SL9yI">
+      <property role="TrG5h" value="pasteFromClipboard" />
+      <node concept="3cqZAl" id="1vOmbRey8XP" role="3clF45" />
+      <node concept="3clFbS" id="1vOmbRey8XT" role="3clF47">
+        <node concept="3cpWs8" id="1vOmbRe$SEs" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbRe$SEr" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="1vOmbRe$XTM" role="1tU5fm" />
+            <node concept="Xl_RD" id="1vOmbRe$SEu" role="33vP2m">
+              <property role="Xl_RC" value="TB2State1 TB2State2\nTB2State2 TB2State1" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1vOmbRe$SEw" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbRe$SEv" role="3cpWs9">
+            <property role="TrG5h" value="stringSelection" />
+            <node concept="3uibUv" id="1vOmbRe$SEx" role="1tU5fm">
+              <ref role="3uigEE" to="kt01:~StringSelection" resolve="StringSelection" />
+            </node>
+            <node concept="2ShNRf" id="1vOmbRe$XEZ" role="33vP2m">
+              <node concept="1pGfFk" id="1vOmbRe$XFc" role="2ShVmc">
+                <ref role="37wK5l" to="kt01:~StringSelection.&lt;init&gt;(java.lang.String)" resolve="StringSelection" />
+                <node concept="37vLTw" id="1vOmbRe$XFd" role="37wK5m">
+                  <ref role="3cqZAo" node="1vOmbRe$SEr" resolve="text" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1vOmbRe$SE_" role="3cqZAp">
+          <node concept="3cpWsn" id="1vOmbRe$SE$" role="3cpWs9">
+            <property role="TrG5h" value="clipboard" />
+            <node concept="3uibUv" id="1vOmbRe$SEA" role="1tU5fm">
+              <ref role="3uigEE" to="kt01:~Clipboard" resolve="Clipboard" />
+            </node>
+            <node concept="2OqwBi" id="1vOmbRe$XZ7" role="33vP2m">
+              <node concept="2YIFZM" id="1vOmbRe$XY0" role="2Oq$k0">
+                <ref role="1Pybhc" to="z60i:~Toolkit" resolve="Toolkit" />
+                <ref role="37wK5l" to="z60i:~Toolkit.getDefaultToolkit()" resolve="getDefaultToolkit" />
+              </node>
+              <node concept="liA8E" id="1vOmbRe$XZ8" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Toolkit.getSystemClipboard()" resolve="getSystemClipboard" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbRe$SED" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbRe$XEV" role="3clFbG">
+            <node concept="37vLTw" id="1vOmbRe$WQF" role="2Oq$k0">
+              <ref role="3cqZAo" node="1vOmbRe$SE$" resolve="clipboard" />
+            </node>
+            <node concept="liA8E" id="1vOmbRe$XEW" role="2OqNvi">
+              <ref role="37wK5l" to="kt01:~Clipboard.setContents(java.awt.datatransfer.Transferable,java.awt.datatransfer.ClipboardOwner)" resolve="setContents" />
+              <node concept="37vLTw" id="1vOmbRe$XEX" role="37wK5m">
+                <ref role="3cqZAo" node="1vOmbRe$SEv" resolve="stringSelection" />
+              </node>
+              <node concept="10Nm6u" id="1vOmbRe$XEY" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1vOmbReDjVz" role="3cqZAp" />
+        <node concept="3cpWs8" id="7NamNJXoOIZ" role="3cqZAp">
+          <node concept="3cpWsn" id="7NamNJXoOJ0" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="7NamNJXoOJ1" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="7NamNJXoOJ2" role="33vP2m">
+              <node concept="1pGfFk" id="7NamNJXoOJ3" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="2OqwBi" id="7NamNJXoOJ4" role="37wK5m">
+                  <node concept="1jxXqW" id="7NamNJXoOJ5" role="2Oq$k0" />
+                  <node concept="liA8E" id="7NamNJXoOJ6" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7NamNJXoOJ7" role="3cqZAp">
+          <node concept="2OqwBi" id="7NamNJXoOJ8" role="3clFbG">
+            <node concept="37vLTw" id="7NamNJXoOJ9" role="2Oq$k0">
+              <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+            </node>
+            <node concept="liA8E" id="7NamNJXoOJa" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="3xONca" id="7NamNJXoOJb" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7NamNJXoOIY" role="3cqZAp" />
+        <node concept="3cpWs8" id="6hm_9jpQplr" role="3cqZAp">
+          <node concept="3cpWsn" id="6hm_9jpQplu" role="3cpWs9">
+            <property role="TrG5h" value="selection" />
+            <node concept="3uibUv" id="6hm_9jpQplv" role="1tU5fm">
+              <ref role="3uigEE" to="9p8b:6Y0V2RJgPcd" resolve="TableRangeSelection" />
+            </node>
+            <node concept="2ShNRf" id="6hm_9jpQplw" role="33vP2m">
+              <node concept="1pGfFk" id="6hm_9jpQplx" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="9p8b:6Y0V2RJhOyt" resolve="TableRangeSelection" />
+                <node concept="37vLTw" id="6hm_9jpQply" role="37wK5m">
+                  <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+                </node>
+                <node concept="2OqwBi" id="6hm_9jpQplz" role="37wK5m">
+                  <node concept="2WthIp" id="6hm_9jpQpl$" role="2Oq$k0" />
+                  <node concept="2XshWL" id="6hm_9jpQpl_" role="2OqNvi">
+                    <ref role="2WH_rO" node="7NamNJX_cHk" resolve="getTableEditor" />
+                    <node concept="37vLTw" id="6hm_9jpQplA" role="2XxRq1">
+                      <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQplB" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQplC" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQplD" role="37wK5m">
+                      <property role="3cmrfH" value="4" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQplE" role="37wK5m">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6hm_9jpQplF" role="37wK5m">
+                  <node concept="1pGfFk" id="6hm_9jpQplG" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="sse1:20OswHE0h6W" resolve="GridPosition" />
+                    <node concept="3cmrfG" id="6hm_9jpQplH" role="37wK5m">
+                      <property role="3cmrfH" value="5" />
+                    </node>
+                    <node concept="3cmrfG" id="6hm_9jpQplI" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2P8zLSg8A66" role="3cqZAp">
+          <node concept="3cpWsn" id="2P8zLSg8A67" role="3cpWs9">
+            <property role="TrG5h" value="data" />
+            <node concept="3uibUv" id="2P8zLSg8A64" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYgq" resolve="TableData" />
+              <node concept="3Tqbb2" id="2P8zLSg8A7w" role="11_B2D" />
+            </node>
+            <node concept="2YIFZM" id="2P8zLSg8BfU" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosQuM5" resolve="fromClipboard" />
+              <ref role="1Pybhc" to="3bri:12YYiosJ3v6" resolve="ClipboardTableUtils" />
+              <node concept="3xONca" id="1vOmbReDkQ3" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="Rm8GO" id="2P8zLSg8Bir" role="37wK5m">
+                <ref role="Rm8GQ" to="3bri:12YYiosJ9Ix" resolve="SPACE" />
+                <ref role="1Px2BO" to="3bri:12YYiosJ9Cy" resolve="TableDataSeparator" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpRcEN" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jpRbqM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jpRevt" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2P8zLSg9cBk" role="3cqZAp">
+          <node concept="3cpWsn" id="2P8zLSg9cBl" role="3cpWs9">
+            <property role="TrG5h" value="handler" />
+            <node concept="3uibUv" id="2P8zLSg9bBQ" role="1tU5fm">
+              <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+            </node>
+            <node concept="2YIFZM" id="2P8zLSg9cBm" role="33vP2m">
+              <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
+              <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+              <node concept="3xONca" id="1vOmbReDkTM" role="37wK5m">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jq2Qnc" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jq2P6Q" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jq2S4w" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2P8zLSg9aOe" role="3cqZAp">
+          <node concept="2OqwBi" id="2P8zLSg9bB7" role="3clFbG">
+            <node concept="37vLTw" id="2P8zLSg9aOc" role="2Oq$k0">
+              <ref role="3cqZAo" node="2P8zLSg9cBl" resolve="handler" />
+            </node>
+            <node concept="liA8E" id="2P8zLSg9bN_" role="2OqNvi">
+              <ref role="37wK5l" to="3bri:12YYiosIoZg" resolve="paste" />
+              <node concept="37vLTw" id="2P8zLSg9bOR" role="37wK5m">
+                <ref role="3cqZAo" node="6hm_9jpQplu" resolve="selection" />
+              </node>
+              <node concept="37vLTw" id="2P8zLSg9bRH" role="37wK5m">
+                <ref role="3cqZAo" node="2P8zLSg8A67" resolve="data" />
+              </node>
+              <node concept="2OqwBi" id="6hm_9jpQDM5" role="37wK5m">
+                <node concept="37vLTw" id="6hm_9jpQCCW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7NamNJXoOJ0" resolve="component" />
+                </node>
+                <node concept="liA8E" id="6hm_9jpQF_G" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1vOmbReDjV$" role="3cqZAp" />
+        <node concept="3clFbF" id="1vOmbReDl0l" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReDl0m" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbReDl0n" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbReDl0o" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbReDl0p" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0q" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0r" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0s" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReDl0t" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReDl0u" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbReDl0v" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbReDl0w" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbReDl0x" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0y" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0z" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0$" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReDl0_" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReDl0A" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbReDl0B" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbReDl0C" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbReDl0D" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0E" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2zd" resolve="tb2Event3" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0F" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0G" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1vOmbReDl0H" role="3cqZAp">
+          <node concept="2OqwBi" id="1vOmbReDl0I" role="3clFbG">
+            <node concept="2WthIp" id="1vOmbReDl0J" role="2Oq$k0" />
+            <node concept="2XshWL" id="1vOmbReDl0K" role="2OqNvi">
+              <ref role="2WH_rO" node="2P8zLSgi8aj" resolve="assertTransition" />
+              <node concept="3xONca" id="1vOmbReDl0L" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgfFRY" resolve="table2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0M" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2EI" resolve="tb2Event4" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0N" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2VC" resolve="tb2State2" />
+              </node>
+              <node concept="3xONca" id="1vOmbReDl0O" role="2XxRq1">
+                <ref role="3xOPvv" node="2P8zLSgi2Kn" resolve="tb2State1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2P8zLSgfFJK" role="1SKRRt">
+      <node concept="2r74Ui" id="2P8zLSgfFJJ" role="1qenE9">
+        <node concept="2r747w" id="2P8zLSgfFJN" role="2r746P">
+          <property role="TrG5h" value="Event1" />
+          <node concept="3xLA65" id="2P8zLSgi10k" role="lGtFl">
+            <property role="TrG5h" value="tb1Event1" />
+          </node>
+        </node>
+        <node concept="2r747v" id="2P8zLSgfFJO" role="2r746Q">
+          <property role="TrG5h" value="TB1State1" />
+          <node concept="3xLA65" id="2P8zLSgi1fm" role="lGtFl">
+            <property role="TrG5h" value="tb1State1" />
+          </node>
+        </node>
+        <node concept="2r747v" id="2P8zLSgfFNO" role="2r746Q">
+          <property role="TrG5h" value="TB1State2" />
+          <node concept="3xLA65" id="2P8zLSgi1un" role="lGtFl">
+            <property role="TrG5h" value="tb1State2" />
+          </node>
+        </node>
+        <node concept="2r747w" id="2P8zLSgfFRO" role="2r746P">
+          <property role="TrG5h" value="Event2" />
+          <node concept="3xLA65" id="2P8zLSgi17P" role="lGtFl">
+            <property role="TrG5h" value="tb1Event2" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="2P8zLSgfFRP" role="lGtFl">
+          <property role="TrG5h" value="table1" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfFW0" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFJO" resolve="TB1State1" />
+          <ref role="2r741U" node="2P8zLSgfFJN" resolve="Event1" />
+          <ref role="2r741I" node="2P8zLSgfFJO" resolve="TB1State1" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfFW1" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFJO" resolve="TB1State1" />
+          <ref role="2r741U" node="2P8zLSgfFRO" resolve="Event2" />
+          <ref role="2r741I" node="2P8zLSgfFNO" resolve="TB1State2" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfFW2" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFNO" resolve="TB1State2" />
+          <ref role="2r741U" node="2P8zLSgfFJN" resolve="Event1" />
+          <ref role="2r741I" node="2P8zLSgfFNO" resolve="TB1State2" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfG1p" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFNO" resolve="TB1State2" />
+          <ref role="2r741U" node="2P8zLSgfFRO" resolve="Event2" />
+          <ref role="2r741I" node="2P8zLSgfFJO" resolve="TB1State1" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2P8zLSgfFRS" role="1SKRRt">
+      <node concept="2r74Ui" id="2P8zLSgfFRT" role="1qenE9">
+        <node concept="2r747w" id="2P8zLSgfFRU" role="2r746P">
+          <property role="TrG5h" value="Event1" />
+          <node concept="3xLA65" id="2P8zLSgi2aN" role="lGtFl">
+            <property role="TrG5h" value="tb2Event1" />
+          </node>
+        </node>
+        <node concept="2r747v" id="2P8zLSgfFRV" role="2r746Q">
+          <property role="TrG5h" value="TB2State1" />
+          <node concept="3xLA65" id="2P8zLSgi2Kn" role="lGtFl">
+            <property role="TrG5h" value="tb2State1" />
+          </node>
+        </node>
+        <node concept="2r747v" id="2P8zLSgfFRW" role="2r746Q">
+          <property role="TrG5h" value="TB2State2" />
+          <node concept="3xLA65" id="2P8zLSgi2VC" role="lGtFl">
+            <property role="TrG5h" value="tb2State2" />
+          </node>
+        </node>
+        <node concept="2r747w" id="2P8zLSgfFRX" role="2r746P">
+          <property role="TrG5h" value="Event2" />
+          <node concept="3xLA65" id="2P8zLSgi2m4" role="lGtFl">
+            <property role="TrG5h" value="tb2Event2" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="2P8zLSgfFRY" role="lGtFl">
+          <property role="TrG5h" value="table2" />
+        </node>
+        <node concept="2r747w" id="2P8zLSgfFRZ" role="2r746P">
+          <property role="TrG5h" value="Event3" />
+          <node concept="3xLA65" id="2P8zLSgi2zd" role="lGtFl">
+            <property role="TrG5h" value="tb2Event3" />
+          </node>
+        </node>
+        <node concept="2r747w" id="2P8zLSgfFS0" role="2r746P">
+          <property role="TrG5h" value="Event4" />
+          <node concept="3xLA65" id="2P8zLSgi2EI" role="lGtFl">
+            <property role="TrG5h" value="tb2Event4" />
+          </node>
+        </node>
+        <node concept="2r747a" id="2P8zLSgfG1q" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFRV" resolve="TB2State1" />
+          <ref role="2r741U" node="2P8zLSgfFRU" resolve="Event1" />
+          <ref role="2r741I" node="2P8zLSgfFRV" resolve="TB2State1" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfG1r" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFRV" resolve="TB2State1" />
+          <ref role="2r741U" node="2P8zLSgfFRX" resolve="Event2" />
+          <ref role="2r741I" node="2P8zLSgfFRW" resolve="TB2State2" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfG1s" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFRW" resolve="TB2State2" />
+          <ref role="2r741U" node="2P8zLSgfFRU" resolve="Event1" />
+          <ref role="2r741I" node="2P8zLSgfFRW" resolve="TB2State2" />
+        </node>
+        <node concept="2r747a" id="2P8zLSgfG1t" role="2r746X">
+          <ref role="2r741x" node="2P8zLSgfFRW" resolve="TB2State2" />
+          <ref role="2r741U" node="2P8zLSgfFRX" resolve="Event2" />
+          <ref role="2r741I" node="2P8zLSgfFRV" resolve="TB2State1" />
         </node>
       </node>
     </node>

--- a/code/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd
+++ b/code/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd
@@ -17,8 +17,10 @@
     <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
     <dependency reexport="false">2d56439e-634d-4d25-9d30-963e89ecda48(de.slisson.mps.tables.demolang)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
     <language slang="l:2d56439e-634d-4d25-9d30-963e89ecda48:de.slisson.mps.tables.demolang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -29,6 +31,7 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
@@ -47,6 +50,7 @@
     <module reference="da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />


### PR DESCRIPTION
Tables now support copying, cutting and deleting when multiple cells are selected with the mouse. Add the action map *TableSelectionActionMap* in the inspector of the table and implement the extension point *TableCopyPaste* to support these features for a specific table. In Addition, two new intention are available for tables that implement the extension point *DataTransformation* which allow parsing table data in textual form (comma- or tab-separated) and paste it to table (e.g., 10 as a number literal).

Note: This feature was initially implemented by @svott7. I moved it to MPS-Extensions and modified it a bit to be more generic.