### PR TITLE
nl.f1re.testing: Utility classes for testing

### DIFF
--- a/code/.mps/modules.xml
+++ b/code/.mps/modules.xml
@@ -117,6 +117,7 @@
       <modulePath path="$PROJECT_DIR$/modellisteners/com.mbeddr.mpsutil.modellisteners.sandbox/com.mbeddr.mpsutil.modellisteners.sandbox.msd" folder="modellisteners" />
       <modulePath path="$PROJECT_DIR$/modellisteners/com.mbeddr.mpsutil.modellisteners.sandboxlang/com.mbeddr.mpsutil.modellisteners.sandboxlang.mpl" folder="modellisteners" />
       <modulePath path="$PROJECT_DIR$/modellisteners/com.mbeddr.mpsutil.modellisteners/com.mbeddr.mpsutil.modellisteners.mpl" folder="modellisteners" />
+      <modulePath path="$PROJECT_DIR$/modellisteners/test.com.mbeddr.mpsutil.modellisteners/test.com.mbeddr.mpsutil.modellisteners.msd" folder="modellisteners" />
       <modulePath path="$PROJECT_DIR$/modelmerger/languages/de.itemis.mps.modelmerger/de.itemis.mps.modelmerger.mpl" folder="modelmerger" />
       <modulePath path="$PROJECT_DIR$/modelmerger/languages/de.itemis.mps.modelmerger/sandbox/de.itemis.mps.modelmerger.testhelper.msd" folder="modelmerger" />
       <modulePath path="$PROJECT_DIR$/modelmerger/languages/test.de.itemis.mps.modelmerger.testlanguage/test.de.itemis.mps.modelmerger.testlanguage.mpl" folder="modelmerger" />
@@ -223,6 +224,10 @@
       <modulePath path="$PROJECT_DIR$/tables/languages/de.slisson.mps.tables/sandbox/de.slisson.mps.tables.sandbox.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/solutions/de.slisson.mps.testutils/de.slisson.mps.testutils.msd" folder="tables" />
       <modulePath path="$PROJECT_DIR$/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd" folder="tables" />
+      <modulePath path="$PROJECT_DIR$/testing/languages/nl.f1re.testing.examples.lang/nl.f1re.testing.examples.lang.mpl" folder="testing" />
+      <modulePath path="$PROJECT_DIR$/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl" folder="testing" />
+      <modulePath path="$PROJECT_DIR$/testing/solutions/nl.f1re.testing.examples/nl.f1re.testing.examples.msd" folder="testing" />
+      <modulePath path="$PROJECT_DIR$/testing/solutions/nl.f1re.testing.runtime/nl.f1re.testing.runtime.msd" folder="testing" />
       <modulePath path="$PROJECT_DIR$/third-party/solutions/MPS.ThirdParty/MPS.ThirdParty.msd" folder="3rd-party" />
       <modulePath path="$PROJECT_DIR$/third-party/solutions/third.party.usage.test/third.party.usage.test.msd" folder="3rd-party" />
       <modulePath path="$PROJECT_DIR$/tooltips/solutions/de.itemis.mps.tooltips.runtime/de.itemis.mps.tooltips.runtime.msd" folder="tooltips" />

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -7261,6 +7261,9 @@
       <node concept="m$_yC" id="VbQeBOymoq" role="m$_yJ">
         <ref role="m$_y1" node="6SVXTgIe8wD" resolve="de.itemis.mps.celllayout" />
       </node>
+      <node concept="m$_yC" id="3OVhQEULL5r" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5CFKsRWRuFN" resolve="jetbrains.mps.debugger.api" />
+      </node>
     </node>
     <node concept="2G$12M" id="VbQeBOybIH" role="3989C9">
       <property role="TrG5h" value="de.itemis.mps.debug" />
@@ -7291,11 +7294,6 @@
         <node concept="1SiIV0" id="VbQeBOyex$" role="3bR37C">
           <node concept="3bR9La" id="VbQeBOyex_" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="VbQeBOyexA" role="3bR37C">
-          <node concept="3bR9La" id="VbQeBOyexB" role="1SiIV1">
-            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
           </node>
         </node>
         <node concept="1BupzO" id="VbQeBOyexN" role="3bR31x">
@@ -7341,11 +7339,6 @@
               <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
             </node>
           </node>
-          <node concept="1SiIV0" id="VbQeBOyexX" role="3bR37C">
-            <node concept="3bR9La" id="VbQeBOyexY" role="1SiIV1">
-              <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
-            </node>
-          </node>
           <node concept="1SiIV0" id="VbQeBOyexZ" role="3bR37C">
             <node concept="3bR9La" id="VbQeBOyey0" role="1SiIV1">
               <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
@@ -7379,6 +7372,11 @@
               </node>
             </node>
           </node>
+          <node concept="1SiIV0" id="3OVhQEV3ZYr" role="3bR37C">
+            <node concept="3bR9La" id="3OVhQEV3ZYs" role="1SiIV1">
+              <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
+            </node>
+          </node>
         </node>
         <node concept="1SiIV0" id="VbQeBOyhXT" role="3bR37C">
           <node concept="3bR9La" id="VbQeBOyhXU" role="1SiIV1">
@@ -7405,6 +7403,11 @@
             <node concept="3qWCbU" id="VbQeBOyimW" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEV3ZYe" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEV3ZYf" role="1SiIV1">
+            <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
           </node>
         </node>
       </node>
@@ -7492,8 +7495,8 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbJt" resolve="jetbrains.mps.ide.platform" />
           </node>
         </node>
-        <node concept="1SiIV0" id="VbQeBOOMZS" role="3bR37C">
-          <node concept="3bR9La" id="VbQeBOOMZT" role="1SiIV1">
+        <node concept="1SiIV0" id="RC4$o911zH" role="3bR37C">
+          <node concept="3bR9La" id="RC4$o911zI" role="1SiIV1">
             <ref role="3bR37D" node="6SVXTgIejl1" resolve="de.itemis.mps.editor.celllayout.runtime" />
           </node>
         </node>
@@ -7510,6 +7513,281 @@
                   <property role="2Ry0Am" value="solutions" />
                   <node concept="2Ry0Ak" id="72xJwSTmBN9" role="2Ry0An">
                     <property role="2Ry0Am" value="de.itemis.mps.debug.runtime" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="3OVhQEUMbrH" role="3989C9">
+      <property role="m$_wk" value="nl.f1re.testing" />
+      <node concept="3_J27D" id="3OVhQEUMbrI" role="m_cZH">
+        <node concept="3Mxwew" id="3OVhQEUMbrJ" role="3MwsjC">
+          <property role="3MwjfP" value="de.itemis.mps.debug" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3OVhQEUMbrK" role="m$_w8">
+        <node concept="3Mxwey" id="3OVhQEUMbrL" role="3MwsjC">
+          <ref role="3Mxwex" node="4MKCCgA1ncQ" resolve="version" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3OVhQEUMbrM" role="m$_yQ">
+        <node concept="3Mxwew" id="3OVhQEUMbrN" role="3MwsjC">
+          <property role="3MwjfP" value="MPS Testing" />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="3OVhQEUMbrO" role="2iVFfd">
+        <property role="2iUeEt" value="F1RE" />
+        <property role="2iUeEu" value="https://www.f1re.nl" />
+      </node>
+      <node concept="3_J27D" id="3OVhQEUMbrP" role="3s6cr7">
+        <node concept="3Mxwew" id="3OVhQEUMbrQ" role="3MwsjC">
+          <property role="3MwjfP" value="Various utility classes for testing in MPS" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="3OVhQEUMbrR" role="m$_yh">
+        <ref role="m$f5T" node="3OVhQEUM8kU" resolve="nl.f1re.testing" />
+      </node>
+      <node concept="m$_yC" id="3OVhQEUMcmH" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:16mx0EU4lyh" resolve="jetbrains.mps.ide" />
+      </node>
+      <node concept="m$_yC" id="3OVhQEUMcv7" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5CFKsRWBBql" resolve="jetbrains.mps.execution.api" />
+      </node>
+      <node concept="m$_yC" id="3OVhQEUMcJU" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:6Hpa5co69BH" resolve="jetbrains.mps.editor.tooltips" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="3OVhQEUM8kU" role="3989C9">
+      <property role="TrG5h" value="nl.f1re.testing" />
+      <node concept="1E1JtD" id="3OVhQEUS9mJ" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.testing" />
+        <property role="3LESm3" value="953e4089-c643-455b-8629-636de7085d1c" />
+        <node concept="398BVA" id="3OVhQEUS9vc" role="3LF7KH">
+          <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3OVhQEUS9K2" role="iGT6I">
+            <property role="2Ry0Am" value="testing" />
+            <node concept="2Ry0Ak" id="3OVhQEUSa0R" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3OVhQEUSahG" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUSayx" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.testing.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUSaWx" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUSaWy" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3OVhQEUSaWI" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3OVhQEUSaWJ" role="1HemKq">
+            <node concept="398BVA" id="3OVhQEUSaWz" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUSaW$" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUSaW_" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="3OVhQEUSaWA" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing" />
+                    <node concept="2Ry0Ak" id="3OVhQEUSaWB" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUSaWK" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1E0d5M" id="3OVhQEUSaWL" role="1E1XAP">
+          <ref role="1E0d5P" node="3OVhQEUM97i" resolve="nl.f1re.testing.runtime" />
+        </node>
+        <node concept="1yeLz9" id="3OVhQEUSaWM" role="1TViLv">
+          <property role="TrG5h" value="nl.f1re.testing.generator" />
+          <property role="3LESm3" value="ce328797-6b80-4260-85af-aea5722a56c7" />
+          <node concept="1BupzO" id="3OVhQEUSaX0" role="3bR31x">
+            <property role="3ZfqAx" value="generator/templates" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="3OVhQEUSaX1" role="1HemKq">
+              <node concept="398BVA" id="3OVhQEUSaWN" role="3LXTmr">
+                <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="3OVhQEUSaWO" role="iGT6I">
+                  <property role="2Ry0Am" value="testing" />
+                  <node concept="2Ry0Ak" id="3OVhQEUSaWP" role="2Ry0An">
+                    <property role="2Ry0Am" value="languages" />
+                    <node concept="2Ry0Ak" id="3OVhQEUSaWQ" role="2Ry0An">
+                      <property role="2Ry0Am" value="nl.f1re.testing" />
+                      <node concept="2Ry0Ak" id="3OVhQEUSaWR" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="3OVhQEUSaWS" role="2Ry0An">
+                          <property role="2Ry0Am" value="templates" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="3OVhQEUSaX2" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="3OVhQEUSipz" role="3bR37C">
+            <node concept="3bR9La" id="3OVhQEUSip$" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:ymnOULAU1u" resolve="jetbrains.mps.lang.test.runtime" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="3OVhQEUSip_" role="3bR37C">
+            <node concept="3bR9La" id="3OVhQEUSipA" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3OVhQEUSbqO" role="3bR31x">
+          <node concept="3LXTmp" id="3OVhQEUSbqP" role="3rtmxm">
+            <node concept="398BVA" id="3OVhQEUSbqQ" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUSbqR" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUSbqS" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="3OVhQEUSbqT" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUSbqV" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUSlqg" role="3bR37C">
+          <node concept="1Busua" id="3OVhQEUSlqh" role="1SiIV1">
+            <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUSlqi" role="3bR37C">
+          <node concept="Rbm2T" id="3OVhQEUSlqj" role="1SiIV1">
+            <ref role="1E1Vl2" node="2Xjt3l57hh_" resolve="de.slisson.mps.reflection" />
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="3OVhQEUM97i" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.testing.runtime" />
+        <property role="3LESm3" value="f4eaf5cb-c1e6-4968-831c-c28a93349488" />
+        <node concept="398BVA" id="3OVhQEUM9o6" role="3LF7KH">
+          <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3OVhQEUM9CW" role="iGT6I">
+            <property role="2Ry0Am" value="testing" />
+            <node concept="2Ry0Ak" id="3OVhQEUM9TL" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="3OVhQEUMaaA" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.testing.runtime" />
+                <node concept="2Ry0Ak" id="3OVhQEUMarr" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.testing.runtime.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPp" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPq" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:2eDSGe9d1qo" resolve="jetbrains.mps.execution.api" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPr" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPs" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPt" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPv" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPw" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPx" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPy" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPz" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaP$" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaP_" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:xAoHD7hU06" resolve="jetbrains.mps.lang.editor.tooltips.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPB" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPC" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1xb0AuwN7WS" resolve="JUnit" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMaPD" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMaPE" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3OVhQEUMaPQ" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3OVhQEUMaPR" role="1HemKq">
+            <node concept="398BVA" id="3OVhQEUMaPF" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUMaPG" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUMaPH" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3OVhQEUMaPI" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.runtime" />
+                    <node concept="2Ry0Ak" id="3OVhQEUMaPJ" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUMaPS" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7nS6IN7MWDN" role="3bR31x">
+          <node concept="3LXTmp" id="7nS6IN7MWDO" role="3rtmxm">
+            <node concept="3qWCbU" id="7nS6IN7MWDP" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7nS6IN7MWDQ" role="3LXTmr">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7nS6IN7MWDR" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="7nS6IN7MWDS" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7nS6IN7MWDT" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.runtime" />
                   </node>
                 </node>
               </node>
@@ -18480,6 +18758,10 @@
         <ref role="m_rDy" node="VbQeBOyjLM" resolve="de.itemis.mps.debug" />
         <node concept="pUk6x" id="VbQeBOym_5" role="pUk7w" />
       </node>
+      <node concept="m$_wl" id="3OVhQEUMftZ" role="39821P">
+        <ref role="m_rDy" node="3OVhQEUMbrH" resolve="nl.f1re.testing" />
+        <node concept="pUk6x" id="3OVhQEUMfRe" role="pUk7w" />
+      </node>
       <node concept="m$_wl" id="2NyZxKpV2Ss" role="39821P">
         <ref role="m_rDy" node="2NyZxKpUXYJ" resolve="de.itemis.mps.blutil" />
         <node concept="pUk6x" id="3D0nl1ssJJU" role="pUk7w" />
@@ -19283,9 +19565,14 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7NamNJXoLvU" role="3bR37C">
-          <node concept="3bR9La" id="7NamNJXoLvV" role="1SiIV1">
+        <node concept="1SiIV0" id="6cyqnzdntZl" role="3bR37C">
+          <node concept="3bR9La" id="6cyqnzdntZm" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6cyqnzduiad" role="3bR37C">
+          <node concept="3bR9La" id="6cyqnzduiae" role="1SiIV1">
+            <ref role="3bR37D" node="4be$WTb1AQa" resolve="de.itemis.mps.editor.diagram.runtime" />
           </node>
         </node>
       </node>
@@ -25257,6 +25544,334 @@
             </node>
             <node concept="3qWCbU" id="3s41kb3BVQI" role="3LXTna">
               <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="3OVhQEUMg1g" role="3989C9">
+      <property role="TrG5h" value="testing" />
+      <node concept="1E1JtD" id="3OVhQEUMg3f" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.testing.examples.lang" />
+        <property role="3LESm3" value="87e083b3-d1b3-4c3f-9d8c-b24d74710f49" />
+        <node concept="398BVA" id="3OVhQEUMg3E" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3OVhQEUMg4w" role="iGT6I">
+            <property role="2Ry0Am" value="testing" />
+            <node concept="2Ry0Ak" id="3OVhQEUMg5l" role="2Ry0An">
+              <property role="2Ry0Am" value="languages" />
+              <node concept="2Ry0Ak" id="3OVhQEUMg7I" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.testing.examples.lang" />
+                <node concept="2Ry0Ak" id="3OVhQEUMg8z" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.testing.examples.lang.mpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMg$Z" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMg_0" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3HV74$ebibC" resolve="jetbrains.mps.lang.text" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMg_1" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMg_2" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMg_3" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMg_4" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3OVhQEUMg_m" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3OVhQEUMg_n" role="1HemKq">
+            <node concept="398BVA" id="3OVhQEUMg_5" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUMg_6" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUMg_7" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="3OVhQEUMg_8" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.examples.lang" />
+                    <node concept="2Ry0Ak" id="3OVhQEUMg_9" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUMg_o" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1yeLz9" id="3OVhQEUMg_p" role="1TViLv">
+          <property role="TrG5h" value="nl.f1re.testing.examples.lang.generator" />
+          <property role="3LESm3" value="aabd29df-488b-436d-8c60-c2651e1dc524" />
+          <node concept="1BupzO" id="3OVhQEUMg_I" role="3bR31x">
+            <property role="3ZfqAx" value="generator/templates" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="3OVhQEUMg_J" role="1HemKq">
+              <node concept="398BVA" id="3OVhQEUMg_q" role="3LXTmr">
+                <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+                <node concept="2Ry0Ak" id="3OVhQEUMg_r" role="iGT6I">
+                  <property role="2Ry0Am" value="testing" />
+                  <node concept="2Ry0Ak" id="3OVhQEUMg_s" role="2Ry0An">
+                    <property role="2Ry0Am" value="languages" />
+                    <node concept="2Ry0Ak" id="3OVhQEUMg_t" role="2Ry0An">
+                      <property role="2Ry0Am" value="nl.f1re.testing.examples.lang" />
+                      <node concept="2Ry0Ak" id="3OVhQEUMg_u" role="2Ry0An">
+                        <property role="2Ry0Am" value="generator" />
+                        <node concept="2Ry0Ak" id="3OVhQEUMg_v" role="2Ry0An">
+                          <property role="2Ry0Am" value="templates" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="3OVhQEUMg_K" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3OVhQEUMgCI" role="3bR31x">
+          <node concept="3LXTmp" id="3OVhQEUMgCJ" role="3rtmxm">
+            <node concept="398BVA" id="3OVhQEUMgCK" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUMgCL" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUMgCM" role="2Ry0An">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="3OVhQEUMgCN" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.examples.lang" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUMgCP" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1E1JtA" id="3OVhQEUMgEu" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="nl.f1re.testing.examples" />
+        <property role="3LESm3" value="aade93d7-c51c-4471-a883-01aa02ec2bc2" />
+        <node concept="398BVA" id="3OVhQEUMgEV" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3OVhQEUMgFL" role="iGT6I">
+            <property role="2Ry0Am" value="testing" />
+            <node concept="2Ry0Ak" id="3OVhQEUMgGA" role="2Ry0An">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="3OVhQEUMgHr" role="2Ry0An">
+                <property role="2Ry0Am" value="nl.f1re.testing.examples" />
+                <node concept="2Ry0Ak" id="3OVhQEUMgIg" role="2Ry0An">
+                  <property role="2Ry0Am" value="nl.f1re.testing.examples.msd" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbh" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbi" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbj" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJ$" resolve="jetbrains.mps.ide.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbl" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbm" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:ymnOULAU1u" resolve="jetbrains.mps.lang.test.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbn" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbo" role="1SiIV1">
+            <ref role="3bR37D" node="3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbp" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbq" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:5MjKXSeu3D$" resolve="jetbrains.mps.kotin.ui.dsl" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbr" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbs" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:5xa9wY2vhaQ" resolve="jetbrains.mps.baseLanguage.execution.util" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbt" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbu" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:39HJr_hyAl1" resolve="jetbrains.mps.ide.vcs.core" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbv" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbw" role="1SiIV1">
+            <ref role="3bR37D" node="3OVhQEUM97i" resolve="nl.f1re.testing.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbx" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhby" role="1SiIV1">
+            <ref role="3bR37D" node="VbQeBOyf1F" resolve="de.itemis.mps.debug.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbz" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhb$" role="1SiIV1">
+            <ref role="3bR37D" node="77YfcvOLBqQ" resolve="de.itemis.mps.comparator" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhb_" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:16mx0EU4kXX" resolve="jetbrains.mps.ide.tools.todo" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbB" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbC" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbD" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbE" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:rD7wKO6k$" resolve="MPS.Generator" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbF" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbG" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:2eDSGe9d1q1" resolve="MPS.Workbench" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbH" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbI" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6L7y" resolve="jetbrains.mps.lang.intentions" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbJ" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbK" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:4WGKd_KIwrs" resolve="jetbrains.mps.vcs.mergehints.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3OVhQEUMhbL" role="3bR37C">
+          <node concept="3bR9La" id="3OVhQEUMhbM" role="1SiIV1">
+            <ref role="3bR37D" node="3OVhQEUMg3f" resolve="nl.f1re.testing.examples.lang" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="3OVhQEUMhc4" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3OVhQEUMhc5" role="1HemKq">
+            <node concept="398BVA" id="3OVhQEUMhbN" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="3OVhQEUMhbO" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="3OVhQEUMhbP" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="3OVhQEUMhbQ" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.examples" />
+                    <node concept="2Ry0Ak" id="3OVhQEUMhbR" role="2Ry0An">
+                      <property role="2Ry0Am" value="models" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3OVhQEUMhc6" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7nS6IN7MWDV" role="3bR31x">
+          <node concept="3LXTmp" id="7nS6IN7MWDW" role="3rtmxm">
+            <node concept="3qWCbU" id="7nS6IN7MWDX" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7nS6IN7MWDY" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7nS6IN7MWDZ" role="iGT6I">
+                <property role="2Ry0Am" value="testing" />
+                <node concept="2Ry0Ak" id="7nS6IN7MWE0" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="7nS6IN7MWE1" role="2Ry0An">
+                    <property role="2Ry0Am" value="nl.f1re.testing.examples" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3UkPvdFivvr" role="3bR37C">
+          <node concept="3bR9La" id="3UkPvdFivvs" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="3OVhQEV5M2y" role="3989C9">
+      <property role="TrG5h" value="modellisteners" />
+      <node concept="1E1JtA" id="3OVhQEV5M2$" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="test.com.mbeddr.mpsutil.modellisteners" />
+        <property role="3LESm3" value="937290a7-392d-4ada-9fd7-7db3b348822b" />
+        <node concept="398BVA" id="3OVhQEV5M2A" role="3LF7KH">
+          <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+          <node concept="2Ry0Ak" id="3OVhQEV5M2E" role="iGT6I">
+            <property role="2Ry0Am" value="modellisteners" />
+            <node concept="2Ry0Ak" id="3OVhQEV5M2H" role="2Ry0An">
+              <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.modellisteners" />
+              <node concept="2Ry0Ak" id="3OVhQEV5M2K" role="2Ry0An">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.modellisteners.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="RC4$o90NDM" role="3bR37C">
+          <node concept="3bR9La" id="RC4$o90NDN" role="1SiIV1">
+            <ref role="3bR37D" node="4zIvKyx$aSl" resolve="com.mbeddr.mpsutil.modellisteners.sandboxlang" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="RC4$o90NE5" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="RC4$o90NE6" role="1HemKq">
+            <node concept="398BVA" id="RC4$o90NDO" role="3LXTmr">
+              <ref role="398BVh" node="4zIvKyx$aPF" resolve="modellisteners.home" />
+              <node concept="2Ry0Ak" id="RC4$o90NDP" role="iGT6I">
+                <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.modellisteners" />
+                <node concept="2Ry0Ak" id="RC4$o90NDQ" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="RC4$o90NE7" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="7nS6IN7MWE3" role="3bR31x">
+          <node concept="3LXTmp" id="7nS6IN7MWE4" role="3rtmxm">
+            <node concept="3qWCbU" id="7nS6IN7MWE5" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="7nS6IN7MWE6" role="3LXTmr">
+              <ref role="398BVh" node="PE3B26neqW" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="7nS6IN7MWE7" role="iGT6I">
+                <property role="2Ry0Am" value="modellisteners" />
+                <node concept="2Ry0Ak" id="7nS6IN7MWE8" role="2Ry0An">
+                  <property role="2Ry0Am" value="test.com.mbeddr.mpsutil.modellisteners" />
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/compare/languages/de.itemis.mps.compare/compare.mpl
+++ b/code/compare/languages/de.itemis.mps.compare/compare.mpl
@@ -85,7 +85,6 @@
         <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
         <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
         <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
-        <module reference="3dad2ab7-12ae-4079-9f64-da295f99ecf8(io.f1re.generation)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
@@ -103,6 +102,7 @@
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="3dad2ab7-12ae-4079-9f64-da295f99ecf8(nl.f1re.generation)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/code/compare/solutions/de.itemis.mps.comparator.diff.tests/de.itemis.mps.comparator.diff.tests.msd
+++ b/code/compare/solutions/de.itemis.mps.comparator.diff.tests/de.itemis.mps.comparator.diff.tests.msd
@@ -77,7 +77,6 @@
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="7037b32c-9607-4f8e-81bd-1f028a4c117b(de.slisson.mps.reflection.runtime)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
-    <module reference="3dad2ab7-12ae-4079-9f64-da295f99ecf8(io.f1re.generation)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
@@ -85,6 +84,7 @@
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="3dad2ab7-12ae-4079-9f64-da295f99ecf8(nl.f1re.generation)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/modellisteners/test.com.mbeddr.mpsutil.modellisteners/models/test.com.mbeddr.mpsutil.modellisteners@tests.mps
+++ b/code/modellisteners/test.com.mbeddr.mpsutil.modellisteners/models/test.com.mbeddr.mpsutil.modellisteners@tests.mps
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:a67a6614-4d97-4d53-ae02-f3b0d488ac12(test.com.mbeddr.mpsutil.modellisteners@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8" name="com.mbeddr.mpsutil.modellisteners.sandboxlang" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
+  </languages>
+  <imports>
+    <import index="64jm" ref="r:53fd5ad6-9dfd-4bea-bf25-c6cd1df32c73(com.mbeddr.mpsutil.modellisteners.sandboxlang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8" name="com.mbeddr.mpsutil.modellisteners.sandboxlang">
+      <concept id="5818559022137967770" name="com.mbeddr.mpsutil.modellisteners.sandboxlang.structure.RootConcept" flags="ng" index="j$yw0" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare">
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+    </language>
+  </registry>
+  <node concept="2XOHcx" id="5yvl18N8PtL">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="1lH9Xt" id="6cyqnzekvwz">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ModelListener" />
+    <node concept="1LZb2c" id="6cyqnzekvwE" role="1SL9yI">
+      <property role="TrG5h" value="child" />
+      <node concept="3cqZAl" id="6cyqnzekvwF" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzekvwJ" role="3clF47">
+        <node concept="3clFbF" id="6cyqnzekxcH" role="3cqZAp">
+          <node concept="2OqwBi" id="6cyqnzek$$r" role="3clFbG">
+            <node concept="2OqwBi" id="6cyqnzekxp5" role="2Oq$k0">
+              <node concept="3xONca" id="6cyqnzekxcG" role="2Oq$k0">
+                <ref role="3xOPvv" node="6cyqnzekxcB" resolve="root" />
+              </node>
+              <node concept="3Tsc0h" id="6cyqnzekxUC" role="2OqNvi">
+                <ref role="3TtcxE" to="64jm:52ZF9D3bos4" resolve="original" />
+              </node>
+            </node>
+            <node concept="WFELt" id="6cyqnzekBcH" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6cyqnzekCLJ" role="3cqZAp" />
+        <node concept="3GXo0L" id="6cyqnzekDrG" role="3cqZAp">
+          <node concept="2OqwBi" id="6cyqnzekGh_" role="3tpDZA">
+            <node concept="2OqwBi" id="6cyqnzekD$4" role="2Oq$k0">
+              <node concept="3xONca" id="6cyqnzekDrS" role="2Oq$k0">
+                <ref role="3xOPvv" node="6cyqnzekxcB" resolve="root" />
+              </node>
+              <node concept="3Tsc0h" id="6cyqnzekDMY" role="2OqNvi">
+                <ref role="3TtcxE" to="64jm:52ZF9D3bosa" resolve="mirror" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="6cyqnzekITV" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="6cyqnzekLHi" role="3tpDZB">
+            <node concept="2OqwBi" id="6cyqnzekJfj" role="2Oq$k0">
+              <node concept="3xONca" id="6cyqnzekJ5j" role="2Oq$k0">
+                <ref role="3xOPvv" node="6cyqnzekxcB" resolve="root" />
+              </node>
+              <node concept="3Tsc0h" id="6cyqnzekJv9" role="2OqNvi">
+                <ref role="3TtcxE" to="64jm:52ZF9D3bos4" resolve="original" />
+              </node>
+            </node>
+            <node concept="1uHKPH" id="6cyqnzekOm$" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6cyqnzekSax" role="3cqZAp" />
+        <node concept="3clFbF" id="6cyqnzekSaH" role="3cqZAp">
+          <node concept="2OqwBi" id="6cyqnzekUXb" role="3clFbG">
+            <node concept="2OqwBi" id="6cyqnzekSjL" role="2Oq$k0">
+              <node concept="3xONca" id="6cyqnzekSaF" role="2Oq$k0">
+                <ref role="3xOPvv" node="6cyqnzekxcB" resolve="root" />
+              </node>
+              <node concept="3Tsc0h" id="6cyqnzekSyB" role="2OqNvi">
+                <ref role="3TtcxE" to="64jm:52ZF9D3bos4" resolve="original" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="6cyqnzekX_t" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="6cyqnzekXNF" role="3cqZAp">
+          <node concept="3cmrfG" id="6cyqnzekXNV" role="3tpDZB">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="2OqwBi" id="6cyqnzel0PU" role="3tpDZA">
+            <node concept="2OqwBi" id="6cyqnzekYQ8" role="2Oq$k0">
+              <node concept="3xONca" id="6cyqnzekYJa" role="2Oq$k0">
+                <ref role="3xOPvv" node="6cyqnzekxcB" resolve="root" />
+              </node>
+              <node concept="3Tsc0h" id="6cyqnzekZ4Y" role="2OqNvi">
+                <ref role="3TtcxE" to="64jm:52ZF9D3bosa" resolve="mirror" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="6cyqnzel3wt" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6cyqnzekwsd" role="1SKRRt">
+      <node concept="j$yw0" id="6cyqnzekwsc" role="1qenE9">
+        <property role="TrG5h" value="Root" />
+        <node concept="3xLA65" id="6cyqnzekxcB" role="lGtFl">
+          <property role="TrG5h" value="root" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/modellisteners/test.com.mbeddr.mpsutil.modellisteners/test.com.mbeddr.mpsutil.modellisteners.msd
+++ b/code/modellisteners/test.com.mbeddr.mpsutil.modellisteners/test.com.mbeddr.mpsutil.modellisteners.msd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="test.com.mbeddr.mpsutil.modellisteners" uuid="937290a7-392d-4ada-9fd7-7db3b348822b" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+    <facet type="tests" />
+  </facets>
+  <dependencies>
+    <dependency reexport="false">4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8(com.mbeddr.mpsutil.modellisteners.sandboxlang)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8:com.mbeddr.mpsutil.modellisteners.sandboxlang" version="0" />
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="4cbe8d8b-9aa4-4342-8d1a-f3bcd858d0e8(com.mbeddr.mpsutil.modellisteners.sandboxlang)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="937290a7-392d-4ada-9fd7-7db3b348822b(test.com.mbeddr.mpsutil.modellisteners)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
+++ b/code/tables/solutions/test.de.slisson.mps.tables/models/test/de/slisson/mps/tables@tests.mps
@@ -7,6 +7,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="c6cfed73-685b-4891-8bdd-b38a1dcb107a" name="de.itemis.mps.structurecheck" version="0" />
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -28,15 +29,18 @@
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="3bri" ref="r:c386283f-4bfc-42ea-a1b4-65abe196bd30(de.slisson.mps.tables.runtime.plugin)" />
-    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
-    <import index="hro9" ref="r:f1c5f6f4-f735-4c95-8571-0c9b99e0bba3(de.slisson.mps.tables.demolang.plugin)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
-    <import index="cf47" ref="r:6b384ea8-f178-47ff-88f9-f7e02a20d230(de.slisson.mps.tables.demolang.behavior)" />
-    <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
-    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="2o4v" ref="r:2a70cba0-4dc5-4697-986d-5cba44622d22(de.itemis.mps.editor.diagram.runtime)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="sse1" ref="r:caea7020-da0a-4ba8-aff6-69334bbc9e02(de.slisson.mps.tables.runtime.simplegrid)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="hro9" ref="r:f1c5f6f4-f735-4c95-8571-0c9b99e0bba3(de.slisson.mps.tables.demolang.plugin)" />
+    <import index="9p8b" ref="r:2a738fcb-23b4-4d1d-9f52-870528559e28(de.slisson.mps.tables.runtime.selection)" />
+    <import index="cf47" ref="r:6b384ea8-f178-47ff-88f9-f7e02a20d230(de.slisson.mps.tables.demolang.behavior)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
@@ -92,6 +96,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -211,8 +216,29 @@
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c6cfed73-685b-4891-8bdd-b38a1dcb107a" name="de.itemis.mps.structurecheck">
+      <concept id="380240910834177326" name="de.itemis.mps.structurecheck.structure.CheckStructureStatement" flags="ng" index="64noQ">
+        <child id="380240910834179070" name="rootElement" index="64nzA" />
+        <child id="380240910835035233" name="checkers" index="68$XT" />
+      </concept>
+      <concept id="380240910834179924" name="de.itemis.mps.structurecheck.structure.SequenceChecker" flags="ng" index="64nLc">
+        <property id="380240910834182503" name="rule" index="64kDZ" />
+        <child id="380240910834182792" name="elements" index="64kAg" />
+        <child id="380240910834180011" name="sequence" index="64nMN" />
+      </concept>
+      <concept id="380240910834210697" name="de.itemis.mps.structurecheck.structure.Element" flags="ng" index="67Jih">
+        <child id="380240910834213223" name="subtype" index="67G9Z" />
+        <child id="380240910834213011" name="multiplier" index="67Geb" />
+        <child id="380240910835034893" name="checkers" index="68$wl" />
+      </concept>
+      <concept id="380240910835034706" name="de.itemis.mps.structurecheck.structure.CompositeChecker" flags="ng" index="68$_a">
+        <child id="380240910835034746" name="checkers" index="68$_y" />
       </concept>
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
@@ -256,6 +282,19 @@
       <concept id="1397920687865457012" name="de.slisson.mps.tables.demolang.structure.RefinesRel" flags="ng" index="2r1o01">
         <reference id="1397920687865457016" name="req" index="2r1o0d" />
       </concept>
+      <concept id="1397920687865838585" name="de.slisson.mps.tables.demolang.structure.Variable" flags="ng" index="2r3Xac" />
+      <concept id="1397920687865838470" name="de.slisson.mps.tables.demolang.structure.Rule" flags="ng" index="2r3XbN">
+        <child id="1397920687865838589" name="variables" index="2r3Xa8" />
+      </concept>
+      <concept id="1397920687865838768" name="de.slisson.mps.tables.demolang.structure.TestSuite" flags="ng" index="2r3Xn5">
+        <reference id="1397920687865838781" name="rule" index="2r3Xn8" />
+        <child id="1397920687865838778" name="tests" index="2r3Xnf" />
+      </concept>
+      <concept id="1397920687865838777" name="de.slisson.mps.tables.demolang.structure.TestCase" flags="ng" index="2r3Xnc">
+        <child id="1397920687865838797" name="actual" index="2r3XmS" />
+        <child id="1397920687865838792" name="expected" index="2r3XmX" />
+        <child id="934534792594025995" name="values" index="1adOLU" />
+      </concept>
       <concept id="1397920687866915007" name="de.slisson.mps.tables.demolang.structure.Transition" flags="ng" index="2r747a">
         <reference id="1397920687866915092" name="from" index="2r741x" />
         <reference id="1397920687866915099" name="to" index="2r741I" />
@@ -270,6 +309,10 @@
       </concept>
       <concept id="7869003205683674568" name="de.slisson.mps.tables.demolang.structure.BaseConceptComment" flags="ng" index="A6MPL">
         <property id="7869003205684092902" name="comment" index="A0oXv" />
+      </concept>
+      <concept id="934534792593989294" name="de.slisson.mps.tables.demolang.structure.VariableValue" flags="ng" index="1adJNv">
+        <reference id="934534792594006923" name="variable" index="1adK7U" />
+        <child id="934534792594006925" name="value" index="1adK7W" />
       </concept>
       <concept id="4618647476138240641" name="de.slisson.mps.tables.demolang.structure.DecisionTableResult" flags="ng" index="3HSt7D">
         <reference id="4618647476138240642" name="xExpression" index="3HSt7E" />
@@ -314,6 +357,13 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -2884,6 +2934,373 @@
           <node concept="2r1o01" id="2WnHFkwZiR" role="2r1o1s">
             <ref role="2r1o0d" node="2WnHFkwZiO" />
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6cyqnzdnrmr">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="TableStructure" />
+    <node concept="1LZb2c" id="6cyqnzdntIo" role="1SL9yI">
+      <property role="TrG5h" value="table" />
+      <node concept="3cqZAl" id="6cyqnzdntIp" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzdntIt" role="3clF47">
+        <node concept="3cpWs8" id="6cyqnzdnusI" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzdnusJ" role="3cpWs9">
+            <property role="TrG5h" value="editorComponent" />
+            <node concept="3uibUv" id="6cyqnzdnusK" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="6cyqnzdnuun" role="33vP2m">
+              <node concept="1pGfFk" id="6cyqnzdnuEV" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                <node concept="2OqwBi" id="6cyqnzdnvha" role="37wK5m">
+                  <node concept="1jxXqW" id="6cyqnzdnuFq" role="2Oq$k0" />
+                  <node concept="liA8E" id="6cyqnzdnvWw" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6cyqnzdnw74" role="3cqZAp">
+          <node concept="2OqwBi" id="6cyqnzdnxwf" role="3clFbG">
+            <node concept="37vLTw" id="6cyqnzdnw72" role="2Oq$k0">
+              <ref role="3cqZAo" node="6cyqnzdnusJ" resolve="editorComponent" />
+            </node>
+            <node concept="liA8E" id="6cyqnzdnz87" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="3xONca" id="6cyqnzdnz9r" role="37wK5m">
+                <ref role="3xOPvv" node="6cyqnzdntGW" resolve="table" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="6cyqnzdvcMB" role="3cqZAp">
+          <node concept="1PaTwC" id="6cyqnzdvcMC" role="1aUNEU">
+            <node concept="3oM_SD" id="6cyqnzdvcVd" role="1PaTwD">
+              <property role="3oM_SC" value="To" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVe" role="1PaTwD">
+              <property role="3oM_SC" value="get" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVf" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVg" role="1PaTwD">
+              <property role="3oM_SC" value="number" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVh" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVi" role="1PaTwD">
+              <property role="3oM_SC" value="elements" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVj" role="1PaTwD">
+              <property role="3oM_SC" value="per" />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVk" role="1PaTwD">
+              <property role="3oM_SC" value="class," />
+            </node>
+            <node concept="3oM_SD" id="6cyqnzdvcVl" role="1PaTwD">
+              <property role="3oM_SC" value="use:" />
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="6cyqnzdvkbP" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3cpWs8" id="6cyqnzduYZ7" role="8Wnug">
+            <node concept="3cpWsn" id="6cyqnzduYZ8" role="3cpWs9">
+              <property role="TrG5h" value="descendantCells" />
+              <node concept="3uibUv" id="6cyqnzduYSi" role="1tU5fm">
+                <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                <node concept="3uibUv" id="6cyqnzduYSl" role="11_B2D">
+                  <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="6cyqnzduYZ9" role="33vP2m">
+                <ref role="37wK5l" to="2o4v:1sJnak6wM46" resolve="descendants" />
+                <ref role="1Pybhc" to="2o4v:1sJnak6wM3n" resolve="EditorUtil" />
+                <node concept="2OqwBi" id="6cyqnzduYZa" role="37wK5m">
+                  <node concept="37vLTw" id="6cyqnzduYZb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6cyqnzdnusJ" resolve="editorComponent" />
+                  </node>
+                  <node concept="liA8E" id="6cyqnzduYZc" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                  </node>
+                </node>
+                <node concept="3VsKOn" id="6cyqnzduYZd" role="37wK5m">
+                  <ref role="3VsUkX" to="g51k:~EditorCell" resolve="EditorCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="6cyqnzdvcuX" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="6cyqnzduZpr" role="8Wnug">
+            <node concept="2OqwBi" id="6cyqnzdv2$Y" role="3clFbG">
+              <node concept="2OqwBi" id="6cyqnzdv0xd" role="2Oq$k0">
+                <node concept="37vLTw" id="6cyqnzduZpp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6cyqnzduYZ8" resolve="descendantCells" />
+                </node>
+                <node concept="liA8E" id="6cyqnzdv21G" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6cyqnzdv3_R" role="2OqNvi">
+                <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                <node concept="2YIFZM" id="6cyqnzdv4EJ" role="37wK5m">
+                  <ref role="37wK5l" to="1ctc:~Collectors.groupingBy(java.util.function.Function,java.util.stream.Collector)" resolve="groupingBy" />
+                  <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                  <node concept="1bVj0M" id="6cyqnzdv52c" role="37wK5m">
+                    <node concept="gl6BB" id="6cyqnzdv52v" role="1bW2Oz">
+                      <property role="TrG5h" value="o" />
+                      <node concept="2jxLKc" id="6cyqnzdv52w" role="1tU5fm" />
+                    </node>
+                    <node concept="3clFbS" id="6cyqnzdv52x" role="1bW5cS">
+                      <node concept="3clFbF" id="6cyqnzdv5Ru" role="3cqZAp">
+                        <node concept="2OqwBi" id="6cyqnzdv8ju" role="3clFbG">
+                          <node concept="2OqwBi" id="6cyqnzdv6it" role="2Oq$k0">
+                            <node concept="37vLTw" id="6cyqnzdv5Rt" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6cyqnzdv52v" resolve="o" />
+                            </node>
+                            <node concept="liA8E" id="6cyqnzdv74x" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="6cyqnzdvaj6" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="6cyqnzdvbJb" role="37wK5m">
+                    <ref role="37wK5l" to="1ctc:~Collectors.counting()" resolve="counting" />
+                    <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6cyqnzdzeFi" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzdzeFj" role="3cpWs9">
+            <property role="TrG5h" value="descendants" />
+            <node concept="3uibUv" id="6cyqnzdyYrH" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="6cyqnzdyYrK" role="11_B2D">
+                <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="6cyqnzdzeFk" role="33vP2m">
+              <ref role="37wK5l" to="2o4v:1sJnak6wM46" resolve="descendants" />
+              <ref role="1Pybhc" to="2o4v:1sJnak6wM3n" resolve="EditorUtil" />
+              <node concept="2OqwBi" id="6cyqnzdzrdu" role="37wK5m">
+                <node concept="37vLTw" id="6cyqnzdzrdv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6cyqnzdnusJ" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="6cyqnzdzrdw" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                </node>
+              </node>
+              <node concept="3VsKOn" id="6cyqnzdzeFm" role="37wK5m">
+                <ref role="3VsUkX" to="g51k:~EditorCell" resolve="EditorCell" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="64noQ" id="6cyqnzdnzEy" role="3cqZAp">
+          <node concept="68$_a" id="6cyqnzdnzEA" role="68$XT">
+            <node concept="64nLc" id="6cyqnzdvhDx" role="68$_y">
+              <property role="64kDZ" value="l6SLw3lU$s/allOrMore" />
+              <node concept="67Jih" id="6cyqnzdnBFs" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdnBFt" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdnBQf" role="67G9Z">
+                  <ref role="3uigEE" to="hm5v:20OswHE0eA6" resolve="EditorCell_GridCell" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzdvcVm" role="67Geb">
+                  <property role="3cmrfH" value="31" />
+                </node>
+              </node>
+              <node concept="67Jih" id="6cyqnzdvp4e" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdvp4f" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdvp4g" role="67G9Z">
+                  <ref role="3uigEE" to="hm5v:1dAqnm8$zBn" resolve="TableEditor" />
+                </node>
+              </node>
+              <node concept="67Jih" id="6cyqnzdvmLn" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdvmLo" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdvmLp" role="67G9Z">
+                  <ref role="3uigEE" to="hm5v:4db20qfqb8U" resolve="RowEndCell" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzdvmLq" role="67Geb">
+                  <property role="3cmrfH" value="6" />
+                </node>
+              </node>
+              <node concept="67Jih" id="6cyqnzdvqKC" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdvqKD" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdvqKE" role="67G9Z">
+                  <ref role="3uigEE" to="hm5v:2Jt5bYCPbd1" resolve="PartialTableEditor" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzdvqW9" role="67Geb">
+                  <property role="3cmrfH" value="3" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="6cyqnzdzeFn" role="64nMN">
+                <ref role="3cqZAo" node="6cyqnzdzeFj" resolve="descendants" />
+              </node>
+            </node>
+            <node concept="64nLc" id="6cyqnzdzhf2" role="68$_y">
+              <property role="64kDZ" value="l6SLw3lU$s/allOrMore" />
+              <node concept="67Jih" id="6cyqnzdzhfd" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdzhfe" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdzhff" role="67G9Z">
+                  <ref role="3uigEE" to="g51k:~EditorCell_Property" resolve="EditorCell_Property" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzd$8wl" role="67Geb">
+                  <property role="3cmrfH" value="19" />
+                </node>
+              </node>
+              <node concept="67Jih" id="6cyqnzdzhfl" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdzhfm" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdzhfn" role="67G9Z">
+                  <ref role="3uigEE" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzdzhfo" role="67Geb">
+                  <property role="3cmrfH" value="10" />
+                </node>
+              </node>
+              <node concept="67Jih" id="6cyqnzdzhf8" role="64kAg">
+                <node concept="68$_a" id="6cyqnzdzhf9" role="68$wl" />
+                <node concept="3uibUv" id="6cyqnzdzhfa" role="67G9Z">
+                  <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                </node>
+                <node concept="3cmrfG" id="6cyqnzdzhfb" role="67Geb">
+                  <property role="3cmrfH" value="36" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="6cyqnzdzhfy" role="64nMN">
+                <ref role="3cqZAo" node="6cyqnzdzeFj" resolve="descendants" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6cyqnzdvfUX" role="64nzA">
+            <node concept="37vLTw" id="6cyqnzduYZe" role="2Oq$k0">
+              <ref role="3cqZAo" node="6cyqnzdnusJ" resolve="editorComponent" />
+            </node>
+            <node concept="liA8E" id="6cyqnzdvh_z" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6cyqnzdnsw0" role="1SKRRt">
+      <node concept="2r3XbN" id="6cyqnzdnsw2" role="1qenE9">
+        <property role="TrG5h" value="Rule" />
+        <node concept="2r3Xac" id="6cyqnzdnsw3" role="2r3Xa8">
+          <property role="TrG5h" value="A" />
+        </node>
+        <node concept="2r3Xac" id="6cyqnzdnsw4" role="2r3Xa8">
+          <property role="TrG5h" value="B" />
+        </node>
+        <node concept="2r3Xac" id="6cyqnzdnsw5" role="2r3Xa8">
+          <property role="TrG5h" value="C" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6cyqnzdnspH" role="1SKRRt">
+      <node concept="2r3Xn5" id="6cyqnzdnspG" role="1qenE9">
+        <ref role="2r3Xn8" node="6cyqnzdnsw2" resolve="Rule" />
+        <node concept="2r3Xnc" id="6cyqnzdnsw6" role="2r3Xnf">
+          <property role="TrG5h" value="1" />
+          <node concept="3cmrfG" id="6cyqnzdnsOm" role="2r3XmX">
+            <property role="3cmrfH" value="4" />
+          </node>
+          <node concept="3cmrfG" id="6cyqnzdnsOG" role="2r3XmS">
+            <property role="3cmrfH" value="5" />
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsGL" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw3" resolve="A" />
+            <node concept="3cmrfG" id="6cyqnzdnsGK" role="1adK7W">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsNb" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw4" resolve="B" />
+            <node concept="3cmrfG" id="6cyqnzdnsNa" role="1adK7W">
+              <property role="3cmrfH" value="2" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsNp" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw5" resolve="C" />
+            <node concept="3cmrfG" id="6cyqnzdnsNo" role="1adK7W">
+              <property role="3cmrfH" value="3" />
+            </node>
+          </node>
+        </node>
+        <node concept="2r3Xnc" id="6cyqnzdnswa" role="2r3Xnf">
+          <property role="TrG5h" value="2" />
+          <node concept="1adJNv" id="6cyqnzdnsNH" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw3" resolve="A" />
+            <node concept="3cmrfG" id="6cyqnzdnsNG" role="1adK7W">
+              <property role="3cmrfH" value="6" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsNP" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw4" resolve="B" />
+            <node concept="3cmrfG" id="6cyqnzdnsNO" role="1adK7W">
+              <property role="3cmrfH" value="7" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsO3" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw5" resolve="C" />
+            <node concept="3cmrfG" id="6cyqnzdnsO2" role="1adK7W">
+              <property role="3cmrfH" value="8" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="6cyqnzdnsPS" role="2r3XmX">
+            <property role="3cmrfH" value="9" />
+          </node>
+          <node concept="3cmrfG" id="6cyqnzdnsQe" role="2r3XmS">
+            <property role="3cmrfH" value="10" />
+          </node>
+        </node>
+        <node concept="2r3Xnc" id="6cyqnzdnswb" role="2r3Xnf">
+          <property role="TrG5h" value="3" />
+          <node concept="1adJNv" id="6cyqnzdnsRl" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw3" resolve="A" />
+            <node concept="3cmrfG" id="6cyqnzdnsRk" role="1adK7W">
+              <property role="3cmrfH" value="11" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsRz" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw4" resolve="B" />
+            <node concept="3cmrfG" id="6cyqnzdnsRy" role="1adK7W">
+              <property role="3cmrfH" value="12" />
+            </node>
+          </node>
+          <node concept="1adJNv" id="6cyqnzdnsRL" role="1adOLU">
+            <ref role="1adK7U" node="6cyqnzdnsw5" resolve="C" />
+            <node concept="3cmrfG" id="6cyqnzdnsRK" role="1adK7W">
+              <property role="3cmrfH" value="13" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="6cyqnzdnsS4" role="2r3XmX">
+            <property role="3cmrfH" value="14" />
+          </node>
+          <node concept="3cmrfG" id="6cyqnzdnsSt" role="2r3XmS">
+            <property role="3cmrfH" value="15" />
+          </node>
+        </node>
+        <node concept="3xLA65" id="6cyqnzdntGW" role="lGtFl">
+          <property role="TrG5h" value="table" />
         </node>
       </node>
     </node>

--- a/code/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd
+++ b/code/tables/solutions/test.de.slisson.mps.tables/test.de.slisson.mps.tables.msd
@@ -18,9 +18,11 @@
     <dependency reexport="false">2d56439e-634d-4d25-9d30-963e89ecda48(de.slisson.mps.tables.demolang)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
+    <language slang="l:c6cfed73-685b-4891-8bdd-b38a1dcb107a:de.itemis.mps.structurecheck" version="0" />
     <language slang="l:2d56439e-634d-4d25-9d30-963e89ecda48:de.slisson.mps.tables.demolang" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
@@ -44,7 +46,12 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="7b45fa94-2707-4a1a-9e6a-ce40c4aaf35a(de.itemis.mps.editor.collapsible.runtime)" version="0" />
+    <module reference="1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)" version="0" />
+    <module reference="56c81845-acaf-48a7-bcd8-e29b36c98dd7(de.itemis.mps.editor.diagram.styles)" version="0" />
+    <module reference="5c13c612-0f7b-4f0a-ab8b-565186b418de(de.itemis.mps.mouselistener.runtime)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="0022e9df-2136-4ef8-81b2-08650aeb1dc7(de.itemis.mps.tooltips.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="2d56439e-634d-4d25-9d30-963e89ecda48(de.slisson.mps.tables.demolang)" version="0" />
     <module reference="da21218f-a674-474d-8b4e-d59e33007003(de.slisson.mps.tables.runtime)" version="0" />

--- a/code/testing/languages/nl.f1re.testing.examples.lang/generator/templates/nl.f1re.testing.examples.lang.generator.templates@generator.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/generator/templates/nl.f1re.testing.examples.lang.generator.templates@generator.mps
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:51ea6447-c236-4d61-a445-6e90b0ad3144(nl.f1re.testing.examples.lang.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="jv43" ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="4GRmlIZP23b">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.behavior.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8d8984b6-c339-4468-b09e-3f05d852d5fc(nl.f1re.testing.examples.lang.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.constraints.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.constraints.mps
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:020d0993-eabc-4e71-8e42-6e37f9bc3cac(nl.f1re.testing.examples.lang.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.editor.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.editor.mps
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:241d801e-1003-46f0-9785-1157a06b80af(nl.f1re.testing.examples.lang.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="0" />
+    <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="jv43" ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor">
+      <concept id="2877762237606985499" name="de.slisson.mps.conditionalEditor.structure.EditorCondition" flags="ig" index="RtMap" />
+      <concept id="2877762237606934069" name="de.slisson.mps.conditionalEditor.structure.ConditionalConceptEditorDeclaration" flags="ig" index="RtYIR">
+        <property id="2877762237607078183" name="priority" index="Rtri_" />
+        <property id="8436908933892732653" name="uniqueName" index="3NULOk" />
+        <child id="2877762237607015161" name="condition" index="RtEXV" />
+      </concept>
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
+        <child id="1140524464360" name="cellLayout" index="2czzBx" />
+      </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="8383079901754291618" name="jetbrains.mps.lang.editor.structure.CellModel_NextEditor" flags="ng" index="B$lHz" />
+      <concept id="7250830207897895674" name="jetbrains.mps.lang.editor.structure.CompletionCustomizationContextSpecificator_Concept" flags="ng" index="KNhPi">
+        <reference id="9115396979021131941" name="conceptDeclaration" index="2RIln$" />
+      </concept>
+      <concept id="7250830207897895678" name="jetbrains.mps.lang.editor.structure.CompletionCustomizationConceptCreatingSpecificator" flags="ng" index="KNhPm" />
+      <concept id="7818019076292260194" name="jetbrains.mps.lang.editor.structure.CompletionStyling" flags="ig" index="3dRTYf">
+        <child id="7250830207897909099" name="specificator" index="KNiz3" />
+        <child id="772883491827840107" name="customizeFunction" index="3l$a4r" />
+      </concept>
+      <concept id="1103016434866" name="jetbrains.mps.lang.editor.structure.CellModel_JComponent" flags="sg" stub="8104358048506731196" index="3gTLQM">
+        <child id="1176475119347" name="componentProvider" index="3FoqZy" />
+      </concept>
+      <concept id="772883491827578824" name="jetbrains.mps.lang.editor.structure.CompletionCustomization_CustomizeFunction" flags="ig" index="3lBaaS" />
+      <concept id="772883491827671446" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameterCustomize_Style" flags="ng" index="3lBNjA" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
+      <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
+        <child id="1225898971709" name="getter" index="1Hhtcw" />
+      </concept>
+      <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
+        <child id="1225900141900" name="modelAccessor" index="1HlULh" />
+      </concept>
+      <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell">
+      <concept id="1161622981231" name="de.slisson.mps.richtext.customcell.structure.ConceptFunctionParameter_cell" flags="nn" index="1Q80Hx" />
+      <concept id="1176749715029" name="de.slisson.mps.richtext.customcell.structure.QueryFunction_Cell" flags="in" index="3VJUX4" />
+      <concept id="2490242408670732052" name="de.slisson.mps.richtext.customcell.structure.CellModel_CustomFactory" flags="ng" index="3ZSo5i">
+        <child id="1073389446424" name="childCellModel" index="3EZMny" />
+        <child id="2490242408670937967" name="factoryMethod" index="3ZZHOD" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips">
+      <concept id="1285659875393567816" name="jetbrains.mps.lang.editor.tooltips.structure.CellModel_Tooltip" flags="ng" index="1v6uyg">
+        <property id="4804083432920625643" name="lazy" index="2oejA6" />
+        <child id="3877544518697818164" name="tooltipCell" index="wsdo6" />
+        <child id="9185659875393569181" name="visibleCell" index="1j7Clw" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="4GRmlIZP$ux">
+    <ref role="1XX52x" to="jv43:4GRmlIZP2B3" resolve="BrokenEditor" />
+    <node concept="1HlG4h" id="4GRmlIZP$uz" role="2wV5jI">
+      <node concept="1HfYo3" id="4GRmlIZP$u_" role="1HlULh">
+        <node concept="3TQlhw" id="4GRmlIZP$uB" role="1Hhtcw">
+          <node concept="3clFbS" id="4GRmlIZP$uD" role="2VODD2">
+            <node concept="3clFbJ" id="4GRmlIZQpli" role="3cqZAp">
+              <node concept="3clFbS" id="4GRmlIZQplk" role="3clFbx">
+                <node concept="3cpWs8" id="4GRmlIZP$IR" role="3cqZAp">
+                  <node concept="3cpWsn" id="4GRmlIZP$IS" role="3cpWs9">
+                    <property role="TrG5h" value="nullObj" />
+                    <node concept="3uibUv" id="4GRmlIZP$IT" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="10Nm6u" id="4GRmlIZP$Lp" role="33vP2m" />
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="4GRmlIZQq8R" role="3cqZAp">
+                  <node concept="2OqwBi" id="4GRmlIZP_pp" role="3cqZAk">
+                    <node concept="37vLTw" id="4GRmlIZP_jx" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4GRmlIZP$IS" resolve="nullObj" />
+                    </node>
+                    <node concept="liA8E" id="4GRmlIZP_HI" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4GRmlIZQpQT" role="3clFbw">
+                <node concept="pncrf" id="4GRmlIZQpmz" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4GRmlIZQq3b" role="2OqNvi">
+                  <ref role="3TsBF5" to="jv43:4GRmlIZQoXl" resolve="break" />
+                </node>
+              </node>
+              <node concept="9aQIb" id="4GRmlIZQqao" role="9aQIa">
+                <node concept="3clFbS" id="4GRmlIZQqap" role="9aQI4">
+                  <node concept="3cpWs6" id="4GRmlIZQqbw" role="3cqZAp">
+                    <node concept="Xl_RD" id="4GRmlIZQqbA" role="3cqZAk">
+                      <property role="Xl_RC" value="not broken" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2$zHkrOzIiP">
+    <ref role="1XX52x" to="jv43:2$zHkrOzI0U" resolve="Readme" />
+    <node concept="3F1sOY" id="2$zHkrOzIj9" role="2wV5jI">
+      <ref role="1NtTu8" to="jv43:2$zHkrOzI1d" resolve="text" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2$zHkrO_0E8">
+    <ref role="1XX52x" to="jv43:2$zHkrO_0E7" resolve="NodeWithToolTip" />
+    <node concept="1v6uyg" id="2$zHkrO_0Ea" role="2wV5jI">
+      <property role="2oejA6" value="true" />
+      <node concept="3F0ifn" id="2$zHkrO_0Ei" role="wsdo6">
+        <property role="3F0ifm" value="Tooltip" />
+      </node>
+      <node concept="3F0ifn" id="2$zHkrO_0Eg" role="1j7Clw">
+        <property role="3F0ifm" value="Node" />
+      </node>
+    </node>
+  </node>
+  <node concept="RtYIR" id="1LcZBjPDvKZ">
+    <property role="Rtri_" value="100" />
+    <property role="3NULOk" value="ConditionalEditor" />
+    <ref role="1XX52x" to="jv43:1LcZBjPDr3g" resolve="ConditionalEditor" />
+    <node concept="RtMap" id="1LcZBjPDvL0" role="RtEXV">
+      <node concept="3clFbS" id="1LcZBjPDvL1" role="2VODD2">
+        <node concept="3clFbF" id="1LcZBjPDH2Z" role="3cqZAp">
+          <node concept="3clFbT" id="1LcZBjPDH2Y" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3ZSo5i" id="1LcZBjPDy9$" role="2wV5jI">
+      <node concept="B$lHz" id="1LcZBjPDy9F" role="3EZMny" />
+      <node concept="3VJUX4" id="1LcZBjPDy9H" role="3ZZHOD">
+        <node concept="3clFbS" id="1LcZBjPDy9I" role="2VODD2">
+          <node concept="3clFbF" id="1LcZBjPDyf1" role="3cqZAp">
+            <node concept="2OqwBi" id="1LcZBjPDyo6" role="3clFbG">
+              <node concept="1Q80Hx" id="1LcZBjPDyf0" role="2Oq$k0" />
+              <node concept="liA8E" id="1LcZBjPDyw9" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+                <node concept="Xl_RD" id="1LcZBjPDyzu" role="37wK5m">
+                  <property role="Xl_RC" value="conditionalEditor" />
+                </node>
+                <node concept="10M0yZ" id="1LcZBjPDyQo" role="37wK5m">
+                  <ref role="3cqZAo" to="wyt6:~Boolean.TRUE" resolve="TRUE" />
+                  <ref role="1PxDUh" to="wyt6:~Boolean" resolve="Boolean" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1LcZBjPDyTm" role="3cqZAp">
+            <node concept="1Q80Hx" id="1LcZBjPDyTl" role="3clFbG" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5yhCTaaqx9E">
+    <ref role="1XX52x" to="jv43:5yhCTaaqx9C" resolve="CompletionStylingExample" />
+    <node concept="3F2HdR" id="5yhCTaaqAXX" role="2wV5jI">
+      <ref role="1NtTu8" to="jv43:5yhCTaaqxa1" resolve="stylings" />
+      <node concept="2iRkQZ" id="5yhCTaaqAXZ" role="2czzBx" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5yhCTaaqx9Q">
+    <ref role="1XX52x" to="jv43:5yhCTaaqx9O" resolve="CompletionStyling" />
+    <node concept="3EZMnI" id="5yhCTaaqx9W" role="2wV5jI">
+      <node concept="2iRfu4" id="5yhCTaaqx9X" role="2iSdaV" />
+      <node concept="3F0ifn" id="5yhCTaaqx9U" role="3EZMnx">
+        <property role="3F0ifm" value="completion styling" />
+      </node>
+      <node concept="3F0A7n" id="5yhCTaaqx9Z" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+    </node>
+  </node>
+  <node concept="3dRTYf" id="5yhCTaaqxa2">
+    <property role="TrG5h" value="CompletionStyling" />
+    <node concept="3Tm1VV" id="5yhCTaaqxa3" role="1B3o_S" />
+    <node concept="KNhPm" id="5yhCTaaqxaJ" role="KNiz3">
+      <ref role="2RIln$" to="jv43:5yhCTaaqx9O" resolve="CompletionStyling" />
+    </node>
+    <node concept="3lBaaS" id="5yhCTaaqxa5" role="3l$a4r">
+      <node concept="3clFbS" id="5yhCTaaqxa6" role="2VODD2">
+        <node concept="3clFbF" id="5yhCTaaqxbc" role="3cqZAp">
+          <node concept="2OqwBi" id="5yhCTaaqxiK" role="3clFbG">
+            <node concept="3lBNjA" id="5yhCTaaqxbb" role="2Oq$k0" />
+            <node concept="liA8E" id="5yhCTaaqxqC" role="2OqNvi">
+              <ref role="37wK5l" to="av1m:~EditorMenuItemStyle.setBold()" resolve="setBold" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5T$OTctiKmY">
+    <ref role="1XX52x" to="jv43:5T$OTctiifk" resolve="SlowEditor" />
+    <node concept="3EZMnI" id="5T$OTctiKn9" role="2wV5jI">
+      <node concept="2iRkQZ" id="5T$OTctiKna" role="2iSdaV" />
+      <node concept="3EZMnI" id="5T$OTctiKn4" role="3EZMnx">
+        <node concept="2iRfu4" id="5T$OTctiKn5" role="2iSdaV" />
+        <node concept="3F0ifn" id="5T$OTctiKn2" role="3EZMnx">
+          <property role="3F0ifm" value="slow mode" />
+        </node>
+        <node concept="3F0A7n" id="5T$OTctiKn7" role="3EZMnx">
+          <ref role="1NtTu8" to="jv43:5T$OTctiKmX" resolve="slowMode" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="5T$OTctiKnb" role="3EZMnx" />
+      <node concept="3gTLQM" id="5T$OTctiKnd" role="3EZMnx">
+        <node concept="3Fmcul" id="5T$OTctiKnf" role="3FoqZy">
+          <node concept="3clFbS" id="5T$OTctiKnh" role="2VODD2">
+            <node concept="3J1_TO" id="5T$OTctiMek" role="3cqZAp">
+              <node concept="3uVAMA" id="5T$OTctiMfg" role="1zxBo5">
+                <node concept="XOnhg" id="5T$OTctiMfh" role="1zc67B">
+                  <property role="TrG5h" value="e" />
+                  <node concept="nSUau" id="5T$OTctiMfi" role="1tU5fm">
+                    <node concept="3uibUv" id="5T$OTctiMgc" role="nSUat">
+                      <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="5T$OTctiMfj" role="1zc67A" />
+              </node>
+              <node concept="3clFbS" id="5T$OTctiMem" role="1zxBo7">
+                <node concept="3clFbF" id="5T$OTctiLjy" role="3cqZAp">
+                  <node concept="2YIFZM" id="5T$OTctiLzv" role="3clFbG">
+                    <ref role="37wK5l" to="wyt6:~Thread.sleep(long)" resolve="sleep" />
+                    <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
+                    <node concept="3cmrfG" id="5T$OTctiL$k" role="37wK5m">
+                      <property role="3cmrfH" value="10000" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5T$OTctiKIJ" role="3cqZAp">
+              <node concept="2ShNRf" id="5T$OTctiKIB" role="3clFbG">
+                <node concept="1pGfFk" id="5T$OTctiL38" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                  <node concept="Xl_RD" id="5T$OTctiTw7" role="37wK5m">
+                    <property role="Xl_RC" value="label" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="pkWqt" id="4k0nQshfg4q" role="pqm2j">
+        <node concept="3clFbS" id="4k0nQshfg4r" role="2VODD2">
+          <node concept="3clFbF" id="4k0nQshfgpS" role="3cqZAp">
+            <node concept="3clFbT" id="4k0nQshfgpR" role="3clFbG" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.intentions.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.intentions.mps
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:3e4fd42b-cb29-4878-b9d5-a8ab809a2520(nl.f1re.testing.examples.lang.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="2$zHkrOxF0o">
+    <property role="TrG5h" value="ClassConceptNewName" />
+    <ref role="2ZfgGC" to="tpee:fz12cDA" resolve="ClassConcept" />
+    <node concept="2S6ZIM" id="2$zHkrOxF0p" role="2ZfVej">
+      <node concept="3clFbS" id="2$zHkrOxF0q" role="2VODD2">
+        <node concept="3clFbF" id="2$zHkrOxFVG" role="3cqZAp">
+          <node concept="Xl_RD" id="2$zHkrOxFVF" role="3clFbG">
+            <property role="Xl_RC" value="New Name for Class" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="2$zHkrOxF0r" role="2ZfgGD">
+      <node concept="3clFbS" id="2$zHkrOxF0s" role="2VODD2">
+        <node concept="3clFbF" id="2$zHkrOxGdl" role="3cqZAp">
+          <node concept="37vLTI" id="2$zHkrOxIRz" role="3clFbG">
+            <node concept="Xl_RD" id="2$zHkrOxIRQ" role="37vLTx">
+              <property role="Xl_RC" value="NewName" />
+            </node>
+            <node concept="2OqwBi" id="2$zHkrOxGEY" role="37vLTJ">
+              <node concept="2Sf5sV" id="2$zHkrOxGdk" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2$zHkrOxHy1" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.structure.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.structure.mps
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="4GRmlIZP2B3">
+    <property role="EcuMT" value="5419898927158929859" />
+    <property role="TrG5h" value="BrokenEditor" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="4GRmlIZQoXl" role="1TKVEl">
+      <property role="IQ2nx" value="5419898927159283541" />
+      <property role="TrG5h" value="break" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2$zHkrOzI0U">
+    <property role="EcuMT" value="2964412296095260730" />
+    <property role="TrG5h" value="Readme" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="2$zHkrOzI1d" role="1TKVEi">
+      <property role="IQ2ns" value="2964412296095260749" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="text" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="zqge:2cLqkTm6vgh" resolve="Text" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2$zHkrO_0E7">
+    <property role="EcuMT" value="2964412296095599239" />
+    <property role="TrG5h" value="NodeWithToolTip" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
+  <node concept="1TIwiD" id="1LcZBjPDr3g">
+    <property role="EcuMT" value="2039284509582930128" />
+    <property role="TrG5h" value="ConditionalEditor" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
+  <node concept="1TIwiD" id="5yhCTaaqx9C">
+    <property role="EcuMT" value="6382061996743463528" />
+    <property role="TrG5h" value="CompletionStylingExample" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="5yhCTaaqxa1" role="1TKVEi">
+      <property role="IQ2ns" value="6382061996743463553" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="stylings" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="5yhCTaaqx9O" resolve="CompletionStyling" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5yhCTaaqx9O">
+    <property role="EcuMT" value="6382061996743463540" />
+    <property role="TrG5h" value="CompletionStyling" />
+    <property role="34LRSv" value="cs" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="5yhCTaaqx9P" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5yhCTaasJqs">
+    <property role="EcuMT" value="6382061996744046236" />
+    <property role="TrG5h" value="VCSCustomization" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
+  <node concept="1TIwiD" id="5T$OTctiifk">
+    <property role="EcuMT" value="6801793966041277396" />
+    <property role="TrG5h" value="SlowEditor" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="5T$OTctiKmX" role="1TKVEl">
+      <property role="IQ2nx" value="6801793966041400765" />
+      <property role="TrG5h" value="slowMode" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.typesystem.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.typesystem.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e270c895-b933-4c48-9ede-d18ec2625856(nl.f1re.testing.examples.lang.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.vcs.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.vcs.mps
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:cc12e372-37ad-4855-8e5e-7c3571abcb72(nl.f1re.testing.examples.lang.vcs)">
+  <persistence version="9" />
+  <languages>
+    <use id="37e03aa1-7289-49bc-8269-30de5eceec76" name="jetbrains.mps.vcs.mergehints" version="2" />
+    <devkit ref="0f6bec2b-49d8-431a-a099-4c072ba32b8e(jetbrains.mps.devkit.aspect.vcs)" />
+  </languages>
+  <imports>
+    <import index="jv43" ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="37e03aa1-7289-49bc-8269-30de5eceec76" name="jetbrains.mps.vcs.mergehints">
+      <concept id="5705146868101924639" name="jetbrains.mps.vcs.mergehints.structure.TheirsStrategy" flags="ng" index="Zygv6" />
+      <concept id="4140018591229954297" name="jetbrains.mps.vcs.mergehints.structure.VCSHints" flags="ng" index="1GGwg0">
+        <child id="4140018591229954298" name="concepts" index="1GGwg3" />
+      </concept>
+      <concept id="4140018591229954300" name="jetbrains.mps.vcs.mergehints.structure.ConceptVCSDescriptor" flags="ng" index="1GGwg5">
+        <reference id="4140018591229954485" name="cncpt" index="1GGwlc" />
+        <child id="5705146868101924673" name="strategy" index="Zyguo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1GGwg0" id="5yhCTaasKbK">
+    <property role="TrG5h" value="VCSCustomization" />
+    <node concept="1GGwg5" id="5yhCTaasKbL" role="1GGwg3">
+      <ref role="1GGwlc" to="jv43:5yhCTaasJqs" resolve="VCSCustomization" />
+      <node concept="Zygv6" id="5yhCTaasKbO" role="Zyguo" />
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing.examples.lang/nl.f1re.testing.examples.lang.mpl
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/nl.f1re.testing.examples.lang.mpl
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="nl.f1re.testing.examples.lang" uuid="87e083b3-d1b3-4c3f-9d8c-b24d74710f49" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="nl.f1re.testing.examples.lang.generator" uuid="aabd29df-488b-436d-8c60-c2651e1dc524">
+      <models>
+        <modelRoot type="default" contentPath="${module}/generator">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet compile="mps" classes="mps" ext="no" type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="87e083b3-d1b3-4c3f-9d8c-b24d74710f49(nl.f1re.testing.examples.lang)" version="0" />
+        <module reference="aabd29df-488b-436d-8c60-c2651e1dc524(nl.f1re.testing.examples.lang.generator)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <dependencies>
+    <dependency reexport="false">c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:b8bb702e-43ed-4090-a902-d180d3e5f292:de.slisson.mps.conditionalEditor" version="0" />
+    <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:b1ab8c10-c118-4755-bf2a-cebab35cf533:jetbrains.mps.lang.editor.tooltips" version="0" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:37e03aa1-7289-49bc-8269-30de5eceec76:jetbrains.mps.vcs.mergehints" version="2" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="87e083b3-d1b3-4c3f-9d8c-b24d74710f49(nl.f1re.testing.examples.lang)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>
+

--- a/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
+++ b/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9dd92fa8-16f6-44db-ad34-9fc99b0abd5d(nl.f1re.testing.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+  </imports>
+  <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
+      </concept>
+      <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
+      <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj" />
+      <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ngI" index="v9R3L">
+        <reference id="1722980698497626483" name="template" index="v9R2y" />
+      </concept>
+      <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
+        <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
+        <child id="1092060348987" name="contentNode" index="13RCb5" />
+      </concept>
+      <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
+        <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="3OVhQEUS0GE">
+    <property role="TrG5h" value="main" />
+    <node concept="3aamgX" id="3OVhQEUSdJ3" role="3acgRq">
+      <ref role="30HIoZ" to="rl2y:2$zHkrOt$DN" resolve="FileNodeEditorExpression" />
+      <node concept="j$656" id="3OVhQEUSdJ5" role="1lVwrX">
+        <ref role="v9R2y" node="50vRVameRNm" resolve="reduce_FileNodeEditorExpression" />
+      </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="50vRVameRNm">
+    <property role="TrG5h" value="reduce_FileNodeEditorExpression" />
+    <ref role="3gUMe" to="rl2y:2$zHkrOt$DN" resolve="FileNodeEditorExpression" />
+    <node concept="312cEu" id="5s44y2KUdmt" role="13RCb5">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="A" />
+      <property role="1sVAO0" value="true" />
+      <node concept="3clFbW" id="2$zHkrOtEem" role="jymVt">
+        <node concept="3cqZAl" id="2$zHkrOtEen" role="3clF45" />
+        <node concept="3Tmbuc" id="2$zHkrOtEeo" role="1B3o_S" />
+        <node concept="37vLTG" id="2$zHkrOtEes" role="3clF46">
+          <property role="TrG5h" value="owner" />
+          <node concept="3uibUv" id="2$zHkrOtEet" role="1tU5fm">
+            <ref role="3uigEE" to="tp6m:e$hNri9cbt" resolve="TransformationTest" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="2$zHkrOtEeu" role="3clF47">
+          <node concept="XkiVB" id="2$zHkrOtEev" role="3cqZAp">
+            <ref role="37wK5l" to="tp6m:1043xPhpns6" resolve="BaseEditorTestBody" />
+            <node concept="37vLTw" id="2$zHkrOtEew" role="37wK5m">
+              <ref role="3cqZAo" node="2$zHkrOtEes" resolve="owner" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="5s44y2KUdnf" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="foo" />
+        <property role="od$2w" value="false" />
+        <property role="DiZV1" value="false" />
+        <node concept="3clFbS" id="5s44y2KUdni" role="3clF47">
+          <node concept="3clFbF" id="2$zHkrOw1II" role="3cqZAp">
+            <node concept="2OqwBi" id="2$zHkrOw31D" role="3clFbG">
+              <node concept="0kSF2" id="2$zHkrOw2vc" role="2Oq$k0">
+                <node concept="3uibUv" id="2$zHkrOw2ve" role="0kSFW">
+                  <ref role="3uigEE" to="tp6m:hPMdj4e" resolve="BaseEditorTestBody" />
+                </node>
+                <node concept="Xjq3P" id="2$zHkrOw1IG" role="0kSFX" />
+              </node>
+              <node concept="1PnCL0" id="2$zHkrOw3qY" role="2OqNvi">
+                <ref role="2Oxat5" to="tp6m:4wzlvyewbW2" resolve="myFileNodeEditor" />
+              </node>
+              <node concept="raruj" id="2$zHkrOw6DP" role="lGtFl" />
+            </node>
+          </node>
+        </node>
+        <node concept="3uibUv" id="2$zHkrOupNQ" role="3clF45">
+          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5s44y2KUdmu" role="1B3o_S" />
+      <node concept="3uibUv" id="5s44y2KUezZ" role="1zkMxy">
+        <ref role="3uigEE" to="tp6m:hPMdj4e" resolve="BaseEditorTestBody" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.editor.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.editor.mps
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:aa13ba37-638f-4ef5-b220-bf10cd493b8f(nl.f1re.testing.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="2$zHkrOt_oU">
+    <ref role="1XX52x" to="rl2y:2$zHkrOt$DN" resolve="FileNodeEditorExpression" />
+    <node concept="PMmxH" id="2wdLO7KhY3L" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.structure.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.structure.mps
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="2$zHkrOt$DN">
+    <property role="EcuMT" value="2964412296093649523" />
+    <property role="TrG5h" value="FileNodeEditorExpression" />
+    <property role="34LRSv" value="fileNodeEditor" />
+    <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.typesystem.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.typesystem.mps
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f9d9e622-4cbc-4d68-97e1-3c2c02c0867d(nl.f1re.testing.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports>
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF" />
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1YbPZF" id="2$zHkrOt_qJ">
+    <property role="TrG5h" value="typeof_FileNodeEditorExpression" />
+    <node concept="3clFbS" id="2$zHkrOt_qK" role="18ibNy">
+      <node concept="1Z5TYs" id="50vRVamfU0w" role="3cqZAp">
+        <node concept="mw_s8" id="50vRVamfU0x" role="1ZfhKB">
+          <node concept="2c44tf" id="50vRVamfU0y" role="mwGJk">
+            <node concept="3uibUv" id="50vRVamfUL$" role="2c44tc">
+              <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="50vRVamfU0$" role="1ZfhK$">
+          <node concept="1Z2H0r" id="50vRVamfU0_" role="mwGJk">
+            <node concept="1YBJjd" id="2$zHkrOt_$A" role="1Z2MuG">
+              <ref role="1YBMHb" node="2$zHkrOt_qM" resolve="editor" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2$zHkrOt_qM" role="1YuTPh">
+      <property role="TrG5h" value="editor" />
+      <ref role="1YaFvo" to="rl2y:2$zHkrOt$DN" resolve="FileNodeEditorExpression" />
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
+++ b/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="nl.f1re.testing" uuid="953e4089-c643-455b-8629-636de7085d1c" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="nl.f1re.testing.generator" uuid="ce328797-6b80-4260-85af-aea5722a56c7">
+      <models>
+        <modelRoot type="default" contentPath="${module}/generator">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet compile="mps" classes="mps" ext="no" type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
+        <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="847a3235-09f9-403c-b6a9-1c294a212e92(Ant)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
+        <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
+        <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
+        <module reference="ce328797-6b80-4260-85af-aea5722a56c7(nl.f1re.testing.generator)" version="0" />
+        <module reference="f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <dependencies>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false" scope="generate-into">654422bf-e75f-44dc-936d-188890a746ce(de.slisson.mps.reflection)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="654422bf-e75f-44dc-936d-188890a746ce(de.slisson.mps.reflection)" version="0" />
+    <module reference="7037b32c-9607-4f8e-81bd-1f028a4c117b(de.slisson.mps.reflection.runtime)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
+  </dependencyVersions>
+  <runtime>
+    <dependency reexport="false">f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)</dependency>
+  </runtime>
+  <extendedLanguages>
+    <extendedLanguage>f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</extendedLanguage>
+  </extendedLanguages>
+</language>
+

--- a/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples.plugin.mps
+++ b/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples.plugin.mps
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7a9845ce-dbf4-48f4-9538-870a2b34c03e(nl.f1re.testing.examples.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+  </languages>
+  <imports>
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
+        <child id="8029776554053057803" name="objectType" index="luc8K" />
+      </concept>
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3HP615" id="6cyqnzemVwE">
+    <property role="TrG5h" value="ExtensionInterface" />
+    <node concept="3clFb_" id="6cyqnzemXM_" role="jymVt">
+      <property role="TrG5h" value="enabled" />
+      <node concept="3clFbS" id="6cyqnzemXMC" role="3clF47" />
+      <node concept="3Tm1VV" id="6cyqnzemXMD" role="1B3o_S" />
+      <node concept="10P_77" id="6cyqnzennSb" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="6cyqnzemVwF" role="1B3o_S" />
+  </node>
+  <node concept="1lYeZD" id="6cyqnzemVqC">
+    <property role="TrG5h" value="TestExtension" />
+    <ref role="1lYe$Y" node="6cyqnzemVvp" resolve="TestExtensionPoint" />
+    <node concept="3Tm1VV" id="6cyqnzemVqD" role="1B3o_S" />
+    <node concept="2tJIrI" id="6cyqnzemVqE" role="jymVt" />
+    <node concept="3tTeZs" id="6cyqnzemVqF" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="6cyqnzemVqG" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="6cyqnzemVqH" role="jymVt" />
+    <node concept="q3mfD" id="6cyqnzemVqI" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="6cyqnzemVqK" role="1B3o_S" />
+      <node concept="3clFbS" id="6cyqnzemVqM" role="3clF47">
+        <node concept="3clFbF" id="6cyqnzenW0e" role="3cqZAp">
+          <node concept="2ShNRf" id="6cyqnzenW0c" role="3clFbG">
+            <node concept="HV5vD" id="6cyqnzeoD6q" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="6cyqnzemZ68" resolve="TestExtensionImpl" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="6cyqnzemVqN" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="6cyqnzemVqI" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6cyqnzemZ68">
+    <property role="TrG5h" value="TestExtensionImpl" />
+    <node concept="Wx3nA" id="6cyqnzena33" role="jymVt">
+      <property role="TrG5h" value="enabled" />
+      <node concept="3Tm6S6" id="6cyqnzena1$" role="1B3o_S" />
+      <node concept="10P_77" id="6cyqnzen9Yn" role="1tU5fm" />
+      <node concept="3clFbT" id="6cyqnzenbaW" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="6cyqnzen5$o" role="jymVt" />
+    <node concept="3Tm1VV" id="6cyqnzemZ69" role="1B3o_S" />
+    <node concept="3uibUv" id="6cyqnzemZ8_" role="EKbjA">
+      <ref role="3uigEE" node="6cyqnzemVwE" resolve="ExtensionInterface" />
+    </node>
+    <node concept="3clFb_" id="6cyqnzemZ9$" role="jymVt">
+      <property role="TrG5h" value="enabled" />
+      <node concept="3Tm1VV" id="6cyqnzemZ9A" role="1B3o_S" />
+      <node concept="10P_77" id="6cyqnzenl0Q" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzemZ9C" role="3clF47">
+        <node concept="3clFbF" id="6cyqnzenmrW" role="3cqZAp">
+          <node concept="37vLTw" id="6cyqnzenmrV" role="3clFbG">
+            <ref role="3cqZAo" node="6cyqnzena33" resolve="enabled" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6cyqnzemZ9D" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6cyqnzen1xt" role="jymVt" />
+    <node concept="2YIFZL" id="6cyqnzen5wB" role="jymVt">
+      <property role="TrG5h" value="enable" />
+      <node concept="3clFbS" id="6cyqnzen5wE" role="3clF47">
+        <node concept="3clFbF" id="6cyqnzendYk" role="3cqZAp">
+          <node concept="37vLTI" id="6cyqnzenfU1" role="3clFbG">
+            <node concept="3clFbT" id="6cyqnzeng$h" role="37vLTx">
+              <property role="3clFbU" value="true" />
+            </node>
+            <node concept="37vLTw" id="LAHK2LwgNM" role="37vLTJ">
+              <ref role="3cqZAo" node="6cyqnzena33" resolve="enabled" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6cyqnzen2UN" role="1B3o_S" />
+      <node concept="3cqZAl" id="6cyqnzen5uw" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6cyqnzengAj" role="jymVt" />
+    <node concept="2YIFZL" id="6cyqnzengBR" role="jymVt">
+      <property role="TrG5h" value="disable" />
+      <node concept="3clFbS" id="6cyqnzengBS" role="3clF47">
+        <node concept="3clFbF" id="6cyqnzengBT" role="3cqZAp">
+          <node concept="37vLTI" id="6cyqnzengBU" role="3clFbG">
+            <node concept="3clFbT" id="6cyqnzengBV" role="37vLTx" />
+            <node concept="37vLTw" id="LAHK2LwgNQ" role="37vLTJ">
+              <ref role="3cqZAo" node="6cyqnzena33" resolve="enabled" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6cyqnzengBW" role="1B3o_S" />
+      <node concept="3cqZAl" id="6cyqnzengBX" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6cyqnzengAk" role="jymVt" />
+  </node>
+  <node concept="vrV6u" id="6cyqnzemVvp">
+    <property role="TrG5h" value="TestExtensionPoint" />
+    <node concept="3uibUv" id="6cyqnzemXZ$" role="luc8K">
+      <ref role="3uigEE" node="6cyqnzemVwE" resolve="ExtensionInterface" />
+    </node>
+  </node>
+</model>
+

--- a/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples@tests.mps
+++ b/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples@tests.mps
@@ -1,0 +1,6641 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7278af02-5968-483c-a44b-8f5fe18eb6a2(nl.f1re.testing.examples@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="87e083b3-d1b3-4c3f-9d8c-b24d74710f49" name="nl.f1re.testing.examples.lang" version="0" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="68015e26-cc4d-49db-8715-b643faea1769" name="jetbrains.mps.lang.test.generator" version="0" />
+    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="6" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
+    <use id="f7e353e6-c7a8-4110-a263-1a2503e8b13c" name="de.itemis.mps.debug" version="0" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="f3347d8a-0e79-4f35-8ac9-1574f25c986f" name="jetbrains.mps.execution.commands" version="0" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="6b3888c1-9802-44d8-8baf-f8e6c33ed689" name="jetbrains.mps.kotlin" version="11" />
+    <use id="953e4089-c643-455b-8629-636de7085d1c" name="nl.f1re.testing" version="-1" />
+  </languages>
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="m531" ref="r:e0971d7a-26cb-4f9b-923b-022db20993f1(nl.f1re.testing.runtime)" />
+    <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="2rdi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.assist(MPS.Editor/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="b8lf" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.selection(MPS.Editor/)" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="tp3j" ref="r:00000000-0000-4000-0000-011c89590353(jetbrains.mps.lang.intentions.structure)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
+    <import index="6swo" ref="r:3e4fd42b-cb29-4878-b9d5-a8ab809a2520(nl.f1re.testing.examples.lang.intentions)" />
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
+    <import index="px75" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.leftHighlighter(MPS.Editor/)" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" />
+    <import index="fnpx" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:com.intellij.notification(MPS.ThirdParty/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="fnpy" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
+    <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="i5cy" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent.atomic(JDK/)" />
+    <import index="al1t" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.diagnostic(MPS.IDEA/)" />
+    <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="prgy" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:kotlinx.coroutines(MPS.IDEA/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="9ti4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.extensions(MPS.IDEA/)" />
+    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="jv43" ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)" />
+    <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
+    <import index="ap4t" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator(MPS.Generator/)" />
+    <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(de.itemis.mps.comparator.code)" />
+    <import index="et5u" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.messages(MPS.Core/)" />
+    <import index="1l1f" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util.gotoByName(MPS.IDEA/)" />
+    <import index="tomq" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.psi.codeStyle(MPS.IDEA/)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="anz6" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.testFramework(MPS.IDEA/)" />
+    <import index="vuw5" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.keymap(MPS.IDEA/)" />
+    <import index="7bx7" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.workbench.action(MPS.Platform/)" />
+    <import index="tqbz" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.actions(MPS.IDEA/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="u73" ref="r:a807e16c-6905-4da7-b0d7-e84d28559259(jetbrains.mps.ide.tools.todo)" />
+    <import index="71xd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tools(MPS.Platform/)" />
+    <import index="jkny" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.wm(MPS.IDEA/)" />
+    <import index="4jk" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vfs.ex.dummy(MPS.IDEA/)" />
+    <import index="jlff" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.vfs(MPS.IDEA/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="rvbb" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.ide.projectPane(MPS.Workbench/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="rgfa" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.tree(JDK/)" />
+    <import index="54q7" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.command.undo(MPS.IDEA/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="j936" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.ui(MPS.IDEA/)" />
+    <import index="fdd1" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.ui.laf(MPS.IDEA/)" />
+    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
+    <import index="uzhr" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.diagnostic(MPS.IDEA/)" />
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="bk90" ref="r:1dca72a1-44ae-4339-a783-4859610b0285(jetbrains.mps.baseLanguage.migration)" />
+    <import index="tpel" ref="r:00000000-0000-4000-0000-011c895902c1(jetbrains.mps.baseLanguage.constraints)" />
+    <import index="tpeh" ref="r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
+    <import index="eo0e" ref="r:7a9845ce-dbf4-48f4-9538-870a2b34c03e(nl.f1re.testing.examples.plugin)" />
+    <import index="go48" ref="r:fc6b4266-fe93-4e02-bc36-aebff4c903c3(jetbrains.mps.baseLanguage.execution.api)" />
+    <import index="97tf" ref="r:a95c5cc9-2803-47d1-ab04-691646825cdd(de.itemis.mps.debug.runtime)" />
+    <import index="ni5j" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.regex(JDK/)" />
+    <import index="57ty" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.messages(MPS.Platform/)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="x6hl" ref="398d67d2-c2e9-11e2-ad49-6cf049e62ea4/kotlinJvm:com.intellij.ui.dsl.builder(jetbrains.mps.kotin.ui.dsl/)" />
+    <import index="ur19" ref="r:d58d9938-2526-431c-a5fe-6bbbfeb64ac2(jetbrains.mps.vcs.util)" />
+    <import index="86l" ref="r:03d3090f-cc5b-43a6-b212-e089f946314d(jetbrains.mps.vcs.mergehints.runtime)" />
+    <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
+    <import index="t335" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui.update(MPS.IDEA/)" />
+    <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+  </imports>
+  <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="8473566765277240526" name="de.slisson.mps.reflection.structure.ReflectionMethodCall" flags="ng" index="1PvZjq" />
+    </language>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
+      <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
+      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU">
+        <child id="8489045168660938635" name="warningRef" index="3lydCh" />
+      </concept>
+      <concept id="1215526290564" name="jetbrains.mps.lang.test.structure.NodeTypeCheckOperation" flags="ng" index="30Omv">
+        <child id="1215526393912" name="type" index="31d$z" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
+      <concept id="592868908271422361" name="jetbrains.mps.lang.test.structure.IsIntentionApplicableExpression" flags="ng" index="2bRw2S">
+        <reference id="592868908271422362" name="intention" index="2bRw2V" />
+      </concept>
+      <concept id="5476670926298696679" name="jetbrains.mps.lang.test.structure.MigrationTestCase" flags="lg" index="2lJO3n">
+        <child id="5476670926298696680" name="inputNodes" index="2lJO3o" />
+        <child id="5476670926298698900" name="outputNodes" index="2lJPY$" />
+        <child id="6626913010124294914" name="migration" index="3ea0P7" />
+      </concept>
+      <concept id="511191073233700873" name="jetbrains.mps.lang.test.structure.ScopesTest" flags="ng" index="2rqxmr">
+        <reference id="5449224527592117654" name="checkingReference" index="1BTHP0" />
+        <child id="3655334166513314307" name="nodes" index="3KTr4d" />
+      </concept>
+      <concept id="7691029917083831655" name="jetbrains.mps.lang.test.structure.UnknownRuleReference" flags="ng" index="2u4KIi" />
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr" />
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1211979288880" name="jetbrains.mps.lang.test.structure.AssertMatch" flags="nn" index="JA50E">
+        <child id="1211979305365" name="before" index="JA92f" />
+        <child id="1211979322383" name="after" index="JAdkl" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <property id="1883175908513350760" name="description" index="3YCmrE" />
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="8333855927540283103" name="jetbrains.mps.lang.test.structure.NodeConstraintsErrorCheckOperation" flags="ng" index="39XrGg">
+        <child id="8333855927548182241" name="errorRef" index="39rjcI" />
+      </concept>
+      <concept id="6626913010124185481" name="jetbrains.mps.lang.test.structure.MigrationReference" flags="ng" index="3ea_Bc">
+        <reference id="6626913010124185482" name="migration" index="3ea_Bf" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1101347953350122758" name="jetbrains.mps.lang.test.structure.BootstrapActionReference" flags="ng" index="3iKlGA">
+        <property id="1101347953350127918" name="actionId" index="3iKnse" />
+      </concept>
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
+      <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
+        <child id="2325284917965993580" name="afterTests" index="0EEgW" />
+        <child id="1216993439383" name="methods" index="1qtyYc" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="2153278993334181113" name="jetbrains.mps.lang.test.structure.InfoStatementReference" flags="ng" index="3A7QsG" />
+      <concept id="2153278993334166130" name="jetbrains.mps.lang.test.structure.NodeInfoCheckOperation" flags="ng" index="3A7TAB">
+        <child id="2153278993334179757" name="statementRef" index="3A7QLS" />
+      </concept>
+      <concept id="3655334166513314291" name="jetbrains.mps.lang.test.structure.ScopesExpectedNode" flags="ng" index="3KTrbX">
+        <reference id="4052780437578824735" name="ref" index="3AHY9a" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1208528650020" name="jetbrains.mps.lang.plugin.structure.ToolType" flags="in" index="1xUVSX">
+        <reference id="1208529537963" name="tool" index="1xYkEM" />
+      </concept>
+      <concept id="3205675194086589964" name="jetbrains.mps.lang.plugin.structure.ActionAccessOperation" flags="nn" index="3$FdUm">
+        <reference id="3205675194086671728" name="action" index="3$FpRE" />
+      </concept>
+      <concept id="3205675194086686068" name="jetbrains.mps.lang.plugin.structure.GroupAccessOperation" flags="nn" index="3$FqnI">
+        <reference id="3205675194086686070" name="group" index="3$FqnG" />
+      </concept>
+    </language>
+    <language id="f3347d8a-0e79-4f35-8ac9-1574f25c986f" name="jetbrains.mps.execution.commands">
+      <concept id="612376536074296995" name="jetbrains.mps.execution.commands.structure.CommandProcessType" flags="in" index="50ouk">
+        <reference id="612376536074296996" name="commandDeclaration" index="50ouj" />
+      </concept>
+      <concept id="856705193941281780" name="jetbrains.mps.execution.commands.structure.CommandBuilderExpression" flags="nn" index="2LYoGx">
+        <reference id="6129022259108621329" name="commandPart" index="3rFKlk" />
+        <child id="856705193941281781" name="argument" index="2LYoGw" />
+      </concept>
+      <concept id="856705193941281764" name="jetbrains.mps.execution.commands.structure.CommandParameterAssignment" flags="ng" index="2LYoGL">
+        <reference id="856705193941281765" name="parameterDeclaration" index="2LYoGK" />
+        <child id="856705193941281766" name="value" index="2LYoGN" />
+      </concept>
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0" />
+    </language>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="681855071694758165" name="jetbrains.mps.lang.plugin.standalone.structure.GetToolInProjectOperation" flags="nn" index="LR4U6">
+        <reference id="681855071694758166" name="tool" index="LR4U5" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+        <child id="1188214630783" name="value" index="2B76xF" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1188214545140" name="jetbrains.mps.baseLanguage.structure.AnnotationInstanceValue" flags="ng" index="2B6LJw">
+        <reference id="1188214555875" name="key" index="2B6OnR" />
+        <child id="1188214607812" name="value" index="2B70Vg" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat6" />
+      </concept>
+      <concept id="5763944538902644732" name="jetbrains.mps.baseLanguage.structure.StaticMethodCallOperation" flags="ng" index="2PDubS" />
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068431790191" name="jetbrains.mps.baseLanguage.structure.Expression" flags="nn" index="33vP2n" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1830039279190439966" name="jetbrains.mps.baseLanguage.structure.AdditionalForLoopVariable" flags="ng" index="1gjucp" />
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1184950988562" name="jetbrains.mps.baseLanguage.structure.ArrayCreator" flags="nn" index="3$_iS1">
+        <child id="1184951007469" name="componentType" index="3$_nBY" />
+        <child id="1184952969026" name="dimensionExpression" index="3$GQph" />
+      </concept>
+      <concept id="1184952934362" name="jetbrains.mps.baseLanguage.structure.DimensionExpression" flags="nn" index="3$GHV9">
+        <child id="1184953288404" name="expression" index="3$I4v7" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
+        <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
+      </concept>
+      <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
+    </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="953e4089-c643-455b-8629-636de7085d1c" name="nl.f1re.testing">
+      <concept id="2964412296093649523" name="nl.f1re.testing.structure.FileNodeEditorExpression" flags="ng" index="3tlvWP" />
+    </language>
+    <language id="6b3888c1-9802-44d8-8baf-f8e6c33ed689" name="jetbrains.mps.kotlin">
+      <concept id="7358760241248942182" name="jetbrains.mps.kotlin.structure.Comment" flags="ng" index="gXE$l">
+        <child id="7358760241248948562" name="lines" index="gXG0x" />
+      </concept>
+      <concept id="1314219036499415210" name="jetbrains.mps.kotlin.structure.AbstractPropertyDeclaration" flags="ng" index="TDTJE">
+        <property id="2936055411806090009" name="isReadonly" index="1Xb$ne" />
+        <child id="2936055411798374330" name="assignment" index="1XD05H" />
+      </concept>
+      <concept id="1314219036498225646" name="jetbrains.mps.kotlin.structure.IStatementHolder" flags="ngI" index="THmaI">
+        <child id="1314219036498225649" name="statements" index="THmaL" />
+      </concept>
+      <concept id="7027413324315184167" name="jetbrains.mps.kotlin.structure.ILambdaAsArgument" flags="ngI" index="3$8iW8">
+        <child id="2936055411798374269" name="lambda" index="1XD06E" />
+      </concept>
+      <concept id="4662566628538083705" name="jetbrains.mps.kotlin.structure.FunctionCallExpression" flags="ng" index="1NbEFs" />
+      <concept id="2936055411798373537" name="jetbrains.mps.kotlin.structure.PropertyDeclaration" flags="ng" index="1XD09Q">
+        <child id="1314219036499436525" name="declaration" index="TDYyH" />
+      </concept>
+      <concept id="2936055411798373439" name="jetbrains.mps.kotlin.structure.AbstractFunctionCall" flags="ng" index="1XD0bC">
+        <reference id="1991556721072067817" name="function" index="AarEw" />
+      </concept>
+      <concept id="2936055411798373745" name="jetbrains.mps.kotlin.structure.VariableDeclaration" flags="ng" index="1XD0eA" />
+      <concept id="2936055411798373655" name="jetbrains.mps.kotlin.structure.LambdaLiteral" flags="ng" index="1XD0f0" />
+      <concept id="2936055411798373673" name="jetbrains.mps.kotlin.structure.KotlinFile" flags="ng" index="1XD0fY">
+        <child id="2936055411798374537" name="declarations" index="1XD0Tu" />
+      </concept>
+      <concept id="2936055411798373223" name="jetbrains.mps.kotlin.structure.PropertyDefaultAssignement" flags="ng" index="1XD0mK">
+        <child id="2936055411798373866" name="expression" index="1XD0cX" />
+      </concept>
+    </language>
+    <language id="87e083b3-d1b3-4c3f-9d8c-b24d74710f49" name="nl.f1re.testing.examples.lang">
+      <concept id="6801793966041277396" name="nl.f1re.testing.examples.lang.structure.SlowEditor" flags="ng" index="13bv17" />
+      <concept id="6382061996743463528" name="nl.f1re.testing.examples.lang.structure.CompletionStylingExample" flags="ng" index="3iYV7U" />
+      <concept id="2964412296095260730" name="nl.f1re.testing.examples.lang.structure.Readme" flags="ng" index="3tFllW">
+        <child id="2964412296095260749" name="text" index="3tFlkb" />
+      </concept>
+      <concept id="2964412296095599239" name="nl.f1re.testing.examples.lang.structure.NodeWithToolTip" flags="ng" index="3tHVZ1" />
+      <concept id="2039284509582930128" name="nl.f1re.testing.examples.lang.structure.ConditionalEditor" flags="ng" index="3DUkU$" />
+      <concept id="5419898927158929859" name="nl.f1re.testing.examples.lang.structure.BrokenEditor" flags="ng" index="3OSR2o" />
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="1196350785110" name="jetbrains.mps.lang.quotation.structure.AbstractAntiquotation" flags="ngI" index="2c44t0">
+        <child id="1196350785111" name="expression" index="2c44t1" />
+      </concept>
+      <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
+        <child id="1196350785114" name="quotedNode" index="2c44tc" />
+      </concept>
+      <concept id="4056363777117001481" name="jetbrains.mps.lang.quotation.structure.StringToTypedValueMigrationInfo" flags="ngI" index="AAgTk">
+        <property id="2173356959483005420" name="stringValueMigrated" index="3qcH_f" />
+      </concept>
+      <concept id="1196866233735" name="jetbrains.mps.lang.quotation.structure.PropertyAntiquotation" flags="ng" index="2EMmih" />
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="de.itemis.mps.compare">
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
+    </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
+        <reference id="7256306938026143658" name="target" index="2aWVGs" />
+      </concept>
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="7080278351417106679" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertIsNotNull" flags="nn" index="2Hmddi">
+        <child id="7080278351417106681" name="expression" index="2Hmdds" />
+      </concept>
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+      <concept id="1172017222794" name="jetbrains.mps.baseLanguage.unitTest.structure.Fail" flags="nn" index="3xETmq" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+    </language>
+    <language id="68015e26-cc4d-49db-8715-b643faea1769" name="jetbrains.mps.lang.test.generator">
+      <concept id="554465258093203543" name="jetbrains.mps.lang.test.generator.structure.TransformationMatchAssertion" flags="ng" index="3FggHx">
+        <child id="554465258093203552" name="referenceModel" index="3FggHm" />
+        <child id="554465258093203550" name="inputModel" index="3FggHC" />
+      </concept>
+      <concept id="554465258093203547" name="jetbrains.mps.lang.test.generator.structure.ArgumentReference" flags="ng" index="3FggHH">
+        <reference id="554465258093203548" name="arg" index="3FggHE" />
+      </concept>
+      <concept id="554465258093190254" name="jetbrains.mps.lang.test.generator.structure.ModelArgument" flags="ng" index="3Fgkto">
+        <child id="554465258093190258" name="param" index="3Fgkt4" />
+      </concept>
+      <concept id="554465258093187774" name="jetbrains.mps.lang.test.generator.structure.GeneratorTest" flags="ng" index="3FgkA8">
+        <property id="554465258093190244" name="description" index="3Fgkti" />
+        <child id="554465258093203559" name="tests" index="3FggHh" />
+        <child id="554465258093190247" name="arguments" index="3Fgkth" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265560" name="project" index="9lYEk" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7400021826771268254" name="jetbrains.mps.lang.smodel.structure.SNodePointerType" flags="ig" index="2sp9CU">
+        <reference id="7400021826771268269" name="concept" index="2sp9C9" />
+      </concept>
+      <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
+        <child id="7400021826774799510" name="ref" index="2tJFKM" />
+      </concept>
+      <concept id="4065387505485742749" name="jetbrains.mps.lang.smodel.structure.AbstractPointerResolveOperation" flags="ng" index="2yCiFS">
+        <child id="3648723375513868575" name="repositoryArg" index="Vysub" />
+      </concept>
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="3648723375513868532" name="jetbrains.mps.lang.smodel.structure.NodePointer_ResolveOperation" flags="ng" index="Vyspw" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="3364660638048049750" name="jetbrains.mps.lang.core.structure.PropertyAttribute" flags="ng" index="A9Btg">
+        <property id="1757699476691236117" name="name_DebugInfo" index="2qtEX9" />
+        <property id="1341860900487648621" name="propertyId" index="P4ACc" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+        <property id="6328114375520539777" name="italic" index="1X82VY" />
+      </concept>
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+        <child id="2535923850359210936" name="lines" index="1PaQFQ" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
+        <child id="4611582986551314344" name="requestedType" index="UnYnz" />
+      </concept>
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="GsdFj4HeQp">
+    <property role="TrG5h" value="Actionmap" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Invoke an action declared in a plugin solution." />
+    <node concept="3clFbS" id="GsdFj4HeQq" role="LjaKd">
+      <node concept="2HxZob" id="GsdFj4HTun" role="3cqZAp">
+        <node concept="1iFQzN" id="GsdFj4HTvv" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:7HPyHg86S0x" resolve="Backspace" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4IRx0" role="25YQCW">
+      <node concept="312cEu" id="GsdFj4IRwY" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="312cEg" id="GsdFj4IS8s" role="jymVt">
+          <property role="TrG5h" value="a" />
+          <property role="3TUv4t" value="true" />
+          <node concept="10Oyi0" id="GsdFj4IS8i" role="1tU5fm">
+            <node concept="LIFWc" id="GsdFj4IZxX" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="GsdFj4IRwZ" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4IS9D" role="25YQFr">
+      <node concept="312cEu" id="GsdFj4IS9B" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="312cEg" id="GsdFj4IUEj" role="jymVt">
+          <property role="TrG5h" value="a" />
+          <node concept="10Oyi0" id="GsdFj4IUDR" role="1tU5fm" />
+        </node>
+        <node concept="3Tm1VV" id="GsdFj4IS9C" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="1LcZBjPA0vn">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="ChangeEditorFontSize" />
+    <property role="3YCmrE" value="Change the editor size. The editor needs to be rebuild because the listener doesn't trigger fast enough." />
+    <node concept="3clFbS" id="1LcZBjPA0vo" role="LjaKd">
+      <node concept="3cpWs8" id="1LcZBjPAcPQ" role="3cqZAp">
+        <node concept="3cpWsn" id="1LcZBjPAcPT" role="3cpWs9">
+          <property role="TrG5h" value="originalSize" />
+          <node concept="10Oyi0" id="1LcZBjPAcPO" role="1tU5fm" />
+          <node concept="2OqwBi" id="1LcZBjPAi3k" role="33vP2m">
+            <node concept="2OqwBi" id="1LcZBjPAeNi" role="2Oq$k0">
+              <node concept="369mXd" id="1LcZBjPAcSf" role="2Oq$k0" />
+              <node concept="liA8E" id="1LcZBjPAhG1" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1LcZBjPAi_g" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getHeight()" resolve="getHeight" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="1LcZBjPAiO1" role="3cqZAp">
+        <node concept="3eOSWO" id="1LcZBjPAl94" role="3vwVQn">
+          <node concept="3cmrfG" id="1LcZBjPAla_" role="3uHU7w">
+            <property role="3cmrfH" value="0" />
+          </node>
+          <node concept="37vLTw" id="1LcZBjPAiQl" role="3uHU7B">
+            <ref role="3cqZAo" node="1LcZBjPAcPT" resolve="originalSize" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="6HRhZeXDM4o" role="3cqZAp">
+        <node concept="2OqwBi" id="6HRhZeXDPib" role="3clFbG">
+          <node concept="2ShNRf" id="6HRhZeXDM4k" role="2Oq$k0">
+            <node concept="1pGfFk" id="6HRhZeXDP0n" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="m531:6HRhZeXDGQF" resolve="EditorComponentTestHelper" />
+              <node concept="369mXd" id="6HRhZeXDP2R" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="liA8E" id="6HRhZeXDPHs" role="2OqNvi">
+            <ref role="37wK5l" to="m531:6HRhZeXDIAg" resolve="increaseUIScale" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6HRhZeXDRVr" role="3cqZAp" />
+      <node concept="3cpWs8" id="1LcZBjPAljv" role="3cqZAp">
+        <node concept="3cpWsn" id="1LcZBjPAljw" role="3cpWs9">
+          <property role="TrG5h" value="newSize" />
+          <node concept="10Oyi0" id="1LcZBjPAljx" role="1tU5fm" />
+          <node concept="2OqwBi" id="1LcZBjPAljy" role="33vP2m">
+            <node concept="2OqwBi" id="1LcZBjPAljz" role="2Oq$k0">
+              <node concept="369mXd" id="1LcZBjPAlj$" role="2Oq$k0" />
+              <node concept="liA8E" id="1LcZBjPAlj_" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1LcZBjPAljA" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.getHeight()" resolve="getHeight" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="1LcZBjPAlHt" role="3cqZAp">
+        <node concept="3eOSWO" id="1LcZBjPAodc" role="3vwVQn">
+          <node concept="37vLTw" id="1LcZBjPAofq" role="3uHU7w">
+            <ref role="3cqZAo" node="1LcZBjPAcPT" resolve="originalSize" />
+          </node>
+          <node concept="37vLTw" id="1LcZBjPAlTP" role="3uHU7B">
+            <ref role="3cqZAo" node="1LcZBjPAljw" resolve="newSize" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LcZBjPA0vx" role="25YQCW">
+      <node concept="312cEu" id="1LcZBjPA0vy" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjPA0vz" role="1B3o_S">
+          <node concept="LIFWc" id="1LcZBjPA0$n" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LcZBjPA0v_" role="25YQFr">
+      <node concept="312cEu" id="1LcZBjPA0vA" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjPA0vB" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="1LcZBjPEnPw">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="Classloading" />
+    <property role="3YCmrE" value="Demonstration for reloading a module." />
+    <node concept="1qefOq" id="1LcZBjPEnP$" role="25YQFr">
+      <node concept="312cEu" id="1LcZBjPEo16" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjPEo17" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="1LcZBjPEnPA" role="LjaKd">
+      <node concept="3clFbF" id="6HRhZeXGc5p" role="3cqZAp">
+        <node concept="2OqwBi" id="6HRhZeXGdKd" role="3clFbG">
+          <node concept="2ShNRf" id="6HRhZeXGc5l" role="2Oq$k0">
+            <node concept="1pGfFk" id="6HRhZeXGdAx" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="m531:6HRhZeXG2y3" resolve="ProjectTestHelper" />
+              <node concept="1jxXqW" id="6HRhZeXGdAT" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="liA8E" id="6HRhZeXGe4l" role="2OqNvi">
+            <ref role="37wK5l" to="m531:3NYwjf355CN" resolve="reloadModule" />
+            <node concept="2OqwBi" id="6HRhZeXGi28" role="37wK5m">
+              <node concept="2JrnkZ" id="6HRhZeXGi29" role="2Oq$k0">
+                <node concept="1jGwE1" id="6HRhZeXGi2a" role="2JrQYb" />
+              </node>
+              <node concept="liA8E" id="6HRhZeXGi2b" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="1LcZBjPFT4v" role="3cqZAp">
+        <node concept="3cpWsn" id="1LcZBjPFT4w" role="3cpWs9">
+          <property role="TrG5h" value="name" />
+          <node concept="17QB3L" id="1LcZBjPFSXc" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="1QHqEK" id="1LcZBjPFTLx" role="3cqZAp">
+        <node concept="1QHqEC" id="1LcZBjPFTLz" role="1QHqEI">
+          <node concept="3clFbS" id="1LcZBjPFTL_" role="1bW5cS">
+            <node concept="3clFbF" id="1LcZBjPFT8u" role="3cqZAp">
+              <node concept="37vLTI" id="1LcZBjPFT8w" role="3clFbG">
+                <node concept="2OqwBi" id="1LcZBjPFT4x" role="37vLTx">
+                  <node concept="3xONca" id="1LcZBjPFT4y" role="2Oq$k0">
+                    <ref role="3xOPvv" node="1LcZBjPFp2R" resolve="cls" />
+                  </node>
+                  <node concept="3TrcHB" id="1LcZBjPFT4z" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="1LcZBjPFT8$" role="37vLTJ">
+                  <ref role="3cqZAo" node="1LcZBjPFT4w" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="1LcZBjPFUEj" role="ukAjM">
+          <node concept="1jxXqW" id="1LcZBjPFTQu" role="2Oq$k0" />
+          <node concept="liA8E" id="1LcZBjPFW0P" role="2OqNvi">
+            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="1LcZBjPFpin" role="3cqZAp">
+        <node concept="Xl_RD" id="1LcZBjPFpmM" role="3tpDZB">
+          <property role="Xl_RC" value="A" />
+        </node>
+        <node concept="37vLTw" id="1LcZBjPFT4$" role="3tpDZA">
+          <ref role="3cqZAo" node="1LcZBjPFT4w" resolve="name" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="1LcZBjPFoYn" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="1LcZBjPEnYW" role="25YQCW">
+      <node concept="312cEu" id="1LcZBjPEnYU" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjPEnYV" role="1B3o_S" />
+        <node concept="LIFWc" id="1LcZBjPEpIo" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+        <node concept="3xLA65" id="1LcZBjPFp2R" role="lGtFl">
+          <property role="TrG5h" value="cls" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="1LcZBjPDAgG">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="ConditionalEditor" />
+    <property role="3YCmrE" value="Check that a conditional editor is used. A user object is used to mark the editor with some additional information so that we can detect it." />
+    <node concept="1qefOq" id="1LcZBjPDAhe" role="25YQCW">
+      <node concept="3DUkU$" id="1LcZBjPDAhd" role="1qenE9">
+        <node concept="LIFWc" id="1LcZBjPDAt9" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="constant_0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LcZBjPDAhw" role="25YQFr">
+      <node concept="3DUkU$" id="1LcZBjPDAhv" role="1qenE9" />
+    </node>
+    <node concept="3clFbS" id="1LcZBjPDACk" role="LjaKd">
+      <node concept="3vlDli" id="1LcZBjPDGah" role="3cqZAp">
+        <node concept="10M0yZ" id="1LcZBjPDGaW" role="3tpDZB">
+          <ref role="3cqZAo" to="wyt6:~Boolean.TRUE" resolve="TRUE" />
+          <ref role="1PxDUh" to="wyt6:~Boolean" resolve="Boolean" />
+        </node>
+        <node concept="2OqwBi" id="1LcZBjPDFrr" role="3tpDZA">
+          <node concept="2OqwBi" id="1LcZBjPDCfe" role="2Oq$k0">
+            <node concept="369mXd" id="1LcZBjPDAC_" role="2Oq$k0" />
+            <node concept="liA8E" id="1LcZBjPDF7V" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+            </node>
+          </node>
+          <node concept="liA8E" id="1LcZBjPDFXl" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~EditorCell.getUserObject(java.lang.Object)" resolve="getUserObject" />
+            <node concept="Xl_RD" id="1LcZBjPDHGf" role="37wK5m">
+              <property role="Xl_RC" value="conditionalEditor" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrO_nvL">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="ContextAssistant" />
+    <property role="3YCmrE" value="Check that the context assistant in the editor has entries." />
+    <node concept="1qefOq" id="2$zHkrO_nvP" role="25YQFr">
+      <node concept="24kQdi" id="2$zHkrO_qMv" role="1qenE9">
+        <node concept="3EYTF0" id="2$zHkrO_qMw" role="2wV5jI" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="2$zHkrO_nvR" role="LjaKd">
+      <node concept="3cpWs8" id="6HRhZeXH6Ty" role="3cqZAp">
+        <node concept="3cpWsn" id="6HRhZeXH6Tz" role="3cpWs9">
+          <property role="TrG5h" value="manager" />
+          <node concept="3uibUv" id="6HRhZeXH6IU" role="1tU5fm">
+            <ref role="3uigEE" to="2rdi:~ContextAssistantManager" resolve="ContextAssistantManager" />
+          </node>
+          <node concept="2OqwBi" id="6HRhZeXH6T$" role="33vP2m">
+            <node concept="2ShNRf" id="6HRhZeXH6T_" role="2Oq$k0">
+              <node concept="1pGfFk" id="6HRhZeXH6TA" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXDGQF" resolve="EditorComponentTestHelper" />
+                <node concept="369mXd" id="6HRhZeXH6TB" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6HRhZeXH6TC" role="2OqNvi">
+              <ref role="37wK5l" to="m531:6HRhZeXH0Jw" resolve="openContextAssistant" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2$zHkrOAic8" role="3cqZAp">
+        <node concept="3cmrfG" id="2$zHkrOAice" role="3tpDZB">
+          <property role="3cmrfH" value="1" />
+        </node>
+        <node concept="2OqwBi" id="2$zHkrOA6Xb" role="3tpDZA">
+          <node concept="2OqwBi" id="2$zHkrO_T5w" role="2Oq$k0">
+            <node concept="37vLTw" id="2$zHkrO_SUe" role="2Oq$k0">
+              <ref role="3cqZAo" node="6HRhZeXH6Tz" resolve="manager" />
+            </node>
+            <node concept="liA8E" id="2$zHkrOA5$X" role="2OqNvi">
+              <ref role="37wK5l" to="2rdi:~ContextAssistantManager.getActiveMenuItems()" resolve="getActiveMenuItems" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2$zHkrOA8lZ" role="2OqNvi">
+            <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrO_nMi" role="25YQCW">
+      <node concept="24kQdi" id="2$zHkrO_qLE" role="1qenE9">
+        <node concept="3EYTF0" id="2$zHkrO_qMe" role="2wV5jI">
+          <node concept="LIFWc" id="2$zHkrO_qML" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Error_nb4xc9_a" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5yhCTaatBEL">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="CopyAndPaste" />
+    <property role="3YCmrE" value="Test Copy&amp;Paste. Make sure to correctly set the cell annotation." />
+    <node concept="1qefOq" id="5yhCTaatBFM" role="25YQCW">
+      <node concept="9aQIb" id="5yhCTaatBS_" role="1qenE9">
+        <node concept="3clFbS" id="5yhCTaatBSA" role="9aQI4">
+          <node concept="3cpWs8" id="5yhCTaatC_$" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaatC_B" role="3cpWs9">
+              <property role="TrG5h" value="a" />
+              <node concept="10Oyi0" id="5yhCTaatC_z" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaatC_K" role="33vP2m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+            <node concept="LIFWc" id="5yhCTaauuvo" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="LIFWd" value="Collection_y9czm0_a" />
+              <property role="ZRATv" value="true" />
+              <property role="p6zMq" value="1" />
+              <property role="p6zMs" value="1" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5yhCTaatDiD" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaatDiG" role="3cpWs9">
+              <property role="TrG5h" value="b" />
+              <node concept="10Oyi0" id="5yhCTaatDiB" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaatDiT" role="33vP2m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5yhCTaatDj3" role="25YQFr">
+      <node concept="9aQIb" id="5yhCTaatDjl" role="1qenE9">
+        <node concept="3clFbS" id="5yhCTaatDjm" role="9aQI4">
+          <node concept="3cpWs8" id="5yhCTaatE0k" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaatE0n" role="3cpWs9">
+              <property role="TrG5h" value="a" />
+              <node concept="10Oyi0" id="5yhCTaatE0j" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaatE0w" role="33vP2m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5yhCTaatFqw" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaatFqz" role="3cpWs9">
+              <property role="TrG5h" value="a" />
+              <node concept="10Oyi0" id="5yhCTaatFqu" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaatFqK" role="33vP2m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5yhCTaatEHp" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaatEHs" role="3cpWs9">
+              <property role="TrG5h" value="b" />
+              <node concept="10Oyi0" id="5yhCTaatEHn" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaatEHB" role="33vP2m">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="5yhCTaavRil" role="LjaKd">
+      <node concept="2HxZob" id="5yhCTaavRij" role="3cqZAp">
+        <node concept="3iKlGA" id="5yhCTaavRiA" role="3iKnsn">
+          <property role="3iKnse" value="$Copy" />
+        </node>
+      </node>
+      <node concept="2HxZob" id="5yhCTaavRuR" role="3cqZAp">
+        <node concept="1iFQzN" id="5yhCTaavRvS" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:R3$tg1aBO2" resolve="MoveDown" />
+        </node>
+      </node>
+      <node concept="2HxZob" id="5yhCTaavRjq" role="3cqZAp">
+        <node concept="3iKlGA" id="5yhCTaavRjr" role="3iKnsn">
+          <property role="3iKnse" value="$Paste" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="5yhCTaavRj9" role="3cqZAp" />
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5yhCTaawWLI">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="CopyAndPasteFromClipboard" />
+    <property role="3YCmrE" value="Paste text from the clipboard into the editor." />
+    <node concept="1qefOq" id="5yhCTaawWLJ" role="25YQCW">
+      <node concept="9aQIb" id="5yhCTaawWLK" role="1qenE9">
+        <node concept="3clFbS" id="5yhCTaawWLL" role="9aQI4">
+          <node concept="3cpWs8" id="5yhCTaawWLM" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaawWLN" role="3cpWs9">
+              <property role="TrG5h" value="var" />
+              <node concept="10Oyi0" id="5yhCTaawWLO" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaawWLP" role="33vP2m">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="LIFWc" id="5yhCTaawWOS" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="3" />
+                <property role="p6zMs" value="3" />
+                <property role="LIFWd" value="VDNCC_property_name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5yhCTaawWLV" role="25YQFr">
+      <node concept="9aQIb" id="5yhCTaawWLW" role="1qenE9">
+        <node concept="3clFbS" id="5yhCTaawWLX" role="9aQI4">
+          <node concept="3cpWs8" id="5yhCTaawXyf" role="3cqZAp">
+            <node concept="3cpWsn" id="5yhCTaawXyi" role="3cpWs9">
+              <property role="TrG5h" value="variable" />
+              <node concept="10Oyi0" id="5yhCTaawXye" role="1tU5fm" />
+              <node concept="3cmrfG" id="5yhCTaawXzf" role="33vP2m">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="5yhCTaawWMa" role="LjaKd">
+      <node concept="3clFbF" id="6HRhZeXHfjK" role="3cqZAp">
+        <node concept="2OqwBi" id="6HRhZeXHkYd" role="3clFbG">
+          <node concept="2ShNRf" id="6HRhZeXHfjG" role="2Oq$k0">
+            <node concept="1pGfFk" id="6HRhZeXHkLd" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="m531:6HRhZeXHgJ5" resolve="PlatformTestHelper" />
+              <node concept="1jxXqW" id="6HRhZeXHqSY" role="37wK5m" />
+            </node>
+          </node>
+          <node concept="liA8E" id="6HRhZeXHldg" role="2OqNvi">
+            <ref role="37wK5l" to="m531:6HRhZeXHgJG" resolve="withClipboardData" />
+            <node concept="1bVj0M" id="6HRhZeXHlrp" role="37wK5m">
+              <node concept="3clFbS" id="6HRhZeXHlru" role="1bW5cS">
+                <node concept="3J1_TO" id="6HRhZeXI6gi" role="3cqZAp">
+                  <node concept="3uVAMA" id="6HRhZeXI6hZ" role="1zxBo5">
+                    <node concept="XOnhg" id="6HRhZeXI6i0" role="1zc67B">
+                      <property role="TrG5h" value="e" />
+                      <node concept="nSUau" id="6HRhZeXI6i1" role="1tU5fm">
+                        <node concept="3uibUv" id="6HRhZeXI6uX" role="nSUat">
+                          <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6HRhZeXI6i2" role="1zc67A">
+                      <node concept="3xETmq" id="6HRhZeXI7hL" role="3cqZAp">
+                        <node concept="3_1$Yv" id="6HRhZeXI7js" role="3_9lra">
+                          <node concept="2OqwBi" id="6HRhZeXI7QO" role="3_1BAH">
+                            <node concept="37vLTw" id="6HRhZeXI7l9" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6HRhZeXI6i0" resolve="e" />
+                            </node>
+                            <node concept="liA8E" id="6HRhZeXI8BH" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="6HRhZeXI6gk" role="1zxBo7">
+                    <node concept="2HxZob" id="5yhCTaawZ7g" role="3cqZAp">
+                      <node concept="3iKlGA" id="5yhCTaawZ7h" role="3iKnsn">
+                        <property role="3iKnse" value="$Paste" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="Xl_RD" id="6HRhZeXHle6" role="37wK5m">
+              <property role="Xl_RC" value="iable" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="5yhCTaawYXa" role="3cqZAp" />
+      <node concept="3clFbH" id="5yhCTaawWMh" role="3cqZAp" />
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrOB4Vv">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="FocusAndSelection" />
+    <property role="3YCmrE" value="Change the focus and selection." />
+    <node concept="3clFbS" id="2$zHkrOB4V_" role="LjaKd">
+      <node concept="3cpWs8" id="2$zHkrOB999" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrOB99a" role="3cpWs9">
+          <property role="TrG5h" value="selection" />
+          <node concept="3uibUv" id="2$zHkrOB98C" role="1tU5fm">
+            <ref role="3uigEE" to="b8lf:~EditorCellLabelSelection" resolve="EditorCellLabelSelection" />
+          </node>
+          <node concept="0kSF2" id="2$zHkrOBktv" role="33vP2m">
+            <node concept="3uibUv" id="2$zHkrOBkty" role="0kSFW">
+              <ref role="3uigEE" to="b8lf:~EditorCellLabelSelection" resolve="EditorCellLabelSelection" />
+            </node>
+            <node concept="2OqwBi" id="2$zHkrOBcU4" role="0kSFX">
+              <node concept="2OqwBi" id="2$zHkrOB99b" role="2Oq$k0">
+                <node concept="369mXd" id="2$zHkrOB99c" role="2Oq$k0" />
+                <node concept="liA8E" id="2$zHkrOBcT8" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                </node>
+              </node>
+              <node concept="liA8E" id="2$zHkrOBd39" role="2OqNvi">
+                <ref role="37wK5l" to="lwvz:~SelectionManager.getSelection()" resolve="getSelection" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Hmddi" id="2$zHkrOBkHa" role="3cqZAp">
+        <node concept="37vLTw" id="2$zHkrOBl1W" role="2Hmdds">
+          <ref role="3cqZAo" node="2$zHkrOB99a" resolve="selection" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2$zHkrOBq5Z" role="3cqZAp">
+        <node concept="2OqwBi" id="2$zHkrOBqEU" role="3tpDZA">
+          <node concept="37vLTw" id="2$zHkrOBq7j" role="2Oq$k0">
+            <ref role="3cqZAo" node="2$zHkrOB99a" resolve="selection" />
+          </node>
+          <node concept="liA8E" id="2$zHkrOBrl3" role="2OqNvi">
+            <ref role="37wK5l" to="b8lf:~EditorCellLabelSelection.getSelectionStart()" resolve="getSelectionStart" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2$zHkrOBrlI" role="3tpDZB">
+          <property role="3cmrfH" value="0" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2$zHkrOBrmP" role="3cqZAp">
+        <node concept="2OqwBi" id="2$zHkrOBrmQ" role="3tpDZA">
+          <node concept="37vLTw" id="2$zHkrOBrmR" role="2Oq$k0">
+            <ref role="3cqZAo" node="2$zHkrOB99a" resolve="selection" />
+          </node>
+          <node concept="liA8E" id="2$zHkrOBrmS" role="2OqNvi">
+            <ref role="37wK5l" to="b8lf:~EditorCellLabelSelection.getSelectionEnd()" resolve="getSelectionEnd" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2$zHkrOBrmT" role="3tpDZB">
+          <property role="3cmrfH" value="0" />
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2$zHkrOBF4g" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrOBF4h" role="3cpWs9">
+          <property role="TrG5h" value="mainMethodCell" />
+          <node concept="3uibUv" id="2$zHkrOBF3c" role="1tU5fm">
+            <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrOBF4i" role="33vP2m">
+            <node concept="369mXd" id="2$zHkrOBF4j" role="2Oq$k0" />
+            <node concept="liA8E" id="2$zHkrOBF4k" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.findNodeCell(org.jetbrains.mps.openapi.model.SNode)" resolve="findNodeCell" />
+              <node concept="3xONca" id="2$zHkrOBF4l" role="37wK5m">
+                <ref role="3xOPvv" node="2$zHkrOBAW3" resolve="mainMethod" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="6HRhZeXJ_o3" role="3cqZAp">
+        <node concept="2OqwBi" id="6HRhZeXJB4Y" role="3clFbG">
+          <node concept="2ShNRf" id="6HRhZeXJ_nZ" role="2Oq$k0">
+            <node concept="1pGfFk" id="6HRhZeXJAS9" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="m531:6HRhZeXDHY2" resolve="EditorCellTestHelper" />
+              <node concept="37vLTw" id="6HRhZeXJASy" role="37wK5m">
+                <ref role="3cqZAo" node="2$zHkrOBF4h" resolve="mainMethodCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="6HRhZeXJBml" role="2OqNvi">
+            <ref role="37wK5l" to="m531:6HRhZeXJvtM" resolve="focus" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2$zHkrOBZsY" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrOBZsZ" role="3cpWs9">
+          <property role="TrG5h" value="voidCell" />
+          <node concept="3uibUv" id="2$zHkrOBZt0" role="1tU5fm">
+            <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrOBZt1" role="33vP2m">
+            <node concept="369mXd" id="2$zHkrOBZt2" role="2Oq$k0" />
+            <node concept="liA8E" id="2$zHkrOBZt3" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.findNodeCell(org.jetbrains.mps.openapi.model.SNode)" resolve="findNodeCell" />
+              <node concept="3xONca" id="2$zHkrOBZt4" role="37wK5m">
+                <ref role="3xOPvv" node="2$zHkrOBZlb" resolve="void" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="2$zHkrOBKc1" role="3cqZAp">
+        <node concept="2OqwBi" id="2$zHkrOBLAj" role="3tpDZA">
+          <node concept="369mXd" id="2$zHkrOBKiM" role="2Oq$k0" />
+          <node concept="liA8E" id="2$zHkrOBNfl" role="2OqNvi">
+            <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+          </node>
+        </node>
+        <node concept="37vLTw" id="2$zHkrOBNmx" role="3tpDZB">
+          <ref role="3cqZAo" node="2$zHkrOBZsZ" resolve="voidCell" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOB5ct" role="25YQCW">
+      <node concept="312cEu" id="2$zHkrOB5cr" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="2YIFZL" id="2$zHkrOB5J6" role="jymVt">
+          <property role="TrG5h" value="main" />
+          <node concept="37vLTG" id="2$zHkrOB5J7" role="3clF46">
+            <property role="TrG5h" value="args" />
+            <node concept="10Q1$e" id="2$zHkrOB5J8" role="1tU5fm">
+              <node concept="17QB3L" id="2$zHkrOB5J9" role="10Q1$1" />
+            </node>
+          </node>
+          <node concept="3cqZAl" id="2$zHkrOB5Ja" role="3clF45">
+            <node concept="3xLA65" id="2$zHkrOBZlb" role="lGtFl">
+              <property role="TrG5h" value="void" />
+            </node>
+          </node>
+          <node concept="3Tm1VV" id="2$zHkrOB5Jb" role="1B3o_S" />
+          <node concept="3clFbS" id="2$zHkrOB5Jc" role="3clF47" />
+          <node concept="3xLA65" id="2$zHkrOBAW3" role="lGtFl">
+            <property role="TrG5h" value="mainMethod" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrOB5cs" role="1B3o_S" />
+        <node concept="LIFWc" id="2$zHkrOB5Mt" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOBl7V" role="25YQFr">
+      <node concept="312cEu" id="2$zHkrOBl7W" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="2YIFZL" id="2$zHkrOBl7X" role="jymVt">
+          <property role="TrG5h" value="main" />
+          <node concept="37vLTG" id="2$zHkrOBl7Y" role="3clF46">
+            <property role="TrG5h" value="args" />
+            <node concept="10Q1$e" id="2$zHkrOBl7Z" role="1tU5fm">
+              <node concept="17QB3L" id="2$zHkrOBl80" role="10Q1$1" />
+            </node>
+          </node>
+          <node concept="3cqZAl" id="2$zHkrOBl81" role="3clF45" />
+          <node concept="3Tm1VV" id="2$zHkrOBl82" role="1B3o_S" />
+          <node concept="3clFbS" id="2$zHkrOBl83" role="3clF47" />
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrOBl84" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrO$CPS">
+    <property role="TrG5h" value="Hyperlink" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Test that the cell has a hyperlink to a node." />
+    <node concept="1qefOq" id="2$zHkrO$CQF" role="25YQCW">
+      <node concept="3VsKOn" id="2$zHkrO$CR_" role="1qenE9">
+        <ref role="3VsUkX" to="wyt6:~Object" resolve="Object" />
+        <node concept="LIFWc" id="2$zHkrO$JN0" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="ReferencePresentation_ejwutq_a0a0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrO$CRY" role="25YQFr">
+      <node concept="3VsKOn" id="2$zHkrO$CSH" role="1qenE9">
+        <ref role="3VsUkX" to="wyt6:~Object" resolve="Object" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="2$zHkrO$CTc" role="LjaKd">
+      <node concept="3cpWs8" id="2$zHkrO$N8U" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrO$N8V" role="3cpWs9">
+          <property role="TrG5h" value="selectedCell" />
+          <node concept="3uibUv" id="2$zHkrO$N8p" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrO$N8W" role="33vP2m">
+            <node concept="369mXd" id="2$zHkrO$N8X" role="2Oq$k0" />
+            <node concept="liA8E" id="2$zHkrO$N8Y" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="2$zHkrO$VDa" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrO$VDb" role="3cpWs9">
+          <property role="TrG5h" value="repository" />
+          <node concept="3uibUv" id="2$zHkrO$VC1" role="1tU5fm">
+            <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrO$VDc" role="33vP2m">
+            <node concept="1jxXqW" id="2$zHkrO$VDd" role="2Oq$k0" />
+            <node concept="liA8E" id="2$zHkrO$VDe" role="2OqNvi">
+              <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1QHqEK" id="2$zHkrO$VAW" role="3cqZAp">
+        <node concept="1QHqEC" id="2$zHkrO$VAY" role="1QHqEI">
+          <node concept="3clFbS" id="2$zHkrO$VB0" role="1bW5cS">
+            <node concept="3vlDli" id="2$zHkrO$Niw" role="3cqZAp">
+              <node concept="2OqwBi" id="2$zHkrO$OFV" role="3tpDZB">
+                <node concept="2tJFMh" id="2$zHkrO$Njp" role="2Oq$k0">
+                  <node concept="ZC_QK" id="2$zHkrO$OnW" role="2tJFKM">
+                    <ref role="2aWVGs" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                </node>
+                <node concept="Vyspw" id="2$zHkrO$Pi8" role="2OqNvi">
+                  <node concept="37vLTw" id="2$zHkrO$VDf" role="Vysub">
+                    <ref role="3cqZAo" node="2$zHkrO$VDb" resolve="repository" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6HRhZeXJHDU" role="3tpDZA">
+                <node concept="2ShNRf" id="6HRhZeXJCQs" role="2Oq$k0">
+                  <node concept="1pGfFk" id="6HRhZeXJF_a" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="m531:6HRhZeXDHY2" resolve="EditorCellTestHelper" />
+                    <node concept="37vLTw" id="6HRhZeXJHrA" role="37wK5m">
+                      <ref role="3cqZAo" node="2$zHkrO$N8V" resolve="selectedCell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6HRhZeXJHSB" role="2OqNvi">
+                  <ref role="37wK5l" to="m531:6HRhZeXDGPN" resolve="getLinkedNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTw" id="2$zHkrO$VI8" role="ukAjM">
+          <ref role="3cqZAo" node="2$zHkrO$VDb" resolve="repository" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrOxMBs">
+    <property role="TrG5h" value="Intention" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Test that an intention has a certain description, is applicable, and execute it afterwards" />
+    <node concept="1qefOq" id="2$zHkrOxMCh" role="25YQCW">
+      <node concept="312cEu" id="2$zHkrOxMCf" role="1qenE9">
+        <property role="TrG5h" value="Test" />
+        <node concept="3Tm1VV" id="2$zHkrOxMCg" role="1B3o_S" />
+        <node concept="LIFWc" id="2$zHkrOxMGY" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOxMDJ" role="25YQFr">
+      <node concept="312cEu" id="2$zHkrOxME1" role="1qenE9">
+        <property role="TrG5h" value="NewName" />
+        <node concept="3Tm1VV" id="2$zHkrOxME2" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="2$zHkrOxMHt" role="LjaKd">
+      <node concept="3cpWs8" id="4k0nQshpecr" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshpecs" role="3cpWs9">
+          <property role="TrG5h" value="editorContext" />
+          <node concept="3uibUv" id="4k0nQshpdYH" role="1tU5fm">
+            <ref role="3uigEE" to="exr9:~EditorContext" resolve="EditorContext" />
+          </node>
+          <node concept="2OqwBi" id="4k0nQshpect" role="33vP2m">
+            <node concept="369mXd" id="4k0nQshpecu" role="2Oq$k0" />
+            <node concept="liA8E" id="4k0nQshpecv" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4k0nQshq1dQ" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshq1dR" role="3cpWs9">
+          <property role="TrG5h" value="repository" />
+          <node concept="3uibUv" id="4k0nQshq13C" role="1tU5fm">
+            <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+          </node>
+          <node concept="2OqwBi" id="4k0nQshq1dS" role="33vP2m">
+            <node concept="1jxXqW" id="4k0nQshq1dT" role="2Oq$k0" />
+            <node concept="liA8E" id="4k0nQshq1dU" role="2OqNvi">
+              <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6HRhZeXJTu_" role="3cqZAp" />
+      <node concept="3cpWs8" id="4k0nQshmiyZ" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshmiz0" role="3cpWs9">
+          <property role="TrG5h" value="tester" />
+          <node concept="3uibUv" id="4k0nQshmiz1" role="1tU5fm">
+            <ref role="3uigEE" to="m531:wUiM63PS_P" resolve="IntentionTester" />
+          </node>
+          <node concept="2ShNRf" id="4k0nQshmizK" role="33vP2m">
+            <node concept="1pGfFk" id="4k0nQshmjT$" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="m531:wUiM63PSJn" resolve="IntentionTester" />
+              <node concept="37vLTw" id="4k0nQshpecw" role="37wK5m">
+                <ref role="3cqZAo" node="4k0nQshpecs" resolve="editorContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4k0nQshoYJR" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshoYJS" role="3cpWs9">
+          <property role="TrG5h" value="intention" />
+          <node concept="3Tqbb2" id="4k0nQshoYJ1" role="1tU5fm">
+            <ref role="ehGHo" to="tp3j:hmS6QkF" resolve="IntentionDeclaration" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4k0nQshp2tP" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshp2tQ" role="3cpWs9">
+          <property role="TrG5h" value="matchingIntention" />
+          <node concept="3uibUv" id="4k0nQshp2t8" role="1tU5fm">
+            <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+            <node concept="3uibUv" id="4k0nQshp2te" role="11_B2D">
+              <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+            </node>
+            <node concept="3uibUv" id="4k0nQshp2td" role="11_B2D">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4k0nQshpcXZ" role="3cqZAp">
+        <node concept="3cpWsn" id="4k0nQshpcY0" role="3cpWs9">
+          <property role="TrG5h" value="node" />
+          <node concept="3uibUv" id="4k0nQshpcw4" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+          <node concept="2OqwBi" id="4k0nQshpcY1" role="33vP2m">
+            <node concept="369mXd" id="4k0nQshpcY2" role="2Oq$k0" />
+            <node concept="liA8E" id="4k0nQshpcY3" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getEditedNode()" resolve="getEditedNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6HRhZeXJX1h" role="3cqZAp" />
+      <node concept="1QHqEK" id="4k0nQshq0DY" role="3cqZAp">
+        <node concept="1QHqEC" id="4k0nQshq0E0" role="1QHqEI">
+          <node concept="3clFbS" id="4k0nQshq0E2" role="1bW5cS">
+            <node concept="3clFbF" id="4k0nQshq2yA" role="3cqZAp">
+              <node concept="37vLTI" id="4k0nQshq2yC" role="3clFbG">
+                <node concept="2OqwBi" id="4k0nQshoYJT" role="37vLTx">
+                  <node concept="2tJFMh" id="4k0nQshoYJU" role="2Oq$k0">
+                    <node concept="ZC_QK" id="4k0nQshoYJV" role="2tJFKM">
+                      <ref role="2aWVGs" to="6swo:2$zHkrOxF0o" resolve="ClassConceptNewName" />
+                    </node>
+                  </node>
+                  <node concept="Vyspw" id="4k0nQshoYJW" role="2OqNvi">
+                    <node concept="37vLTw" id="4k0nQshq1dV" role="Vysub">
+                      <ref role="3cqZAo" node="4k0nQshq1dR" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4k0nQshq2yG" role="37vLTJ">
+                  <ref role="3cqZAo" node="4k0nQshoYJS" resolve="intention" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQshqQza" role="3cqZAp">
+              <node concept="37vLTI" id="4k0nQshqQzc" role="3clFbG">
+                <node concept="2OqwBi" id="4k0nQshp2tR" role="37vLTx">
+                  <node concept="37vLTw" id="4k0nQshp2tS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4k0nQshmiz0" resolve="tester" />
+                  </node>
+                  <node concept="liA8E" id="4k0nQshp2tT" role="2OqNvi">
+                    <ref role="37wK5l" to="m531:wUiM63PU8C" resolve="getSingleMatchingIntention" />
+                    <node concept="37vLTw" id="4k0nQshpcY4" role="37wK5m">
+                      <ref role="3cqZAo" node="4k0nQshpcY0" resolve="node" />
+                    </node>
+                    <node concept="2ShNRf" id="4k0nQshp2tX" role="37wK5m">
+                      <node concept="1pGfFk" id="4k0nQshp2tY" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="tp6m:wUiM63QTC$" resolve="MatchIntentionById" />
+                        <node concept="3cpWs3" id="4k0nQshp2tZ" role="37wK5m">
+                          <node concept="Xl_RD" id="4k0nQshp2u0" role="3uHU7w">
+                            <property role="Xl_RC" value="_Intention" />
+                          </node>
+                          <node concept="2OqwBi" id="4k0nQshp2u1" role="3uHU7B">
+                            <node concept="37vLTw" id="4k0nQshp2u2" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4k0nQshoYJS" resolve="intention" />
+                            </node>
+                            <node concept="2qgKlT" id="4k0nQshp2u3" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4k0nQshqQzg" role="37vLTJ">
+                  <ref role="3cqZAo" node="4k0nQshp2tQ" resolve="matchingIntention" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTw" id="4k0nQshq22i" role="ukAjM">
+          <ref role="3cqZAo" node="4k0nQshq1dR" resolve="repository" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="6HRhZeXJZnS" role="3cqZAp" />
+      <node concept="3vlDli" id="4k0nQshp3Cy" role="3cqZAp">
+        <node concept="Xl_RD" id="4k0nQshp4Du" role="3tpDZB">
+          <property role="Xl_RC" value="New Name for Class" />
+        </node>
+        <node concept="2OqwBi" id="4k0nQshpc6C" role="3tpDZA">
+          <node concept="2OqwBi" id="4k0nQshp5zq" role="2Oq$k0">
+            <node concept="37vLTw" id="4k0nQshp4ST" role="2Oq$k0">
+              <ref role="3cqZAo" node="4k0nQshp2tQ" resolve="matchingIntention" />
+            </node>
+            <node concept="2OwXpG" id="4k0nQshpbAg" role="2OqNvi">
+              <ref role="2Oxat6" to="18ew:~Pair.o1" resolve="o1" />
+            </node>
+          </node>
+          <node concept="liA8E" id="4k0nQshpcW9" role="2OqNvi">
+            <ref role="37wK5l" to="nddn:~IntentionExecutable.getDescription(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getDescription" />
+            <node concept="37vLTw" id="4k0nQshpdzb" role="37wK5m">
+              <ref role="3cqZAo" node="4k0nQshpcY0" resolve="node" />
+            </node>
+            <node concept="37vLTw" id="4k0nQshpePX" role="37wK5m">
+              <ref role="3cqZAo" node="4k0nQshpecs" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6HRhZeXJVuw" role="3cqZAp" />
+      <node concept="3vwNmj" id="4k0nQshlRlg" role="3cqZAp">
+        <node concept="2bRw2S" id="4k0nQshlR8S" role="3vwVQn">
+          <ref role="2bRw2V" to="6swo:2$zHkrOxF0o" resolve="ClassConceptNewName" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="4k0nQshqR$E" role="3cqZAp" />
+      <node concept="1MFPAf" id="2$zHkrOxMHs" role="3cqZAp">
+        <ref role="1MFYO6" to="6swo:2$zHkrOxF0o" resolve="ClassConceptNewName" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="GsdFj4DiDF">
+    <property role="TrG5h" value="KeyMap" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Enter a character in the editor to invoke the side transformation." />
+    <node concept="3clFbS" id="GsdFj4DiDL" role="LjaKd">
+      <node concept="2TK7Tu" id="GsdFj4H9TZ" role="3cqZAp">
+        <property role="2TTd_B" value="[" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4GAPs" role="25YQCW">
+      <node concept="3cpWsn" id="GsdFj4H3Sz" role="1qenE9">
+        <property role="TrG5h" value="a" />
+        <node concept="10Oyi0" id="GsdFj4H4ho" role="1tU5fm">
+          <node concept="LIFWc" id="GsdFj4H4ij" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="3" />
+            <property role="p6zMs" value="3" />
+            <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4H4hY" role="25YQFr">
+      <node concept="3cpWsn" id="GsdFj4H4hZ" role="1qenE9">
+        <property role="TrG5h" value="a" />
+        <node concept="10Q1$e" id="GsdFj4H4rB" role="1tU5fm">
+          <node concept="10Oyi0" id="GsdFj4H4i0" role="10Q1$1" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="1LcZBjP$2iW">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="LeftHighlighter" />
+    <property role="3YCmrE" value="Access the left highlighter and check that the line numbers column can be found." />
+    <node concept="3clFbS" id="1LcZBjP$2vS" role="LjaKd">
+      <node concept="3cpWs8" id="1LcZBjP$kEc" role="3cqZAp">
+        <node concept="3cpWsn" id="1LcZBjP$kEd" role="3cpWs9">
+          <property role="TrG5h" value="leftEditorHighlighter" />
+          <node concept="3uibUv" id="1LcZBjP$kDG" role="1tU5fm">
+            <ref role="3uigEE" to="px75:~LeftEditorHighlighter" resolve="LeftEditorHighlighter" />
+          </node>
+          <node concept="2OqwBi" id="1LcZBjP$kEe" role="33vP2m">
+            <node concept="369mXd" id="1LcZBjP$kEf" role="2Oq$k0" />
+            <node concept="liA8E" id="1LcZBjP$kEg" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getLeftEditorHighlighter()" resolve="getLeftEditorHighlighter" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Hmddi" id="1LcZBjP$kRE" role="3cqZAp">
+        <node concept="37vLTw" id="1LcZBjP$kSx" role="2Hmdds">
+          <ref role="3cqZAo" node="1LcZBjP$kEd" resolve="leftEditorHighlighter" />
+        </node>
+      </node>
+      <node concept="3cpWs8" id="6HRhZeXKF8w" role="3cqZAp">
+        <node concept="3cpWsn" id="6HRhZeXKF8x" role="3cpWs9">
+          <property role="TrG5h" value="leftColumns" />
+          <node concept="2OqwBi" id="6HRhZeXKF8y" role="33vP2m">
+            <node concept="37vLTw" id="6HRhZeXKF8z" role="2Oq$k0">
+              <ref role="3cqZAo" node="1LcZBjP$kEd" resolve="leftEditorHighlighter" />
+            </node>
+            <node concept="liA8E" id="6HRhZeXKF8$" role="2OqNvi">
+              <ref role="37wK5l" to="px75:~LeftEditorHighlighter.getLeftColumns()" resolve="getLeftColumns" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="6HRhZeXKFB2" role="1tU5fm">
+            <node concept="3uibUv" id="6HRhZeXKFQN" role="_ZDj9">
+              <ref role="3uigEE" to="px75:~AbstractLeftColumn" resolve="AbstractLeftColumn" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Hmddi" id="6HRhZeXK$wC" role="3cqZAp">
+        <node concept="2OqwBi" id="6HRhZeXKHj8" role="2Hmdds">
+          <node concept="37vLTw" id="6HRhZeXKF8_" role="2Oq$k0">
+            <ref role="3cqZAo" node="6HRhZeXKF8x" resolve="leftColumns" />
+          </node>
+          <node concept="1z4cxt" id="6HRhZeXKJvM" role="2OqNvi">
+            <node concept="1bVj0M" id="6HRhZeXKJvO" role="23t8la">
+              <node concept="3clFbS" id="6HRhZeXKJvP" role="1bW5cS">
+                <node concept="3clFbF" id="6HRhZeXKK5i" role="3cqZAp">
+                  <node concept="1Wc70l" id="6HRhZeXKPfk" role="3clFbG">
+                    <node concept="2OqwBi" id="6HRhZeXKRiw" role="3uHU7w">
+                      <node concept="2OqwBi" id="6HRhZeXKPEf" role="2Oq$k0">
+                        <node concept="37vLTw" id="6HRhZeXKPjB" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6HRhZeXKJvQ" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="6HRhZeXKPSt" role="2OqNvi">
+                          <ref role="37wK5l" to="px75:~AbstractLeftColumn.getName()" resolve="getName" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6HRhZeXKTqN" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                        <node concept="Xl_RD" id="6HRhZeXKTyn" role="37wK5m">
+                          <property role="Xl_RC" value="Line" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3y3z36" id="6HRhZeXKOpS" role="3uHU7B">
+                      <node concept="2OqwBi" id="6HRhZeXKKg3" role="3uHU7B">
+                        <node concept="37vLTw" id="6HRhZeXKK5h" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6HRhZeXKJvQ" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="6HRhZeXKK_d" role="2OqNvi">
+                          <ref role="37wK5l" to="px75:~AbstractLeftColumn.getName()" resolve="getName" />
+                        </node>
+                      </node>
+                      <node concept="10Nm6u" id="6HRhZeXKOXw" role="3uHU7w" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="gl6BB" id="6HRhZeXKJvQ" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="6HRhZeXKJvR" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LcZBjP$kSR" role="25YQCW">
+      <node concept="312cEu" id="1LcZBjP$kSP" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjP$kSQ" role="1B3o_S" />
+        <node concept="LIFWc" id="1LcZBjP$kXF" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1LcZBjP$kVX" role="25YQFr">
+      <node concept="312cEu" id="1LcZBjP$kVV" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="1LcZBjP$kVW" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="5yhCTaaqtQn">
+    <property role="TrG5h" value="NodeSubstitutionAndCompletionCustomization" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Invoke the code completion menu and check that the first entry is bold." />
+    <node concept="1qefOq" id="5yhCTaaqtQo" role="25YQCW">
+      <node concept="3iYV7U" id="5yhCTaaqG2y" role="1qenE9">
+        <node concept="LIFWc" id="5yhCTaaqGRF" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_stylings" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="5yhCTaaqtQu" role="LjaKd">
+      <node concept="2HxZob" id="5yhCTaaqtQv" role="3cqZAp">
+        <node concept="1iFQzN" id="5yhCTaaqtQw" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3cpWs8" id="5yhCTaaqtQx" role="3cqZAp">
+        <node concept="3cpWsn" id="5yhCTaaqtQy" role="3cpWs9">
+          <property role="TrG5h" value="nodeSubstituteChooser" />
+          <node concept="3uibUv" id="5yhCTaaqtQz" role="1tU5fm">
+            <ref role="3uigEE" to="6lvu:~NodeSubstituteChooser" resolve="NodeSubstituteChooser" />
+          </node>
+          <node concept="2OqwBi" id="5yhCTaaqtQ$" role="33vP2m">
+            <node concept="369mXd" id="5yhCTaaqtQ_" role="2Oq$k0" />
+            <node concept="liA8E" id="5yhCTaaqtQA" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="5yhCTaaqKXx" role="3cqZAp">
+        <node concept="3cpWsn" id="5yhCTaaqKXy" role="3cpWs9">
+          <property role="TrG5h" value="action" />
+          <node concept="2OqwBi" id="5yhCTaaqMwz" role="33vP2m">
+            <node concept="2OqwBi" id="5yhCTaaqKXz" role="2Oq$k0">
+              <node concept="37vLTw" id="5yhCTaaqKX$" role="2Oq$k0">
+                <ref role="3cqZAo" node="5yhCTaaqtQy" resolve="nodeSubstituteChooser" />
+              </node>
+              <node concept="1PvZjq" id="5yhCTaaqKX_" role="2OqNvi">
+                <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getMatchingActions(java.lang.String)" resolve="getMatchingActions" />
+                <node concept="Xl_RD" id="5yhCTaaqKXA" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5yhCTaaqOJG" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+              <node concept="3cmrfG" id="5yhCTaaqORU" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3uibUv" id="5yhCTaaqKFX" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="5yhCTaaqPrS" role="3cqZAp">
+        <node concept="2OqwBi" id="5yhCTaaqIIQ" role="3vwVQn">
+          <node concept="2OqwBi" id="5yhCTaaqIdX" role="2Oq$k0">
+            <node concept="37vLTw" id="5yhCTaaqHRV" role="2Oq$k0">
+              <ref role="3cqZAo" node="5yhCTaaqtQy" resolve="nodeSubstituteChooser" />
+            </node>
+            <node concept="liA8E" id="5yhCTaaqI_m" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCompletionCustomizationManager()" resolve="getCompletionCustomizationManager" />
+            </node>
+          </node>
+          <node concept="1PvZjq" id="5yhCTaaqKWI" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~CompletionCustomizationManager.isBold(jetbrains.mps.openapi.editor.cells.SubstituteAction,java.lang.String)" resolve="isBold" />
+            <node concept="37vLTw" id="5yhCTaarUXi" role="37wK5m">
+              <ref role="3cqZAo" node="5yhCTaaqKXy" resolve="action" />
+            </node>
+            <node concept="Xl_RD" id="5yhCTaarVbX" role="37wK5m">
+              <property role="Xl_RC" value="" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5yhCTaaqtQR" role="25YQFr">
+      <node concept="3iYV7U" id="5yhCTaaqG3k" role="1qenE9" />
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="1LcZBjPGt7D">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="Notification" />
+    <node concept="1LZb2c" id="1LcZBjPGt7X" role="1SL9yI">
+      <property role="TrG5h" value="testNotification" />
+      <node concept="3cqZAl" id="1LcZBjPGt7Y" role="3clF45" />
+      <node concept="3clFbS" id="1LcZBjPGt82" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXLIuw" role="3cqZAp">
+          <node concept="2OqwBi" id="6HRhZeXLKr_" role="3clFbG">
+            <node concept="2ShNRf" id="6HRhZeXLIus" role="2Oq$k0">
+              <node concept="1pGfFk" id="6HRhZeXLJZ8" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXHgJ5" resolve="PlatformTestHelper" />
+                <node concept="1jxXqW" id="6HRhZeXLKbc" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="6HRhZeXLKLC" role="2OqNvi">
+              <ref role="37wK5l" to="m531:6HRhZeXL36l" resolve="findNotification" />
+              <node concept="1bVj0M" id="6HRhZeXMMVk" role="37wK5m">
+                <node concept="3clFbS" id="6HRhZeXMMVp" role="1bW5cS">
+                  <node concept="3cpWs8" id="1LcZBjPIVYb" role="3cqZAp">
+                    <node concept="3cpWsn" id="1LcZBjPIVYa" role="3cpWs9">
+                      <property role="TrG5h" value="group" />
+                      <node concept="3uibUv" id="1LcZBjPIVYc" role="1tU5fm">
+                        <ref role="3uigEE" to="fnpx:~NotificationGroup" resolve="NotificationGroup" />
+                      </node>
+                      <node concept="2ShNRf" id="1LcZBjPJ7Xn" role="33vP2m">
+                        <node concept="1pGfFk" id="1LcZBjPJ9q3" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="fnpx:~NotificationGroup.&lt;init&gt;(java.lang.String,com.intellij.notification.NotificationDisplayType,boolean)" resolve="NotificationGroup" />
+                          <node concept="Xl_RD" id="1LcZBjPJ9wU" role="37wK5m">
+                            <property role="Xl_RC" value="TestGroup" />
+                          </node>
+                          <node concept="Rm8GO" id="1LcZBjPJa$5" role="37wK5m">
+                            <ref role="Rm8GQ" to="fnpx:~NotificationDisplayType.BALLOON" resolve="BALLOON" />
+                            <ref role="1Px2BO" to="fnpx:~NotificationDisplayType" resolve="NotificationDisplayType" />
+                          </node>
+                          <node concept="3clFbT" id="1LcZBjPJaLb" role="37wK5m">
+                            <property role="3clFbU" value="true" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="1LcZBjPIVYi" role="3cqZAp">
+                    <node concept="3cpWsn" id="1LcZBjPIVYh" role="3cpWs9">
+                      <property role="TrG5h" value="notification" />
+                      <node concept="3uibUv" id="1LcZBjPIVYj" role="1tU5fm">
+                        <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                      </node>
+                      <node concept="2OqwBi" id="1LcZBjPIWXi" role="33vP2m">
+                        <node concept="37vLTw" id="1LcZBjPIW3r" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1LcZBjPIVYa" resolve="group" />
+                        </node>
+                        <node concept="liA8E" id="1LcZBjPIWXj" role="2OqNvi">
+                          <ref role="37wK5l" to="fnpx:~NotificationGroup.createNotification(java.lang.String,java.lang.String,com.intellij.notification.NotificationType)" resolve="createNotification" />
+                          <node concept="Xl_RD" id="1LcZBjPIWXk" role="37wK5m">
+                            <property role="Xl_RC" value="Title" />
+                          </node>
+                          <node concept="Xl_RD" id="1LcZBjPIWXl" role="37wK5m">
+                            <property role="Xl_RC" value="Content" />
+                          </node>
+                          <node concept="Rm8GO" id="1LcZBjPJ64z" role="37wK5m">
+                            <ref role="Rm8GQ" to="fnpx:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                            <ref role="1Px2BO" to="fnpx:~NotificationType" resolve="NotificationType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="1LcZBjPIY70" role="3cqZAp">
+                    <node concept="2YIFZM" id="1LcZBjPIYv4" role="3clFbG">
+                      <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification,com.intellij.openapi.project.Project)" resolve="notify" />
+                      <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
+                      <node concept="37vLTw" id="1LcZBjPIYUD" role="37wK5m">
+                        <ref role="3cqZAo" node="1LcZBjPIVYh" resolve="notification" />
+                      </node>
+                      <node concept="2YIFZM" id="1LcZBjPG$PI" role="37wK5m">
+                        <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                        <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                        <node concept="1jxXqW" id="1LcZBjPHNH4" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1bVj0M" id="6HRhZeXLKT0" role="37wK5m">
+                <node concept="gl6BB" id="6HRhZeXLKT7" role="1bW2Oz">
+                  <property role="TrG5h" value="notification" />
+                  <node concept="2jxLKc" id="6HRhZeXLKT8" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="6HRhZeXLKT9" role="1bW5cS">
+                  <node concept="3vlDli" id="6HRhZeXLNH4" role="3cqZAp">
+                    <node concept="Xl_RD" id="6HRhZeXLNH5" role="3tpDZB">
+                      <property role="Xl_RC" value="Title" />
+                    </node>
+                    <node concept="2OqwBi" id="6HRhZeXLNH6" role="3tpDZA">
+                      <node concept="37vLTw" id="6HRhZeXLNH7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXLKT7" resolve="notification" />
+                      </node>
+                      <node concept="liA8E" id="6HRhZeXLNH8" role="2OqNvi">
+                        <ref role="37wK5l" to="fnpy:~Notification.getTitle()" resolve="getTitle" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3vlDli" id="6HRhZeXLNH9" role="3cqZAp">
+                    <node concept="Xl_RD" id="6HRhZeXLNHa" role="3tpDZB">
+                      <property role="Xl_RC" value="Content" />
+                    </node>
+                    <node concept="2OqwBi" id="6HRhZeXLNHb" role="3tpDZA">
+                      <node concept="37vLTw" id="6HRhZeXLNHc" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXLKT7" resolve="notification" />
+                      </node>
+                      <node concept="liA8E" id="6HRhZeXLNHd" role="2OqNvi">
+                        <ref role="37wK5l" to="fnpy:~Notification.getContent()" resolve="getContent" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3vlDli" id="6HRhZeXLNHe" role="3cqZAp">
+                    <node concept="2OqwBi" id="6HRhZeXLNHf" role="3tpDZA">
+                      <node concept="37vLTw" id="6HRhZeXLNHg" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXLKT7" resolve="notification" />
+                      </node>
+                      <node concept="liA8E" id="6HRhZeXLNHh" role="2OqNvi">
+                        <ref role="37wK5l" to="fnpy:~Notification.getType()" resolve="getType" />
+                      </node>
+                    </node>
+                    <node concept="Rm8GO" id="6HRhZeXLNHi" role="3tpDZB">
+                      <ref role="Rm8GQ" to="fnpy:~NotificationType.INFORMATION" resolve="INFORMATION" />
+                      <ref role="1Px2BO" to="fnpy:~NotificationType" resolve="NotificationType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cmrfG" id="6HRhZeXLOk6" role="37wK5m">
+                <property role="3cmrfH" value="1000" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6cyqnzd$P4A">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="OpenNode" />
+    <node concept="1LZb2c" id="6cyqnzd$P5d" role="1SL9yI">
+      <property role="TrG5h" value="openNode" />
+      <node concept="3cqZAl" id="6cyqnzd$P5e" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzd$P5i" role="3clF47">
+        <node concept="3cpWs8" id="6cyqnzd_dS4" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzd_dS5" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="6cyqnzd_dRh" role="1tU5fm">
+              <ref role="ehGHo" to="tp5g:hHlH9T6" resolve="NodesTestCase" />
+            </node>
+            <node concept="2OqwBi" id="6cyqnzd_dS6" role="33vP2m">
+              <node concept="2tJFMh" id="6cyqnzd_dS7" role="2Oq$k0">
+                <node concept="ZC_QK" id="6cyqnzd_dS8" role="2tJFKM">
+                  <ref role="2aWVGs" node="6cyqnzd$P4A" resolve="OpenNode" />
+                </node>
+              </node>
+              <node concept="Vyspw" id="6cyqnzd_dS9" role="2OqNvi">
+                <node concept="2OqwBi" id="6cyqnzd_dSa" role="Vysub">
+                  <node concept="1jxXqW" id="6cyqnzd_dSb" role="2Oq$k0" />
+                  <node concept="liA8E" id="6cyqnzd_dSc" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="36nYO9w2MGF" role="3cqZAp">
+          <node concept="2OqwBi" id="36nYO9w3Num" role="3clFbG">
+            <node concept="2ShNRf" id="36nYO9w2MGB" role="2Oq$k0">
+              <node concept="1pGfFk" id="36nYO9w3Lf4" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="exr9:~EditorPanelManagerImpl.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorPanelManagerImpl" />
+                <node concept="1jxXqW" id="63oreXBZ6C_" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="36nYO9w3POp" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorPanelManagerImpl.openEditor(org.jetbrains.mps.openapi.model.SNode)" resolve="openEditor" />
+              <node concept="37vLTw" id="36nYO9w3QpJ" role="37wK5m">
+                <ref role="3cqZAo" node="6cyqnzd_dS5" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6cyqnzd_dNP" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzd_dNQ" role="3cpWs9">
+            <property role="TrG5h" value="currentEditorComponent" />
+            <node concept="3uibUv" id="6cyqnzd_dNf" role="1tU5fm">
+              <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="2YIFZM" id="3OVhQEUL8Vt" role="33vP2m">
+              <ref role="37wK5l" to="97tf:7_uCKm_nknH" resolve="getCurrentEditorComponent" />
+              <ref role="1Pybhc" to="97tf:7_uCKm_jZa0" resolve="DebugHelper" />
+              <node concept="1jxXqW" id="6cyqnzd_dNS" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GXo0L" id="6cyqnzd_elp" role="3cqZAp">
+          <node concept="37vLTw" id="6cyqnzd_eot" role="3tpDZB">
+            <ref role="3cqZAo" node="6cyqnzd_dS5" resolve="node" />
+          </node>
+          <node concept="2OqwBi" id="6cyqnzd_eDa" role="3tpDZA">
+            <node concept="37vLTw" id="6cyqnzd_es4" role="2Oq$k0">
+              <ref role="3cqZAo" node="6cyqnzd_dNQ" resolve="currentEditorComponent" />
+            </node>
+            <node concept="liA8E" id="6cyqnzd_eT4" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorComponent.getEditedNode()" resolve="getEditedNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="GsdFj4Ipap">
+    <property role="TrG5h" value="SideTransformation" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Enter text to trigger a side transformation." />
+    <node concept="3clFbS" id="GsdFj4Ipaq" role="LjaKd">
+      <node concept="2TK7Tu" id="GsdFj4Iseu" role="3cqZAp">
+        <property role="2TTd_B" value="+1" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4IFrf" role="25YQCW">
+      <node concept="3cpWs8" id="GsdFj4IFrc" role="1qenE9">
+        <node concept="3cpWsn" id="GsdFj4IFrd" role="3cpWs9">
+          <property role="TrG5h" value="a" />
+          <node concept="10Oyi0" id="GsdFj4IFO3" role="1tU5fm" />
+          <node concept="3cmrfG" id="GsdFj4IFOI" role="33vP2m">
+            <property role="3cmrfH" value="1" />
+            <node concept="LIFWc" id="GsdFj4IKh3" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="1" />
+              <property role="p6zMs" value="1" />
+              <property role="LIFWd" value="property_value" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4IGlN" role="25YQFr">
+      <node concept="3cpWs8" id="GsdFj4IGlK" role="1qenE9">
+        <node concept="3cpWsn" id="GsdFj4IGlL" role="3cpWs9">
+          <property role="TrG5h" value="a" />
+          <node concept="10Oyi0" id="GsdFj4IGIB" role="1tU5fm" />
+          <node concept="3cpWs3" id="GsdFj4IJL8" role="33vP2m">
+            <node concept="3cmrfG" id="GsdFj4IJLb" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="3cmrfG" id="GsdFj4IGJi" role="3uHU7B">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="5T$OTctiTcU">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="SlowEditor" />
+    <node concept="1LZb2c" id="4k0nQsh2exS" role="1SL9yI">
+      <property role="TrG5h" value="detectSlowEditor" />
+      <node concept="3cqZAl" id="4k0nQsh2exT" role="3clF45" />
+      <node concept="3clFbS" id="4k0nQsh2exX" role="3clF47">
+        <node concept="3SKdUt" id="4k0nQshfWzT" role="3cqZAp">
+          <node concept="1PaTwC" id="4k0nQshfWzU" role="1aUNEU">
+            <node concept="3oM_SD" id="4k0nQshfX7h" role="1PaTwD">
+              <property role="3oM_SC" value="FIXME" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshfX7i" role="1PaTwD">
+              <property role="3oM_SC" value="Always" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshfX7j" role="1PaTwD">
+              <property role="3oM_SC" value="true." />
+            </node>
+            <node concept="3oM_SD" id="5nwfWGQbn71" role="1PaTwD">
+              <property role="3oM_SC" value="A" />
+            </node>
+            <node concept="3oM_SD" id="5nwfWGQbnc4" role="1PaTwD">
+              <property role="3oM_SC" value="different" />
+            </node>
+            <node concept="3oM_SD" id="5nwfWGQbnm9" role="1PaTwD">
+              <property role="3oM_SC" value="freeze" />
+            </node>
+            <node concept="3oM_SD" id="5nwfWGQbnrc" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="5nwfWGQbnrd" role="1PaTwD">
+              <property role="3oM_SC" value="found" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQsh4ir8" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQsh4ir9" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="4k0nQsh4ira" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="4k0nQsh4irV" role="33vP2m">
+              <node concept="1pGfFk" id="4k0nQsh5GDv" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="exr9:~NodeEditorComponent.&lt;init&gt;(org.jetbrains.mps.openapi.module.SRepository)" resolve="NodeEditorComponent" />
+                <node concept="2OqwBi" id="4k0nQsh5J5X" role="37wK5m">
+                  <node concept="1jxXqW" id="4k0nQsh5GDY" role="2Oq$k0" />
+                  <node concept="liA8E" id="4k0nQsh5Kp9" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQshbnk4" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshbnk5" role="3cpWs9">
+            <property role="TrG5h" value="eventTriggered" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="4k0nQshbnk6" role="1tU5fm">
+              <ref role="3uigEE" to="i5cy:~AtomicBoolean" resolve="AtomicBoolean" />
+            </node>
+            <node concept="2ShNRf" id="4k0nQshbnZw" role="33vP2m">
+              <node concept="1pGfFk" id="4k0nQshbprU" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="i5cy:~AtomicBoolean.&lt;init&gt;(boolean)" resolve="AtomicBoolean" />
+                <node concept="3clFbT" id="4k0nQshbprW" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4k0nQshbr$B" role="3cqZAp" />
+        <node concept="3cpWs8" id="4k0nQsh624r" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQsh624s" role="3cpWs9">
+            <property role="TrG5h" value="watcher" />
+            <node concept="3uibUv" id="4k0nQsh624t" role="1tU5fm">
+              <ref role="3uigEE" to="al1t:~PerformanceWatcherImpl" resolve="PerformanceWatcherImpl" />
+            </node>
+            <node concept="0kSF2" id="4k0nQsh62AE" role="33vP2m">
+              <node concept="3uibUv" id="4k0nQsh62AH" role="0kSFW">
+                <ref role="3uigEE" to="al1t:~PerformanceWatcherImpl" resolve="PerformanceWatcherImpl" />
+              </node>
+              <node concept="2YIFZM" id="4k0nQsh5VSR" role="0kSFX">
+                <ref role="37wK5l" to="al1t:~PerformanceWatcher.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="al1t:~PerformanceWatcher" resolve="PerformanceWatcher" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQsh6Js4" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQsh6Js5" role="3cpWs9">
+            <property role="TrG5h" value="performanceListener" />
+            <node concept="3uibUv" id="4k0nQsh6Js6" role="1tU5fm">
+              <ref role="3uigEE" to="al1t:~PerformanceListener" resolve="PerformanceListener" />
+            </node>
+            <node concept="2ShNRf" id="4k0nQsh6K1b" role="33vP2m">
+              <node concept="YeOm9" id="4k0nQsh6MQU" role="2ShVmc">
+                <node concept="1Y3b0j" id="4k0nQsh6MQX" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="al1t:~PerformanceListener" resolve="PerformanceListener" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3Tm1VV" id="4k0nQsh6MQY" role="1B3o_S" />
+                  <node concept="3clFb_" id="4k0nQsh7Rr8" role="jymVt">
+                    <property role="TrG5h" value="uiFreezeStarted" />
+                    <node concept="3Tm1VV" id="4k0nQsh7Rra" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4k0nQsh7Rrc" role="3clF45" />
+                    <node concept="37vLTG" id="4k0nQsh7Rrd" role="3clF46">
+                      <property role="TrG5h" value="reportDir" />
+                      <node concept="3uibUv" id="4k0nQsh7Rre" role="1tU5fm">
+                        <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
+                      </node>
+                      <node concept="2AHcQZ" id="4k0nQsh7Rrf" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="4k0nQsh7Rrg" role="3clF46">
+                      <property role="TrG5h" value="coroutineScope" />
+                      <node concept="3uibUv" id="4k0nQsh7Rrh" role="1tU5fm">
+                        <ref role="3uigEE" to="prgy:~CoroutineScope" resolve="CoroutineScope" />
+                      </node>
+                      <node concept="2AHcQZ" id="4k0nQsh7Rri" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4k0nQsh7Rrk" role="3clF47">
+                      <node concept="3clFbF" id="4k0nQshd7Ak" role="3cqZAp">
+                        <node concept="2OqwBi" id="4k0nQshd7Ah" role="3clFbG">
+                          <node concept="10M0yZ" id="4k0nQshd7Ai" role="2Oq$k0">
+                            <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                            <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                          </node>
+                          <node concept="liA8E" id="4k0nQshd7Aj" role="2OqNvi">
+                            <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                            <node concept="Xl_RD" id="4k0nQshd895" role="37wK5m">
+                              <property role="Xl_RC" value="freeze started" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4k0nQshbsgT" role="3cqZAp">
+                        <node concept="2OqwBi" id="4k0nQshbtkt" role="3clFbG">
+                          <node concept="37vLTw" id="4k0nQshbsgS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4k0nQshbnk5" resolve="eventTriggered" />
+                          </node>
+                          <node concept="liA8E" id="4k0nQshbtXV" role="2OqNvi">
+                            <ref role="37wK5l" to="i5cy:~AtomicBoolean.set(boolean)" resolve="set" />
+                            <node concept="3clFbT" id="4k0nQshbv15" role="37wK5m">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4k0nQsh7Rrl" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2tJIrI" id="4k0nQshdTYH" role="jymVt" />
+                  <node concept="3clFb_" id="4k0nQshdUM0" role="jymVt">
+                    <property role="TrG5h" value="uiFreezeFinished" />
+                    <node concept="3Tm1VV" id="4k0nQshdUM2" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4k0nQshdUM4" role="3clF45" />
+                    <node concept="37vLTG" id="4k0nQshdUM5" role="3clF46">
+                      <property role="TrG5h" value="durationMs" />
+                      <node concept="3cpWsb" id="4k0nQshdUM6" role="1tU5fm" />
+                    </node>
+                    <node concept="37vLTG" id="4k0nQshdUM7" role="3clF46">
+                      <property role="TrG5h" value="reportDir" />
+                      <node concept="3uibUv" id="4k0nQshdUM8" role="1tU5fm">
+                        <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
+                      </node>
+                      <node concept="2AHcQZ" id="4k0nQshdUM9" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4k0nQshdUMb" role="3clF47">
+                      <node concept="3clFbF" id="4k0nQshdXTl" role="3cqZAp">
+                        <node concept="2OqwBi" id="4k0nQshdXTi" role="3clFbG">
+                          <node concept="10M0yZ" id="4k0nQshdXTj" role="2Oq$k0">
+                            <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                            <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                          </node>
+                          <node concept="liA8E" id="4k0nQshdXTk" role="2OqNvi">
+                            <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                            <node concept="Xl_RD" id="4k0nQshdYTS" role="37wK5m">
+                              <property role="Xl_RC" value="freeze finished" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4k0nQshdUMc" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3clFb_" id="4k0nQshdUMj" role="jymVt">
+                    <property role="TrG5h" value="uiFreezeRecorded" />
+                    <node concept="3Tm1VV" id="4k0nQshdUMl" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4k0nQshdUMn" role="3clF45" />
+                    <node concept="37vLTG" id="4k0nQshdUMo" role="3clF46">
+                      <property role="TrG5h" value="durationMs" />
+                      <node concept="3cpWsb" id="4k0nQshdUMp" role="1tU5fm" />
+                    </node>
+                    <node concept="37vLTG" id="4k0nQshdUMq" role="3clF46">
+                      <property role="TrG5h" value="reportDir" />
+                      <node concept="3uibUv" id="4k0nQshdUMr" role="1tU5fm">
+                        <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
+                      </node>
+                      <node concept="2AHcQZ" id="4k0nQshdUMs" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4k0nQshdUMu" role="3clF47">
+                      <node concept="3clFbF" id="4k0nQshe0yj" role="3cqZAp">
+                        <node concept="2OqwBi" id="4k0nQshe0yk" role="3clFbG">
+                          <node concept="10M0yZ" id="4k0nQshe0yl" role="2Oq$k0">
+                            <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                            <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                          </node>
+                          <node concept="liA8E" id="4k0nQshe0ym" role="2OqNvi">
+                            <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                            <node concept="Xl_RD" id="4k0nQshe0yn" role="37wK5m">
+                              <property role="Xl_RC" value="freeze recorded" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4k0nQshdUMv" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQsh6BXF" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQsh6BXG" role="3cpWs9">
+            <property role="TrG5h" value="EP_NAME" />
+            <node concept="3uibUv" id="4k0nQsh6BXD" role="1tU5fm">
+              <ref role="3uigEE" to="9ti4:~ExtensionPointName" resolve="ExtensionPointName" />
+              <node concept="3uibUv" id="4k0nQsh6CfE" role="11_B2D">
+                <ref role="3uigEE" to="al1t:~PerformanceListener" resolve="PerformanceListener" />
+              </node>
+            </node>
+            <node concept="10Nm6u" id="4k0nQsh71u1" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4k0nQshbpXu" role="3cqZAp" />
+        <node concept="3J1_TO" id="4k0nQsh6DMu" role="3cqZAp">
+          <node concept="3clFbS" id="4k0nQsh6DMv" role="1zxBo7">
+            <node concept="3cpWs8" id="4k0nQsh6wdH" role="3cqZAp">
+              <node concept="3cpWsn" id="4k0nQsh6wdI" role="3cpWs9">
+                <property role="TrG5h" value="epField" />
+                <node concept="3uibUv" id="4k0nQsh6wdJ" role="1tU5fm">
+                  <ref role="3uigEE" to="t6h5:~Field" resolve="Field" />
+                </node>
+                <node concept="2OqwBi" id="4k0nQsh6xzx" role="33vP2m">
+                  <node concept="3VsKOn" id="4k0nQsh6wl5" role="2Oq$k0">
+                    <ref role="3VsUkX" to="al1t:~PerformanceWatcherImplKt" resolve="PerformanceWatcherImplKt" />
+                  </node>
+                  <node concept="liA8E" id="4k0nQsh6zNh" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Class.getDeclaredField(java.lang.String)" resolve="getDeclaredField" />
+                    <node concept="Xl_RD" id="4k0nQsh6zTb" role="37wK5m">
+                      <property role="Xl_RC" value="EP_NAME" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQsh6_$W" role="3cqZAp">
+              <node concept="2OqwBi" id="4k0nQsh6A1q" role="3clFbG">
+                <node concept="37vLTw" id="4k0nQsh6_$U" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4k0nQsh6wdI" resolve="epField" />
+                </node>
+                <node concept="liA8E" id="4k0nQsh6A$F" role="2OqNvi">
+                  <ref role="37wK5l" to="t6h5:~Field.setAccessible(boolean)" resolve="setAccessible" />
+                  <node concept="3clFbT" id="4k0nQsh6A$H" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQsh6ZBt" role="3cqZAp">
+              <node concept="37vLTI" id="4k0nQsh6ZBv" role="3clFbG">
+                <node concept="1eOMI4" id="4k0nQsh6CsD" role="37vLTx">
+                  <node concept="10QFUN" id="4k0nQsh6CsA" role="1eOMHV">
+                    <node concept="3uibUv" id="4k0nQsh6CsF" role="10QFUM">
+                      <ref role="3uigEE" to="9ti4:~ExtensionPointName" resolve="ExtensionPointName" />
+                      <node concept="3uibUv" id="4k0nQsh6CsG" role="11_B2D">
+                        <ref role="3uigEE" to="al1t:~PerformanceListener" resolve="PerformanceListener" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4k0nQsh6CYU" role="10QFUP">
+                      <node concept="37vLTw" id="4k0nQsh6Cwr" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4k0nQsh6wdI" resolve="epField" />
+                      </node>
+                      <node concept="liA8E" id="4k0nQsh6DzR" role="2OqNvi">
+                        <ref role="37wK5l" to="t6h5:~Field.get(java.lang.Object)" resolve="get" />
+                        <node concept="37vLTw" id="4k0nQsh6DCK" role="37wK5m">
+                          <ref role="3cqZAo" node="4k0nQsh624s" resolve="watcher" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4k0nQsh6ZBz" role="37vLTJ">
+                  <ref role="3cqZAo" node="4k0nQsh6BXG" resolve="EP_NAME" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQsh6EXS" role="3cqZAp">
+              <node concept="2OqwBi" id="4k0nQsh6Hed" role="3clFbG">
+                <node concept="2OqwBi" id="4k0nQsh6Fvu" role="2Oq$k0">
+                  <node concept="37vLTw" id="4k0nQsh6EXQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4k0nQsh6BXG" resolve="EP_NAME" />
+                  </node>
+                  <node concept="liA8E" id="4k0nQsh6GOB" role="2OqNvi">
+                    <ref role="37wK5l" to="9ti4:~ExtensionPointName.getPoint()" resolve="getPoint" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="4k0nQsh6HSU" role="2OqNvi">
+                  <ref role="37wK5l" to="9ti4:~ExtensionPoint.registerExtension(java.lang.Object,com.intellij.openapi.Disposable)" resolve="registerExtension" />
+                  <node concept="37vLTw" id="4k0nQsh6Rkb" role="37wK5m">
+                    <ref role="3cqZAo" node="4k0nQsh6Js5" resolve="performanceListener" />
+                  </node>
+                  <node concept="2YIFZM" id="5nwfWGQbxLv" role="37wK5m">
+                    <ref role="37wK5l" to="zn9m:~Disposer.newDisposable()" resolve="newDisposable" />
+                    <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="5nwfWGQbo_N" role="3cqZAp">
+              <node concept="1PaTwC" id="5nwfWGQbo_O" role="1aUNEU">
+                <node concept="3oM_SD" id="5nwfWGQbp4E" role="1PaTwD">
+                  <property role="3oM_SC" value="It" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4F" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4G" role="1PaTwD">
+                  <property role="3oM_SC" value="set" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4H" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4I" role="1PaTwD">
+                  <property role="3oM_SC" value="false" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4J" role="1PaTwD">
+                  <property role="3oM_SC" value="but" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4K" role="1PaTwD">
+                  <property role="3oM_SC" value="there" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4L" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4M" role="1PaTwD">
+                  <property role="3oM_SC" value="still" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4N" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="5nwfWGQbp4O" role="1PaTwD">
+                  <property role="3oM_SC" value="freeze" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQsh5T8b" role="3cqZAp">
+              <node concept="37vLTI" id="4k0nQsh5VuS" role="3clFbG">
+                <node concept="3clFbT" id="4k0nQsh5Vwd" role="37vLTx" />
+                <node concept="2OqwBi" id="4k0nQsh5TlB" role="37vLTJ">
+                  <node concept="3xONca" id="4k0nQsh5T89" role="2Oq$k0">
+                    <ref role="3xOPvv" node="4k0nQsh5PIt" resolve="slowMode" />
+                  </node>
+                  <node concept="3TrcHB" id="4k0nQsh5TF7" role="2OqNvi">
+                    <ref role="3TsBF5" to="jv43:5T$OTctiKmX" resolve="slowMode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4k0nQsh5Npx" role="3cqZAp">
+              <node concept="2OqwBi" id="4k0nQsh5PHk" role="3clFbG">
+                <node concept="37vLTw" id="4k0nQsh5Npv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4k0nQsh4ir9" resolve="component" />
+                </node>
+                <node concept="liA8E" id="4k0nQsh5SS6" role="2OqNvi">
+                  <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+                  <node concept="3xONca" id="4k0nQsh5Vzx" role="37wK5m">
+                    <ref role="3xOPvv" node="4k0nQsh5PIt" resolve="slowMode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4k0nQshbwg0" role="3cqZAp">
+              <node concept="3cpWsn" id="4k0nQshbwfZ" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="10P_77" id="4k0nQshbwg1" role="1tU5fm" />
+                <node concept="2OqwBi" id="4k0nQshbJhc" role="33vP2m">
+                  <node concept="2ShNRf" id="4k0nQshb$ld" role="2Oq$k0">
+                    <node concept="YeOm9" id="4k0nQshbEvi" role="2ShVmc">
+                      <node concept="1Y3b0j" id="4k0nQshbEvl" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="9w4s:~WaitFor.&lt;init&gt;(int)" resolve="WaitFor" />
+                        <ref role="1Y3XeK" to="9w4s:~WaitFor" resolve="WaitFor" />
+                        <node concept="3Tm1VV" id="4k0nQshbEvm" role="1B3o_S" />
+                        <node concept="3cmrfG" id="4k0nQshbDbT" role="37wK5m">
+                          <property role="3cmrfH" value="15000" />
+                        </node>
+                        <node concept="3clFb_" id="4k0nQshbEMt" role="jymVt">
+                          <property role="TrG5h" value="condition" />
+                          <node concept="3Tmbuc" id="4k0nQshbEMu" role="1B3o_S" />
+                          <node concept="10P_77" id="4k0nQshbEMw" role="3clF45" />
+                          <node concept="3clFbS" id="4k0nQshbEMy" role="3clF47">
+                            <node concept="3clFbF" id="4k0nQshbGYO" role="3cqZAp">
+                              <node concept="2OqwBi" id="4k0nQshbHQL" role="3clFbG">
+                                <node concept="37vLTw" id="4k0nQshbGYN" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4k0nQshbnk5" resolve="eventTriggered" />
+                                </node>
+                                <node concept="liA8E" id="4k0nQshbI$7" role="2OqNvi">
+                                  <ref role="37wK5l" to="i5cy:~AtomicBoolean.get()" resolve="get" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="4k0nQshbEMz" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4k0nQshbKQn" role="2OqNvi">
+                    <ref role="37wK5l" node="4k0nQshbEMt" resolve="condition" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3vwNmj" id="4k0nQshbLW2" role="3cqZAp">
+              <node concept="37vLTw" id="4k0nQshbMtK" role="3vwVQn">
+                <ref role="3cqZAo" node="4k0nQshbwfZ" resolve="result" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="4k0nQshbvE6" role="3cqZAp" />
+          </node>
+          <node concept="3uVAMA" id="4k0nQsh6DMx" role="1zxBo5">
+            <node concept="3clFbS" id="4k0nQsh6DMy" role="1zc67A" />
+            <node concept="XOnhg" id="4k0nQsh6DMz" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4k0nQsh6DM$" role="1tU5fm">
+                <node concept="3uibUv" id="4k0nQsh6DMw" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~NoSuchFieldException" resolve="NoSuchFieldException" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="4k0nQsh6EnR" role="1zxBo5">
+            <node concept="3clFbS" id="4k0nQsh6EnS" role="1zc67A" />
+            <node concept="XOnhg" id="4k0nQsh6EnT" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4k0nQsh6EnU" role="1tU5fm">
+                <node concept="3uibUv" id="4k0nQsh6EnQ" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~IllegalAccessException" resolve="IllegalAccessException" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="4k0nQsh6Wgy" role="1zxBo6">
+            <node concept="3clFbS" id="4k0nQsh6Wgz" role="1wplMD">
+              <node concept="3clFbJ" id="4k0nQsh72Z$" role="3cqZAp">
+                <node concept="3clFbS" id="4k0nQsh72ZA" role="3clFbx">
+                  <node concept="3clFbF" id="4k0nQsh6WCC" role="3cqZAp">
+                    <node concept="2OqwBi" id="4k0nQsh6XzV" role="3clFbG">
+                      <node concept="2OqwBi" id="4k0nQsh6WCE" role="2Oq$k0">
+                        <node concept="37vLTw" id="4k0nQsh6WCF" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4k0nQsh6BXG" resolve="EP_NAME" />
+                        </node>
+                        <node concept="liA8E" id="4k0nQsh6WCG" role="2OqNvi">
+                          <ref role="37wK5l" to="9ti4:~ExtensionPointName.getPoint()" resolve="getPoint" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4k0nQsh6Ykd" role="2OqNvi">
+                        <ref role="37wK5l" to="9ti4:~ExtensionPoint.unregisterExtension(java.lang.Class)" resolve="unregisterExtension" />
+                        <node concept="3VsKOn" id="5nwfWGQbzAH" role="37wK5m">
+                          <ref role="3VsUkX" to="al1t:~PerformanceListener" resolve="PerformanceListener" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="4k0nQsh74LW" role="3clFbw">
+                  <node concept="10Nm6u" id="4k0nQsh75r2" role="3uHU7w" />
+                  <node concept="37vLTw" id="4k0nQsh73Ib" role="3uHU7B">
+                    <ref role="3cqZAo" node="4k0nQsh6BXG" resolve="EP_NAME" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5T$OTctiTcW" role="1SKRRt">
+      <node concept="13bv17" id="5T$OTctiTcV" role="1qenE9">
+        <node concept="3xLA65" id="4k0nQsh5PIt" role="lGtFl">
+          <property role="TrG5h" value="slowMode" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="GsdFj4P2AO">
+    <property role="TrG5h" value="SubstituteMenu" />
+    <property role="3GE5qa" value="editor" />
+    <property role="3YCmrE" value="Check that the substitute menu contains a certain matching text." />
+    <node concept="1qefOq" id="GsdFj4P2AP" role="25YQCW">
+      <node concept="3cpWs8" id="GsdFj4P2Cw" role="1qenE9">
+        <node concept="3cpWsn" id="GsdFj4P2Cx" role="3cpWs9">
+          <property role="TrG5h" value="a" />
+          <node concept="10P_77" id="GsdFj4P3Py" role="1tU5fm" />
+          <node concept="33vP2n" id="GsdFj4P3PR" role="33vP2m">
+            <node concept="LIFWc" id="GsdFj4P43C" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Custom_1ltshm_a0" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="GsdFj4P2AW" role="LjaKd">
+      <node concept="2HxZob" id="GsdFj4P429" role="3cqZAp">
+        <node concept="1iFQzN" id="GsdFj4P42r" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3cpWs8" id="GsdFj4P7QG" role="3cqZAp">
+        <node concept="3cpWsn" id="GsdFj4P7QH" role="3cpWs9">
+          <property role="TrG5h" value="nodeSubstituteChooser" />
+          <node concept="3uibUv" id="GsdFj4P7Qb" role="1tU5fm">
+            <ref role="3uigEE" to="6lvu:~NodeSubstituteChooser" resolve="NodeSubstituteChooser" />
+          </node>
+          <node concept="2OqwBi" id="GsdFj4P7QI" role="33vP2m">
+            <node concept="369mXd" id="GsdFj4P7QJ" role="2Oq$k0" />
+            <node concept="liA8E" id="GsdFj4P7QK" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="GsdFj4P4fa" role="3cqZAp">
+        <node concept="2OqwBi" id="GsdFj4P82n" role="3vwVQn">
+          <node concept="37vLTw" id="GsdFj4P7Te" role="2Oq$k0">
+            <ref role="3cqZAo" node="GsdFj4P7QH" resolve="nodeSubstituteChooser" />
+          </node>
+          <node concept="liA8E" id="GsdFj4P8dO" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.isVisible()" resolve="isVisible" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="GsdFj4P8qA" role="3cqZAp">
+        <node concept="Xl_RD" id="GsdFj4P8rT" role="3tpDZB">
+          <property role="Xl_RC" value="false" />
+        </node>
+        <node concept="2OqwBi" id="GsdFj4PbQu" role="3tpDZA">
+          <node concept="2OqwBi" id="GsdFj4PabI" role="2Oq$k0">
+            <node concept="2OqwBi" id="GsdFj4P8AS" role="2Oq$k0">
+              <node concept="37vLTw" id="GsdFj4P8tM" role="2Oq$k0">
+                <ref role="3cqZAo" node="GsdFj4P7QH" resolve="nodeSubstituteChooser" />
+              </node>
+              <node concept="1PvZjq" id="GsdFj4P8My" role="2OqNvi">
+                <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getMatchingActions(java.lang.String)" resolve="getMatchingActions" />
+                <node concept="Xl_RD" id="GsdFj4P8Ng" role="37wK5m">
+                  <property role="Xl_RC" value="fal" />
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="GsdFj4Pbyd" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+              <node concept="3cmrfG" id="GsdFj4PbCs" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="GsdFj4Pc8n" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.getVisibleMatchingText(java.lang.String)" resolve="getVisibleMatchingText" />
+            <node concept="Xl_RD" id="GsdFj4PcfB" role="37wK5m">
+              <property role="Xl_RC" value="fal" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="GsdFj4PkIZ" role="25YQFr">
+      <node concept="3cpWs8" id="GsdFj4PkIW" role="1qenE9">
+        <node concept="3cpWsn" id="GsdFj4PkIX" role="3cpWs9">
+          <property role="TrG5h" value="a" />
+          <node concept="10P_77" id="GsdFj4Pm4r" role="1tU5fm" />
+          <node concept="33vP2n" id="GsdFj4Pm52" role="33vP2m" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrO_1hi">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="Tooltip" />
+    <property role="3YCmrE" value="Check that the tooltip of the cell contains a certain text." />
+    <node concept="1qefOq" id="2$zHkrO_1iz" role="25YQCW">
+      <node concept="3tHVZ1" id="2$zHkrO_1iP" role="1qenE9">
+        <node concept="LIFWc" id="2$zHkrO_1PJ" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_vfxqrs_a0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrO_1j6" role="25YQFr">
+      <node concept="3tHVZ1" id="2$zHkrO_1j8" role="1qenE9" />
+    </node>
+    <node concept="3clFbS" id="2$zHkrO_1tM" role="LjaKd">
+      <node concept="3cpWs8" id="2$zHkrO_5bO" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrO_5bP" role="3cpWs9">
+          <property role="TrG5h" value="selectedCell" />
+          <node concept="3uibUv" id="2$zHkrO_5bj" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrO_5bQ" role="33vP2m">
+            <node concept="369mXd" id="2$zHkrO_5bR" role="2Oq$k0" />
+            <node concept="liA8E" id="2$zHkrO_5bS" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="7PTDMdvgZ0f" role="3cqZAp">
+        <node concept="Xl_RD" id="7PTDMdvgZ4X" role="3tpDZB">
+          <property role="Xl_RC" value="Tooltip" />
+        </node>
+        <node concept="2OqwBi" id="7PTDMdvjSNA" role="3tpDZA">
+          <node concept="0kSF2" id="7PTDMdvjRJB" role="2Oq$k0">
+            <node concept="3uibUv" id="7PTDMdvjRJD" role="0kSFW">
+              <ref role="3uigEE" to="g51k:~EditorCell_Constant" resolve="EditorCell_Constant" />
+            </node>
+            <node concept="2OqwBi" id="7PTDMdvjPV1" role="0kSFX">
+              <node concept="2OqwBi" id="7PTDMdvhLOJ" role="2Oq$k0">
+                <node concept="2ShNRf" id="7PTDMdvgZ7r" role="2Oq$k0">
+                  <node concept="1pGfFk" id="7PTDMdvhJtX" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="m531:6HRhZeXDHY2" resolve="EditorCellTestHelper" />
+                    <node concept="37vLTw" id="7PTDMdvhLjH" role="37wK5m">
+                      <ref role="3cqZAo" node="2$zHkrO_5bP" resolve="selectedCell" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="7PTDMdvhM4Q" role="2OqNvi">
+                  <ref role="37wK5l" to="m531:7PTDMdvgIBe" resolve="getToolTipCell" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7PTDMdvjR4k" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell_Collection.firstContentCell()" resolve="firstContentCell" />
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="7PTDMdvjUBo" role="2OqNvi">
+            <ref role="37wK5l" to="g51k:~EditorCell_Label.getText()" resolve="getText" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="5kFTseQQT1w">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="3tFllW" id="2$zHkrO$C8n">
+    <property role="3GE5qa" value="diagrams" />
+    <node concept="1Pa9Pv" id="2$zHkrO$C8o" role="3tFlkb">
+      <node concept="1PaTwC" id="2$zHkrO$C8p" role="1PaQFQ">
+        <node concept="3oM_SD" id="2$zHkrO$C8q" role="1PaTwD">
+          <property role="3oM_SC" value="Diagram" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8r" role="1PaTwD">
+          <property role="3oM_SC" value="tests" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8s" role="1PaTwD">
+          <property role="3oM_SC" value="can" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8t" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8u" role="1PaTwD">
+          <property role="3oM_SC" value="found" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8v" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrO$C8x" role="1PaTwD">
+          <property role="3oM_SC" value="test.de.itemis.mps.editor.diagram.solution" />
+          <property role="1X82VY" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="5T$OTctdljQ">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="generator" />
+    <property role="TrG5h" value="GeneratorPerformance" />
+    <node concept="1LZb2c" id="5T$OTctdlka" role="1SL9yI">
+      <property role="TrG5h" value="timeGenerator" />
+      <node concept="3cqZAl" id="5T$OTctdlkb" role="3clF45" />
+      <node concept="3clFbS" id="5T$OTctdlkf" role="3clF47">
+        <node concept="3cpWs8" id="5T$OTctgBFZ" role="3cqZAp">
+          <node concept="3cpWsn" id="5T$OTctgBG0" role="3cpWs9">
+            <property role="TrG5h" value="statusRef" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="5T$OTctgBDK" role="1tU5fm">
+              <ref role="3uigEE" to="i5cy:~AtomicReference" resolve="AtomicReference" />
+              <node concept="3uibUv" id="7PTDMdvpvX2" role="11_B2D">
+                <ref role="3uigEE" to="ap4t:~GenerationStatus" resolve="GenerationStatus" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="7PTDMdvpInU" role="33vP2m">
+              <node concept="1pGfFk" id="7PTDMdvpKu1" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="i5cy:~AtomicReference.&lt;init&gt;()" resolve="AtomicReference" />
+                <node concept="3uibUv" id="7PTDMdvpM6H" role="1pMfVU">
+                  <ref role="3uigEE" to="ap4t:~GenerationStatus" resolve="GenerationStatus" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7PTDMdvkJJ9" role="3cqZAp">
+          <node concept="3cpWsn" id="7PTDMdvkJJa" role="3cpWs9">
+            <property role="TrG5h" value="timeInMS" />
+            <node concept="3cpWsb" id="7PTDMdvkIH1" role="1tU5fm" />
+            <node concept="10M0yZ" id="7PTDMdvl4lL" role="33vP2m">
+              <ref role="3cqZAo" to="wyt6:~Long.MAX_VALUE" resolve="MAX_VALUE" />
+              <ref role="1PxDUh" to="wyt6:~Long" resolve="Long" />
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="7PTDMdvkVaT" role="3cqZAp">
+          <node concept="3uVAMA" id="7PTDMdvkVgq" role="1zxBo5">
+            <node concept="XOnhg" id="7PTDMdvkVgr" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="7PTDMdvkVgs" role="1tU5fm">
+                <node concept="3uibUv" id="7PTDMdvkXCM" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7PTDMdvkVgt" role="1zc67A">
+              <node concept="3xETmq" id="7PTDMdvl1rj" role="3cqZAp">
+                <node concept="3_1$Yv" id="7PTDMdvl1w9" role="3_9lra">
+                  <node concept="2OqwBi" id="7PTDMdvl2px" role="3_1BAH">
+                    <node concept="37vLTw" id="7PTDMdvl1_1" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7PTDMdvkVgr" resolve="e" />
+                    </node>
+                    <node concept="liA8E" id="7PTDMdvl2Zg" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="7PTDMdvkVaU" role="1zxBo7">
+            <node concept="3clFbF" id="7PTDMdvl3Hh" role="3cqZAp">
+              <node concept="37vLTI" id="7PTDMdvl3Hj" role="3clFbG">
+                <node concept="2YIFZM" id="7PTDMdvkJJb" role="37vLTx">
+                  <ref role="37wK5l" to="9w4s:~TimeoutUtil.measureExecutionTime(com.intellij.util.ThrowableRunnable)" resolve="measureExecutionTime" />
+                  <ref role="1Pybhc" to="9w4s:~TimeoutUtil" resolve="TimeoutUtil" />
+                  <node concept="2ShNRf" id="7PTDMdvmpog" role="37wK5m">
+                    <node concept="YeOm9" id="7PTDMdvmslc" role="2ShVmc">
+                      <node concept="1Y3b0j" id="7PTDMdvmslf" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <property role="373rjd" value="true" />
+                        <ref role="1Y3XeK" to="9w4s:~ThrowableRunnable" resolve="ThrowableRunnable" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="3Tm1VV" id="7PTDMdvmslg" role="1B3o_S" />
+                        <node concept="3clFb_" id="7PTDMdvmslu" role="jymVt">
+                          <property role="TrG5h" value="run" />
+                          <node concept="3Tm1VV" id="7PTDMdvmslv" role="1B3o_S" />
+                          <node concept="3cqZAl" id="7PTDMdvmslx" role="3clF45" />
+                          <node concept="3clFbS" id="7PTDMdvmsly" role="3clF47">
+                            <node concept="3clFbF" id="7PTDMdvp$hO" role="3cqZAp">
+                              <node concept="2OqwBi" id="7PTDMdvp_a9" role="3clFbG">
+                                <node concept="37vLTw" id="7PTDMdvp$hM" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5T$OTctgBG0" resolve="statusRef" />
+                                </node>
+                                <node concept="liA8E" id="7PTDMdvpAmc" role="2OqNvi">
+                                  <ref role="37wK5l" to="i5cy:~AtomicReference.set(java.lang.Object)" resolve="set" />
+                                  <node concept="2OqwBi" id="5T$OTctgBG1" role="37wK5m">
+                                    <node concept="2ShNRf" id="5T$OTctgBG2" role="2Oq$k0">
+                                      <node concept="HV5vD" id="5T$OTctgBG3" role="2ShVmc">
+                                        <property role="373rjd" value="true" />
+                                        <ref role="HV5vE" to="mqum:58oUBCRuqiK" resolve="GeneratorFacade" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="5T$OTctgBG4" role="2OqNvi">
+                                      <ref role="37wK5l" to="mqum:5Bng$8dmaOo" resolve="runGenerator" />
+                                      <node concept="2OqwBi" id="5T$OTctgBG5" role="37wK5m">
+                                        <node concept="1jxXqW" id="5T$OTctgBG6" role="2Oq$k0" />
+                                        <node concept="liA8E" id="5T$OTctgBG7" role="2OqNvi">
+                                          <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                                        </node>
+                                      </node>
+                                      <node concept="10Nm6u" id="5T$OTctgBG8" role="37wK5m" />
+                                      <node concept="1Xw6AR" id="5T$OTctgBG9" role="37wK5m">
+                                        <node concept="1dCxOl" id="3OVhQEUJc0S" role="1XwpL7">
+                                          <property role="1XweGQ" value="r:7a418de5-925b-4367-b95e-862bf70ebd19" />
+                                          <node concept="1j_P7g" id="3OVhQEUJc0T" role="1j$8Uc">
+                                            <property role="1j_P7h" value="nl.f1re.testing.inputModel@tests" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2YIFZM" id="5T$OTctgBGc" role="37wK5m">
+                                        <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                                        <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                                        <node concept="1jxXqW" id="5T$OTctgBGd" role="37wK5m" />
+                                      </node>
+                                      <node concept="10M0yZ" id="5T$OTctgBGe" role="37wK5m">
+                                        <ref role="3cqZAo" to="et5u:~IMessageHandler.NULL_HANDLER" resolve="NULL_HANDLER" />
+                                        <ref role="1PxDUh" to="et5u:~IMessageHandler" resolve="IMessageHandler" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="7PTDMdvmsl$" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7PTDMdvl3Hn" role="37vLTJ">
+                  <ref role="3cqZAo" node="7PTDMdvkJJa" resolve="timeInMS" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7PTDMdvpEX2" role="3cqZAp">
+          <node concept="3cpWsn" id="7PTDMdvpEX3" role="3cpWs9">
+            <property role="TrG5h" value="status" />
+            <node concept="3uibUv" id="7PTDMdvpEr6" role="1tU5fm">
+              <ref role="3uigEE" to="ap4t:~GenerationStatus" resolve="GenerationStatus" />
+            </node>
+            <node concept="2OqwBi" id="7PTDMdvpEX4" role="33vP2m">
+              <node concept="37vLTw" id="7PTDMdvpEX5" role="2Oq$k0">
+                <ref role="3cqZAo" node="5T$OTctgBG0" resolve="statusRef" />
+              </node>
+              <node concept="liA8E" id="7PTDMdvpEX6" role="2OqNvi">
+                <ref role="37wK5l" to="i5cy:~AtomicReference.get()" resolve="get" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5T$OTctgCtR" role="3cqZAp">
+          <node concept="1Wc70l" id="7PTDMdvkUfG" role="3vwVQn">
+            <node concept="3y3z36" id="7PTDMdvkURv" role="3uHU7B">
+              <node concept="10Nm6u" id="7PTDMdvkV6k" role="3uHU7w" />
+              <node concept="37vLTw" id="7PTDMdvpEX7" role="3uHU7B">
+                <ref role="3cqZAo" node="7PTDMdvpEX3" resolve="status" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5T$OTctgD1K" role="3uHU7w">
+              <node concept="37vLTw" id="5T$OTctgC$M" role="2Oq$k0">
+                <ref role="3cqZAo" node="7PTDMdvpEX3" resolve="status" />
+              </node>
+              <node concept="liA8E" id="5T$OTctgDJz" role="2OqNvi">
+                <ref role="37wK5l" to="18ew:~IStatus.isOk()" resolve="isOk" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="7PTDMdvkMtr" role="3cqZAp">
+          <node concept="3eOVzh" id="7PTDMdvkRGk" role="3vwVQn">
+            <node concept="3cmrfG" id="7PTDMdvkSv$" role="3uHU7w">
+              <property role="3cmrfH" value="1000" />
+            </node>
+            <node concept="37vLTw" id="7PTDMdvkN5n" role="3uHU7B">
+              <ref role="3cqZAo" node="7PTDMdvkJJa" resolve="timeInMS" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3FgkA8" id="2$zHkrOz9b8">
+    <property role="TrG5h" value="GeneratorTest" />
+    <property role="3GE5qa" value="generator" />
+    <property role="3Fgkti" value="Compare an input model against an output model." />
+    <node concept="3Fgkto" id="3OVhQEUJczy" role="3Fgkth">
+      <property role="TrG5h" value="input" />
+      <node concept="1dCxOl" id="3OVhQEUJcz_" role="3Fgkt4">
+        <property role="1XweGQ" value="r:7a418de5-925b-4367-b95e-862bf70ebd19" />
+        <node concept="1j_P7g" id="3OVhQEUJczA" role="1j$8Uc">
+          <property role="1j_P7h" value="nl.f1re.testing.inputModel@tests" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Fgkto" id="3OVhQEUJczC" role="3Fgkth">
+      <property role="TrG5h" value="output" />
+      <node concept="1dCxOl" id="3OVhQEUJczF" role="3Fgkt4">
+        <property role="1XweGQ" value="r:91c69ca8-29b0-4099-b66a-9bee418254ed" />
+        <node concept="1j_P7g" id="3OVhQEUJczG" role="1j$8Uc">
+          <property role="1j_P7h" value="nl.f1re.testing.outputModel@tests" />
+        </node>
+      </node>
+    </node>
+    <node concept="3FggHx" id="2$zHkrOzauB" role="3FggHh">
+      <node concept="3FggHH" id="2$zHkrOzauC" role="3FggHC">
+        <ref role="3FggHE" node="3OVhQEUJczy" resolve="input" />
+      </node>
+      <node concept="3FggHH" id="2$zHkrOzauD" role="3FggHm">
+        <ref role="3FggHE" node="3OVhQEUJczC" resolve="output" />
+      </node>
+    </node>
+  </node>
+  <node concept="3tFllW" id="2$zHkrOzIJl">
+    <property role="3GE5qa" value="generator" />
+    <node concept="1Pa9Pv" id="2$zHkrOzIJm" role="3tFlkb">
+      <node concept="1PaTwC" id="2$zHkrOzIJn" role="1PaQFQ">
+        <node concept="3oM_SD" id="2$zHkrOzILo" role="1PaTwD">
+          <property role="3oM_SC" value="Tests" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILp" role="1PaTwD">
+          <property role="3oM_SC" value="using" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILr" role="1PaTwD">
+          <property role="3oM_SC" value="com.mbeddr.mpsutil.compare" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzJ0K" role="1PaTwD">
+          <property role="3oM_SC" value="including" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzJ0L" role="1PaTwD">
+          <property role="3oM_SC" value="textgen" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILs" role="1PaTwD">
+          <property role="3oM_SC" value="can" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILt" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILu" role="1PaTwD">
+          <property role="3oM_SC" value="found" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILv" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzILw" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzINd" role="1PaTwD">
+          <property role="3oM_SC" value="solution" />
+        </node>
+        <node concept="3oM_SD" id="2$zHkrOzINf" role="1PaTwD">
+          <property role="3oM_SC" value="com.mbeddr.mpsutil.comparator.diff.tests" />
+          <property role="1X82VY" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4GRmlJ02FJ4">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ExtensionPointMasking" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="2XrIbr" id="4GRmlJ032Nq" role="1qtyYc">
+      <property role="TrG5h" value="actionMatches" />
+      <node concept="3uibUv" id="4GRmlJ0335N" role="3clF45">
+        <ref role="3uigEE" to="1l1f:~MatchMode" resolve="MatchMode" />
+      </node>
+      <node concept="3clFbS" id="4GRmlJ032Ns" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlJ03lBi" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ03lBj" role="3cpWs9">
+            <property role="TrG5h" value="matcher" />
+            <node concept="3uibUv" id="4GRmlJ03l_X" role="1tU5fm">
+              <ref role="3uigEE" to="tomq:~WordPrefixMatcher" resolve="WordPrefixMatcher" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ03lBk" role="33vP2m">
+              <node concept="1pGfFk" id="4GRmlJ03lBl" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="tomq:~WordPrefixMatcher.&lt;init&gt;(java.lang.String)" resolve="WordPrefixMatcher" />
+                <node concept="37vLTw" id="4GRmlJ03lBm" role="37wK5m">
+                  <ref role="3cqZAo" node="4GRmlJ0337Y" resolve="pattern" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlJ033hx" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ033hw" role="3cpWs9">
+            <property role="TrG5h" value="model" />
+            <node concept="3uibUv" id="4GRmlJ033hy" role="1tU5fm">
+              <ref role="3uigEE" to="1l1f:~GotoActionModel" resolve="GotoActionModel" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ033iN" role="33vP2m">
+              <node concept="1pGfFk" id="4GRmlJ033j1" role="2ShVmc">
+                <ref role="37wK5l" to="1l1f:~GotoActionModel.&lt;init&gt;(com.intellij.openapi.project.Project,java.awt.Component,com.intellij.openapi.editor.Editor)" resolve="GotoActionModel" />
+                <node concept="2YIFZM" id="4GRmlJ033yz" role="37wK5m">
+                  <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                  <node concept="1jxXqW" id="4GRmlJ033_E" role="37wK5m" />
+                </node>
+                <node concept="10Nm6u" id="4GRmlJ033j3" role="37wK5m" />
+                <node concept="10Nm6u" id="4GRmlJ033j4" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlJ035_B" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlJ036kl" role="3clFbG">
+            <node concept="37vLTw" id="4GRmlJ035__" role="2Oq$k0">
+              <ref role="3cqZAo" node="4GRmlJ033hw" resolve="model" />
+            </node>
+            <node concept="1PvZjq" id="4GRmlJ03nxx" role="2OqNvi">
+              <ref role="37wK5l" to="1l1f:~GotoActionModel.buildGroupMappings()" resolve="buildGroupMappings" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlJ03nIl" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlJ03ouU" role="3clFbG">
+            <node concept="37vLTw" id="4GRmlJ03nIj" role="2Oq$k0">
+              <ref role="3cqZAo" node="4GRmlJ033hw" resolve="model" />
+            </node>
+            <node concept="1PvZjq" id="4GRmlJ03pi5" role="2OqNvi">
+              <ref role="37wK5l" to="1l1f:~GotoActionModel.actionMatches(java.lang.String,com.intellij.util.text.Matcher,com.intellij.openapi.actionSystem.AnAction)" resolve="actionMatches" />
+              <node concept="37vLTw" id="4GRmlJ03pmt" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlJ0337Y" resolve="pattern" />
+              </node>
+              <node concept="37vLTw" id="4GRmlJ03pqY" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlJ03lBj" resolve="matcher" />
+              </node>
+              <node concept="37vLTw" id="4GRmlJ03pAV" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlJ0338Q" resolve="action" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4GRmlJ0337Y" role="3clF46">
+        <property role="TrG5h" value="pattern" />
+        <node concept="17QB3L" id="4GRmlJ0337X" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="4GRmlJ0338Q" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="3uibUv" id="4GRmlJ0339B" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlJ02FJo" role="1SL9yI">
+      <property role="TrG5h" value="maskExtension" />
+      <node concept="3cqZAl" id="4GRmlJ02FJp" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlJ02FJt" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlJ04PaH" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ04PaI" role="3cpWs9">
+            <property role="TrG5h" value="matcher" />
+            <node concept="3uibUv" id="4GRmlJ04PaG" role="1tU5fm">
+              <ref role="3uigEE" to="1l1f:~GotoActionAliasMatcher" resolve="GotoActionAliasMatcher" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ04PaJ" role="33vP2m">
+              <node concept="YeOm9" id="4GRmlJ04PaK" role="2ShVmc">
+                <node concept="1Y3b0j" id="4GRmlJ04PaL" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="1l1f:~GotoActionAliasMatcher" resolve="GotoActionAliasMatcher" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3Tm1VV" id="4GRmlJ04PaM" role="1B3o_S" />
+                  <node concept="3clFb_" id="4GRmlJ04PaN" role="jymVt">
+                    <property role="TrG5h" value="match" />
+                    <node concept="3Tm1VV" id="4GRmlJ04PaO" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="4GRmlJ04PaP" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+                      <node concept="2B6LJw" id="4GRmlJ04PaQ" role="2B76xF">
+                        <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+                        <node concept="3clFbT" id="4GRmlJ04PaR" role="2B70Vg">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="10P_77" id="4GRmlJ04PaS" role="3clF45" />
+                    <node concept="37vLTG" id="4GRmlJ04PaT" role="3clF46">
+                      <property role="TrG5h" value="action" />
+                      <node concept="3uibUv" id="4GRmlJ04PaU" role="1tU5fm">
+                        <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+                      </node>
+                      <node concept="2AHcQZ" id="4GRmlJ04PaV" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="4GRmlJ04PaW" role="3clF46">
+                      <property role="TrG5h" value="name" />
+                      <node concept="3uibUv" id="4GRmlJ04PaX" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                      </node>
+                      <node concept="2AHcQZ" id="4GRmlJ04PaY" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4GRmlJ04PaZ" role="3clF47">
+                      <node concept="3clFbF" id="4GRmlJ04Pb0" role="3cqZAp">
+                        <node concept="2OqwBi" id="4GRmlJ04Pb1" role="3clFbG">
+                          <node concept="37vLTw" id="4GRmlJ04Pb2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4GRmlJ04PaW" resolve="name" />
+                          </node>
+                          <node concept="liA8E" id="4GRmlJ04Pb3" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                            <node concept="Xl_RD" id="4GRmlJ04Pb4" role="37wK5m">
+                              <property role="Xl_RC" value="TEST" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="4GRmlJ04Pb5" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlJ02PWE" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlJ0462L" role="3clFbG">
+            <ref role="37wK5l" to="anz6:~ExtensionTestUtil.maskExtensions(com.intellij.openapi.extensions.ExtensionPointName,java.util.List,com.intellij.openapi.Disposable)" resolve="maskExtensions" />
+            <ref role="1Pybhc" to="anz6:~ExtensionTestUtil" resolve="ExtensionTestUtil" />
+            <node concept="10M0yZ" id="4GRmlJ0462M" role="37wK5m">
+              <ref role="3cqZAo" to="1l1f:~GotoActionAliasMatcher.EP_NAME" resolve="EP_NAME" />
+              <ref role="1PxDUh" to="1l1f:~GotoActionAliasMatcher" resolve="GotoActionAliasMatcher" />
+            </node>
+            <node concept="2OqwBi" id="4GRmlJ0462N" role="37wK5m">
+              <node concept="2ShNRf" id="4GRmlJ0462O" role="2Oq$k0">
+                <node concept="2HTt$P" id="4GRmlJ0462P" role="2ShVmc">
+                  <node concept="37vLTw" id="4GRmlJ04Pb6" role="2HTEbv">
+                    <ref role="3cqZAo" node="4GRmlJ04PaI" resolve="matcher" />
+                  </node>
+                  <node concept="3uibUv" id="4GRmlJ0463d" role="2HTBi0">
+                    <ref role="3uigEE" to="1l1f:~GotoActionAliasMatcher" resolve="GotoActionAliasMatcher" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="4GRmlJ0463e" role="2OqNvi" />
+            </node>
+            <node concept="10M0yZ" id="3UkPvdFhJkQ" role="37wK5m">
+              <ref role="3cqZAo" node="6H1$aDlmOZV" resolve="disposable" />
+              <ref role="1PxDUh" node="6H1$aDlmM9B" resolve="Disposable" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlJ03qIF" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ03qIG" role="3cpWs9">
+            <property role="TrG5h" value="action" />
+            <node concept="3uibUv" id="4GRmlJ03qIH" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~AnAction" resolve="AnAction" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ03rcr" role="33vP2m">
+              <node concept="YeOm9" id="4GRmlJ03v4x" role="2ShVmc">
+                <node concept="1Y3b0j" id="4GRmlJ03v4$" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="qkt:~AnAction.&lt;init&gt;(java.lang.String)" resolve="AnAction" />
+                  <ref role="1Y3XeK" to="qkt:~AnAction" resolve="AnAction" />
+                  <node concept="3Tm1VV" id="4GRmlJ03v4_" role="1B3o_S" />
+                  <node concept="Xl_RD" id="4GRmlJ03t0B" role="37wK5m">
+                    <property role="Xl_RC" value="TEST_MATCH" />
+                  </node>
+                  <node concept="3clFb_" id="4GRmlJ03vRj" role="jymVt">
+                    <property role="TrG5h" value="actionPerformed" />
+                    <node concept="3Tm1VV" id="4GRmlJ03vRk" role="1B3o_S" />
+                    <node concept="3cqZAl" id="4GRmlJ03vRm" role="3clF45" />
+                    <node concept="37vLTG" id="4GRmlJ03vRn" role="3clF46">
+                      <property role="TrG5h" value="event" />
+                      <node concept="3uibUv" id="4GRmlJ03vRo" role="1tU5fm">
+                        <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+                      </node>
+                      <node concept="2AHcQZ" id="4GRmlJ03vRp" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="4GRmlJ03vRr" role="3clF47" />
+                    <node concept="2AHcQZ" id="4GRmlJ03vRs" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="4GRmlJ03XoS" role="3cqZAp">
+          <node concept="Rm8GO" id="4GRmlJ03YZi" role="3tpDZB">
+            <ref role="Rm8GQ" to="1l1f:~MatchMode.NAME" resolve="NAME" />
+            <ref role="1Px2BO" to="1l1f:~MatchMode" resolve="MatchMode" />
+          </node>
+          <node concept="2OqwBi" id="4GRmlJ03znL" role="3tpDZA">
+            <node concept="2WthIp" id="4GRmlJ03zc2" role="2Oq$k0" />
+            <node concept="2XshWL" id="4GRmlJ03$fU" role="2OqNvi">
+              <ref role="2WH_rO" node="4GRmlJ032Nq" resolve="actionMatches" />
+              <node concept="Xl_RD" id="4GRmlJ03$oD" role="2XxRq1">
+                <property role="Xl_RC" value="TEST_MATCH" />
+              </node>
+              <node concept="37vLTw" id="4GRmlJ03_vU" role="2XxRq1">
+                <ref role="3cqZAo" node="4GRmlJ03qIG" resolve="action" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCn" id="6H1$aDlmP5F" role="0EEgL">
+      <node concept="3clFbS" id="6H1$aDlmP5G" role="2VODD2">
+        <node concept="3clFbF" id="6H1$aDlmQ2U" role="3cqZAp">
+          <node concept="37vLTI" id="6H1$aDlmQYy" role="3clFbG">
+            <node concept="2YIFZM" id="6H1$aDlmQZQ" role="37vLTx">
+              <ref role="37wK5l" to="zn9m:~Disposer.newDisposable()" resolve="newDisposable" />
+              <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+            </node>
+            <node concept="10M0yZ" id="6H1$aDlmQ3E" role="37vLTJ">
+              <ref role="3cqZAo" node="6H1$aDlmOZV" resolve="disposable" />
+              <ref role="1PxDUh" node="6H1$aDlmM9B" resolve="Disposable" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCo" id="6H1$aDlmSyM" role="0EEgW">
+      <node concept="3clFbS" id="6H1$aDlmSyN" role="2VODD2">
+        <node concept="3clFbF" id="6H1$aDlmUgX" role="3cqZAp">
+          <node concept="2YIFZM" id="6H1$aDlmV4O" role="3clFbG">
+            <ref role="37wK5l" to="zn9m:~Disposer.dispose(com.intellij.openapi.Disposable)" resolve="dispose" />
+            <ref role="1Pybhc" to="zn9m:~Disposer" resolve="Disposer" />
+            <node concept="10M0yZ" id="6H1$aDlmTJf" role="37wK5m">
+              <ref role="3cqZAo" node="6H1$aDlmOZV" resolve="disposable" />
+              <ref role="1PxDUh" node="6H1$aDlmM9B" resolve="Disposable" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="5yhCTaaps7$">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="Keyboardshortcut" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="5yhCTaaps7_" role="1SL9yI">
+      <property role="TrG5h" value="saveAction" />
+      <node concept="3cqZAl" id="5yhCTaaps7A" role="3clF45" />
+      <node concept="3clFbS" id="5yhCTaaps7B" role="3clF47">
+        <node concept="3cpWs8" id="5yhCTaapDAa" role="3cqZAp">
+          <node concept="3cpWsn" id="5yhCTaapDAb" role="3cpWs9">
+            <property role="TrG5h" value="activeKeymap" />
+            <node concept="3uibUv" id="5yhCTaapD_H" role="1tU5fm">
+              <ref role="3uigEE" to="vuw5:~Keymap" resolve="Keymap" />
+            </node>
+            <node concept="2OqwBi" id="5yhCTaapDAc" role="33vP2m">
+              <node concept="2YIFZM" id="5yhCTaapDAd" role="2Oq$k0">
+                <ref role="37wK5l" to="vuw5:~KeymapManager.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="vuw5:~KeymapManager" resolve="KeymapManager" />
+              </node>
+              <node concept="liA8E" id="5yhCTaapDAe" role="2OqNvi">
+                <ref role="37wK5l" to="vuw5:~KeymapManager.getActiveKeymap()" resolve="getActiveKeymap" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5yhCTaapFLj" role="3cqZAp">
+          <node concept="3cpWsn" id="5yhCTaapFLk" role="3cpWs9">
+            <property role="TrG5h" value="shortcuts" />
+            <node concept="A3Dl8" id="5yhCTaapFKK" role="1tU5fm">
+              <node concept="3uibUv" id="5yhCTaapFKN" role="A3Ik2">
+                <ref role="3uigEE" to="qkt:~Shortcut" resolve="Shortcut" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5yhCTaapFLl" role="33vP2m">
+              <node concept="2OqwBi" id="5yhCTaapFLm" role="2Oq$k0">
+                <node concept="37vLTw" id="5yhCTaapFLn" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5yhCTaapDAb" resolve="activeKeymap" />
+                </node>
+                <node concept="liA8E" id="5yhCTaapFLo" role="2OqNvi">
+                  <ref role="37wK5l" to="vuw5:~Keymap.getShortcuts(java.lang.String)" resolve="getShortcuts" />
+                  <node concept="Xl_RD" id="5yhCTaapFLp" role="37wK5m">
+                    <property role="Xl_RC" value="SaveAll" />
+                  </node>
+                </node>
+              </node>
+              <node concept="39bAoz" id="5yhCTaapFLq" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="5yhCTaapFjL" role="3cqZAp">
+          <node concept="2OqwBi" id="5yhCTaapGA4" role="3vwVQn">
+            <node concept="37vLTw" id="5yhCTaapFV5" role="2Oq$k0">
+              <ref role="3cqZAo" node="5yhCTaapFLk" resolve="shortcuts" />
+            </node>
+            <node concept="2HwmR7" id="5yhCTaapHQN" role="2OqNvi">
+              <node concept="1bVj0M" id="5yhCTaapHQP" role="23t8la">
+                <node concept="3clFbS" id="5yhCTaapHQQ" role="1bW5cS">
+                  <node concept="3clFbF" id="5yhCTaapIDk" role="3cqZAp">
+                    <node concept="2OqwBi" id="5yhCTaapQ2D" role="3clFbG">
+                      <node concept="2OqwBi" id="5yhCTaapIRA" role="2Oq$k0">
+                        <node concept="37vLTw" id="5yhCTaapIDj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5yhCTaapHQR" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="5yhCTaapOmW" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5yhCTaapSa6" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                        <node concept="Xl_RD" id="5yhCTaapSi_" role="37wK5m">
+                          <property role="Xl_RC" value="S" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="5yhCTaapHQR" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5yhCTaapHQS" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5yhCTaaps8c" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="4k0nQshw_Sq">
+    <property role="TrG5h" value="Leak" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="312cEg" id="4k0nQshw_VE" role="jymVt">
+      <property role="TrG5h" value="leakedList" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="4k0nQshwA1f" role="1B3o_S" />
+      <node concept="3uibUv" id="4k0nQshw_VG" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+        <node concept="3uibUv" id="4k0nQshw_VH" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="4k0nQshw_VI" role="33vP2m">
+        <node concept="1pGfFk" id="4k0nQshw_VJ" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4k0nQshw_Sr" role="1B3o_S" />
+  </node>
+  <node concept="1lH9Xt" id="4k0nQshwA9i">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="LeakTest" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="4k0nQshwAc_" role="1SL9yI">
+      <property role="TrG5h" value="finalListLeak" />
+      <node concept="3cqZAl" id="4k0nQshwAcA" role="3clF45" />
+      <node concept="3clFbS" id="4k0nQshwAcE" role="3clF47">
+        <node concept="3SKdUt" id="4k0nQshwAfU" role="3cqZAp">
+          <node concept="1PaTwC" id="4k0nQshwAfV" role="1aUNEU">
+            <node concept="3oM_SD" id="4k0nQshwAfW" role="1PaTwD">
+              <property role="3oM_SC" value="Add" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAfX" role="1PaTwD">
+              <property role="3oM_SC" value="objects" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAfY" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAfZ" role="1PaTwD">
+              <property role="3oM_SC" value="instance" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAg0" role="1PaTwD">
+              <property role="3oM_SC" value="field" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAg1" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAg2" role="1PaTwD">
+              <property role="3oM_SC" value="simulate" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAg3" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAg4" role="1PaTwD">
+              <property role="3oM_SC" value="leak" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQshwBuu" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshwBuv" role="3cpWs9">
+            <property role="TrG5h" value="leak" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="4k0nQshwBuw" role="1tU5fm">
+              <ref role="3uigEE" node="4k0nQshw_Sq" resolve="Leak" />
+            </node>
+            <node concept="2ShNRf" id="4k0nQshwBAM" role="33vP2m">
+              <node concept="HV5vD" id="4k0nQshwEB$" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="4k0nQshw_Sq" resolve="Leak" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="4k0nQshwAg5" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshwAg6" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="4k0nQshwAg7" role="1tU5fm" />
+            <node concept="3cmrfG" id="4k0nQshwAg8" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="4k0nQshwAg9" role="1Dwp0S">
+            <node concept="37vLTw" id="4k0nQshwAga" role="3uHU7B">
+              <ref role="3cqZAo" node="4k0nQshwAg6" resolve="i" />
+            </node>
+            <node concept="3cmrfG" id="4k0nQshwAgb" role="3uHU7w">
+              <property role="3cmrfH" value="1000" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="4k0nQshwAgc" role="1Dwrff">
+            <node concept="37vLTw" id="4k0nQshwAgd" role="2$L3a6">
+              <ref role="3cqZAo" node="4k0nQshwAg6" resolve="i" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4k0nQshwAge" role="2LFqv$">
+            <node concept="3clFbF" id="4k0nQshwFyn" role="3cqZAp">
+              <node concept="2OqwBi" id="4k0nQshwI3p" role="3clFbG">
+                <node concept="2OqwBi" id="4k0nQshwFOT" role="2Oq$k0">
+                  <node concept="37vLTw" id="4k0nQshwFyl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4k0nQshwBuv" resolve="leak" />
+                  </node>
+                  <node concept="2OwXpG" id="4k0nQshwGoL" role="2OqNvi">
+                    <ref role="2Oxat6" node="4k0nQshw_VE" resolve="leakedList" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="4k0nQshwKpM" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                  <node concept="2ShNRf" id="4k0nQshwK$g" role="37wK5m">
+                    <node concept="1pGfFk" id="4k0nQshwNFE" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="4k0nQshwAgl" role="3cqZAp">
+          <node concept="1PaTwC" id="4k0nQshwAgm" role="1aUNEU">
+            <node concept="3oM_SD" id="4k0nQshwAgn" role="1PaTwD">
+              <property role="3oM_SC" value="Trigger" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAgo" role="1PaTwD">
+              <property role="3oM_SC" value="GC" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAgp" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAgq" role="1PaTwD">
+              <property role="3oM_SC" value="detect" />
+            </node>
+            <node concept="3oM_SD" id="4k0nQshwAgr" role="1PaTwD">
+              <property role="3oM_SC" value="leak" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4k0nQshwAgs" role="3cqZAp">
+          <node concept="2YIFZM" id="4k0nQshwAgt" role="3clFbG">
+            <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+            <ref role="37wK5l" to="wyt6:~System.gc()" resolve="gc" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4k0nQshwAgu" role="3cqZAp">
+          <node concept="2YIFZM" id="4k0nQshwAgv" role="3clFbG">
+            <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
+            <ref role="37wK5l" to="wyt6:~Thread.sleep(long)" resolve="sleep" />
+            <node concept="3cmrfG" id="4k0nQshwAgw" role="37wK5m">
+              <property role="3cmrfH" value="100" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4k0nQshwAgx" role="3cqZAp" />
+        <node concept="3clFbF" id="5nwfWGQ3Obl" role="3cqZAp">
+          <node concept="2YIFZM" id="2d4iuOOGEAe" role="3clFbG">
+            <ref role="37wK5l" to="m531:5nwfWGQ3NG7" resolve="assertFails" />
+            <ref role="1Pybhc" to="m531:5nwfWGQ3LWe" resolve="Asserts" />
+            <node concept="2ShNRf" id="5Tz8vreoPF0" role="37wK5m">
+              <node concept="YeOm9" id="5Tz8vrepGqC" role="2ShVmc">
+                <node concept="1Y3b0j" id="5Tz8vrepGqF" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="9w4s:~ThrowableRunnable" resolve="ThrowableRunnable" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3Tm1VV" id="5Tz8vrepGqG" role="1B3o_S" />
+                  <node concept="3clFb_" id="5Tz8vrepGqT" role="jymVt">
+                    <property role="TrG5h" value="run" />
+                    <node concept="3Tm1VV" id="5Tz8vrepGqU" role="1B3o_S" />
+                    <node concept="3cqZAl" id="5Tz8vrepGqW" role="3clF45" />
+                    <node concept="3uibUv" id="5Tz8vrepGr4" role="Sfmx6">
+                      <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                    </node>
+                    <node concept="3clFbS" id="5Tz8vrepGqY" role="3clF47">
+                      <node concept="3clFbF" id="6wYwmAsyG5G" role="3cqZAp">
+                        <node concept="2YIFZM" id="5nwfWGQ3P7d" role="3clFbG">
+                          <ref role="37wK5l" to="anz6:~LeakHunter.checkLeak(java.lang.Object,java.lang.Class)" resolve="checkLeak" />
+                          <ref role="1Pybhc" to="anz6:~LeakHunter" resolve="LeakHunter" />
+                          <node concept="2OqwBi" id="5nwfWGQ3P7e" role="37wK5m">
+                            <node concept="37vLTw" id="5nwfWGQ3P7f" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4k0nQshwBuv" resolve="leak" />
+                            </node>
+                            <node concept="2OwXpG" id="5nwfWGQ3P7g" role="2OqNvi">
+                              <ref role="2Oxat6" node="4k0nQshw_VE" resolve="leakedList" />
+                            </node>
+                          </node>
+                          <node concept="3VsKOn" id="5nwfWGQ3P7h" role="37wK5m">
+                            <ref role="3VsUkX" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="5Tz8vrepGr0" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="3uibUv" id="5Tz8vrepGr3" role="2Ghqu4">
+                    <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4k0nQshwOFg" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="GsdFj4J9d1">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="MainMenuHasAction" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="2XrIbr" id="GsdFj4LQZC" role="1qtyYc">
+      <property role="TrG5h" value="getActions" />
+      <node concept="_YKpA" id="GsdFj4LRXm" role="3clF45">
+        <node concept="3uibUv" id="GsdFj4LSeX" role="_ZDj9">
+          <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="GsdFj4LQZE" role="3clF47">
+        <node concept="3clFbF" id="GsdFj4LSB6" role="3cqZAp">
+          <node concept="2OqwBi" id="GsdFj4LTGj" role="3clFbG">
+            <node concept="2OqwBi" id="GsdFj4LSB8" role="2Oq$k0">
+              <node concept="2OqwBi" id="GsdFj4LSB9" role="2Oq$k0">
+                <node concept="2OqwBi" id="GsdFj4LSBa" role="2Oq$k0">
+                  <node concept="37vLTw" id="GsdFj4LT6b" role="2Oq$k0">
+                    <ref role="3cqZAo" node="GsdFj4LSAd" resolve="group" />
+                  </node>
+                  <node concept="liA8E" id="GsdFj4LSBc" role="2OqNvi">
+                    <ref role="37wK5l" to="qkt:~ActionGroup.getChildren(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="getChildren" />
+                    <node concept="10Nm6u" id="GsdFj4LSBd" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="39bAoz" id="GsdFj4LSBe" role="2OqNvi" />
+              </node>
+              <node concept="UnYns" id="GsdFj4LSBf" role="2OqNvi">
+                <node concept="3uibUv" id="GsdFj4LSBg" role="UnYnz">
+                  <ref role="3uigEE" to="7bx7:~BaseAction" resolve="BaseAction" />
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="GsdFj4LU_n" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="GsdFj4LSAd" role="3clF46">
+        <property role="TrG5h" value="group" />
+        <node concept="3uibUv" id="GsdFj4LSAc" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~ActionGroup" resolve="ActionGroup" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="GsdFj4J9dl" role="1SL9yI">
+      <property role="TrG5h" value="hasEditorAction" />
+      <node concept="3cqZAl" id="GsdFj4J9dm" role="3clF45" />
+      <node concept="3clFbS" id="GsdFj4J9dq" role="3clF47">
+        <node concept="3vwNmj" id="GsdFj4LOxg" role="3cqZAp">
+          <node concept="2OqwBi" id="GsdFj4KJ5F" role="3vwVQn">
+            <node concept="2OqwBi" id="GsdFj4LUG8" role="2Oq$k0">
+              <node concept="2WthIp" id="GsdFj4LUGb" role="2Oq$k0" />
+              <node concept="2XshWL" id="GsdFj4LUGd" role="2OqNvi">
+                <ref role="2WH_rO" node="GsdFj4LQZC" resolve="getActions" />
+                <node concept="3$FqnI" id="GsdFj4KFqY" role="2XxRq1">
+                  <ref role="3$FqnG" to="ekwn:6KwcZ1G3PiL" resolve="EditorActions" />
+                </node>
+              </node>
+            </node>
+            <node concept="2HwmR7" id="GsdFj4KK36" role="2OqNvi">
+              <node concept="1bVj0M" id="GsdFj4KK38" role="23t8la">
+                <node concept="3clFbS" id="GsdFj4KK39" role="1bW5cS">
+                  <node concept="3clFbF" id="GsdFj4KKw5" role="3cqZAp">
+                    <node concept="17R0WA" id="GsdFj4KOGQ" role="3clFbG">
+                      <node concept="2OqwBi" id="GsdFj4KTg1" role="3uHU7w">
+                        <node concept="3$FdUm" id="GsdFj4KR0h" role="2Oq$k0">
+                          <ref role="3$FpRE" to="ekwn:3Ps9wDHYw7A" resolve="Find" />
+                        </node>
+                        <node concept="liA8E" id="GsdFj4KU4q" role="2OqNvi">
+                          <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="GsdFj4KL3n" role="3uHU7B">
+                        <node concept="37vLTw" id="GsdFj4KKw4" role="2Oq$k0">
+                          <ref role="3cqZAo" node="GsdFj4KK3a" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="GsdFj4KN7Q" role="2OqNvi">
+                          <ref role="37wK5l" to="7bx7:~BaseAction.getActionId()" resolve="getActionId" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="GsdFj4KK3a" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="GsdFj4KK3b" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="GsdFj4LM94" role="1SL9yI">
+      <property role="TrG5h" value="hasMainMenuAction" />
+      <node concept="3cqZAl" id="GsdFj4LM95" role="3clF45" />
+      <node concept="3clFbS" id="GsdFj4LM99" role="3clF47">
+        <node concept="3vwNmj" id="GsdFj4MtLf" role="3cqZAp">
+          <node concept="2OqwBi" id="GsdFj4MuW6" role="3vwVQn">
+            <node concept="2HwmR7" id="GsdFj4Mwr6" role="2OqNvi">
+              <node concept="1bVj0M" id="GsdFj4Mwr8" role="23t8la">
+                <node concept="3clFbS" id="GsdFj4Mwr9" role="1bW5cS">
+                  <node concept="3clFbF" id="GsdFj4Mx08" role="3cqZAp">
+                    <node concept="2ZW3vV" id="GsdFj4O3qN" role="3clFbG">
+                      <node concept="3uibUv" id="GsdFj4O5qJ" role="2ZW6by">
+                        <ref role="3uigEE" to="tqbz:~SaveAllAction" resolve="SaveAllAction" />
+                      </node>
+                      <node concept="37vLTw" id="GsdFj4Mx07" role="2ZW6bz">
+                        <ref role="3cqZAo" node="GsdFj4Mwra" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="GsdFj4Mwra" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="GsdFj4Mwrb" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="GsdFj4NMHd" role="2Oq$k0">
+              <node concept="2OqwBi" id="GsdFj4Nb02" role="2Oq$k0">
+                <node concept="liA8E" id="GsdFj4Nb04" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~ActionGroup.getChildren(com.intellij.openapi.actionSystem.AnActionEvent)" resolve="getChildren" />
+                  <node concept="10Nm6u" id="GsdFj4Nb05" role="37wK5m" />
+                </node>
+                <node concept="0kSF2" id="GsdFj4Nb4k" role="2Oq$k0">
+                  <node concept="3uibUv" id="GsdFj4Nb4l" role="0kSFW">
+                    <ref role="3uigEE" to="qkt:~ActionGroup" resolve="ActionGroup" />
+                  </node>
+                  <node concept="2OqwBi" id="GsdFj4Nb4m" role="0kSFX">
+                    <node concept="2YIFZM" id="GsdFj4Nb4n" role="2Oq$k0">
+                      <ref role="37wK5l" to="qkt:~ActionManager.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="qkt:~ActionManager" resolve="ActionManager" />
+                    </node>
+                    <node concept="liA8E" id="GsdFj4Nb4o" role="2OqNvi">
+                      <ref role="37wK5l" to="qkt:~ActionManager.getAction(java.lang.String)" resolve="getAction" />
+                      <node concept="10M0yZ" id="GsdFj4N_Co" role="37wK5m">
+                        <ref role="3cqZAo" to="qkt:~IdeActions.GROUP_FILE" resolve="GROUP_FILE" />
+                        <ref role="1PxDUh" to="qkt:~IdeActions" resolve="IdeActions" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="39bAoz" id="GsdFj4NN1y" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="GsdFj4Pu3u">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="OpenTool" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="GsdFj4Pvhj" role="1SL9yI">
+      <property role="TrG5h" value="openMPSTool" />
+      <node concept="3cqZAl" id="GsdFj4Pvhk" role="3clF45" />
+      <node concept="3clFbS" id="GsdFj4Pvho" role="3clF47">
+        <node concept="3cpWs8" id="GsdFj4PwnK" role="3cqZAp">
+          <node concept="3cpWsn" id="GsdFj4PwnL" role="3cpWs9">
+            <property role="TrG5h" value="ideaProject" />
+            <node concept="3uibUv" id="GsdFj4Pwnu" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+            </node>
+            <node concept="2YIFZM" id="GsdFj4PwnM" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="1jxXqW" id="GsdFj4PwnN" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="GsdFj4PKZE" role="3cqZAp">
+          <node concept="3cpWsn" id="GsdFj4PKZF" role="3cpWs9">
+            <property role="TrG5h" value="viewer" />
+            <node concept="1xUVSX" id="GsdFj4PKOk" role="1tU5fm">
+              <ref role="1xYkEM" to="u73:4HeMkQiYObL" resolve="TodoViewer" />
+            </node>
+            <node concept="2OqwBi" id="GsdFj4PKZG" role="33vP2m">
+              <node concept="37vLTw" id="GsdFj4PKZH" role="2Oq$k0">
+                <ref role="3cqZAo" node="GsdFj4PwnL" resolve="ideaProject" />
+              </node>
+              <node concept="LR4U6" id="GsdFj4PKZI" role="2OqNvi">
+                <ref role="LR4U5" to="u73:4HeMkQiYObL" resolve="TodoViewer" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="GsdFj4PKLJ" role="3cqZAp">
+          <node concept="3clFbS" id="GsdFj4PKLL" role="1zxBo7">
+            <node concept="3clFbF" id="GsdFj4PIRZ" role="3cqZAp">
+              <node concept="2OqwBi" id="GsdFj4PJ6G" role="3clFbG">
+                <node concept="37vLTw" id="GsdFj4PKZJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="GsdFj4PKZF" resolve="viewer" />
+                </node>
+                <node concept="liA8E" id="GsdFj4PJj9" role="2OqNvi">
+                  <ref role="37wK5l" to="71xd:~BaseTool.openTool(boolean)" resolve="openTool" />
+                  <node concept="3clFbT" id="GsdFj4PJZE" role="37wK5m">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3vwNmj" id="GsdFj4PMOT" role="3cqZAp">
+              <node concept="2OqwBi" id="GsdFj4PN4a" role="3vwVQn">
+                <node concept="37vLTw" id="GsdFj4PMQX" role="2Oq$k0">
+                  <ref role="3cqZAo" node="GsdFj4PKZF" resolve="viewer" />
+                </node>
+                <node concept="liA8E" id="GsdFj4PNhE" role="2OqNvi">
+                  <ref role="37wK5l" to="71xd:~BaseTool.isAvailable()" resolve="isAvailable" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="GsdFj4PKNH" role="1zxBo6">
+            <node concept="3clFbS" id="GsdFj4PKNI" role="1wplMD">
+              <node concept="3clFbF" id="GsdFj4POlh" role="3cqZAp">
+                <node concept="2OqwBi" id="GsdFj4PO_6" role="3clFbG">
+                  <node concept="37vLTw" id="GsdFj4POlg" role="2Oq$k0">
+                    <ref role="3cqZAo" node="GsdFj4PKZF" resolve="viewer" />
+                  </node>
+                  <node concept="liA8E" id="GsdFj4POMT" role="2OqNvi">
+                    <ref role="37wK5l" to="71xd:~BaseTool.close()" resolve="close" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="GsdFj4PZ1K" role="1SL9yI">
+      <property role="TrG5h" value="openIntellijTool" />
+      <node concept="3cqZAl" id="GsdFj4PZ1L" role="3clF45" />
+      <node concept="3clFbS" id="GsdFj4PZ1M" role="3clF47">
+        <node concept="3cpWs8" id="GsdFj4PZ1N" role="3cqZAp">
+          <node concept="3cpWsn" id="GsdFj4PZ1O" role="3cpWs9">
+            <property role="TrG5h" value="ideaProject" />
+            <node concept="3uibUv" id="GsdFj4PZ1P" role="1tU5fm">
+              <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+            </node>
+            <node concept="2YIFZM" id="GsdFj4PZ1Q" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="1jxXqW" id="GsdFj4PZ1R" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="GsdFj4Q0$D" role="3cqZAp">
+          <node concept="3cpWsn" id="GsdFj4Q0$E" role="3cpWs9">
+            <property role="TrG5h" value="terminalToolWindow" />
+            <node concept="3uibUv" id="GsdFj4Q0$F" role="1tU5fm">
+              <ref role="3uigEE" to="jkny:~ToolWindow" resolve="ToolWindow" />
+            </node>
+            <node concept="2OqwBi" id="GsdFj4Q0VY" role="33vP2m">
+              <node concept="2YIFZM" id="GsdFj4Q0Gw" role="2Oq$k0">
+                <ref role="37wK5l" to="jkny:~ToolWindowManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <ref role="1Pybhc" to="jkny:~ToolWindowManager" resolve="ToolWindowManager" />
+                <node concept="37vLTw" id="GsdFj4Q0Nl" role="37wK5m">
+                  <ref role="3cqZAo" node="GsdFj4PZ1O" resolve="ideaProject" />
+                </node>
+              </node>
+              <node concept="liA8E" id="GsdFj4Q17p" role="2OqNvi">
+                <ref role="37wK5l" to="jkny:~ToolWindowManager.getToolWindow(java.lang.String)" resolve="getToolWindow" />
+                <node concept="Xl_RD" id="GsdFj4Q1a7" role="37wK5m">
+                  <property role="Xl_RC" value="Terminal" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Hmddi" id="GsdFj4Q5uk" role="3cqZAp">
+          <node concept="37vLTw" id="GsdFj4Q5xn" role="2Hmdds">
+            <ref role="3cqZAo" node="GsdFj4Q0$E" resolve="terminalToolWindow" />
+          </node>
+        </node>
+        <node concept="3J1_TO" id="GsdFj4PZ1Y" role="3cqZAp">
+          <node concept="3clFbS" id="GsdFj4PZ1Z" role="1zxBo7">
+            <node concept="3clFbF" id="GsdFj4Q1xF" role="3cqZAp">
+              <node concept="2OqwBi" id="5nwfWGQcUNX" role="3clFbG">
+                <node concept="37vLTw" id="GsdFj4Q1xD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="GsdFj4Q0$E" resolve="terminalToolWindow" />
+                </node>
+                <node concept="liA8E" id="GsdFj4Q2nj" role="2OqNvi">
+                  <ref role="37wK5l" to="jkny:~ToolWindow.activate(java.lang.Runnable)" resolve="activate" />
+                  <node concept="1bVj0M" id="GsdFj4QeNt" role="37wK5m">
+                    <node concept="3clFbS" id="GsdFj4QeNw" role="1bW5cS">
+                      <node concept="3vwNmj" id="GsdFj4Q491" role="3cqZAp">
+                        <node concept="2OqwBi" id="GsdFj4Q4z7" role="3vwVQn">
+                          <node concept="37vLTw" id="GsdFj4Q4bO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="GsdFj4Q0$E" resolve="terminalToolWindow" />
+                          </node>
+                          <node concept="liA8E" id="GsdFj4Q4WZ" role="2OqNvi">
+                            <ref role="37wK5l" to="jkny:~ToolWindow.isActive()" resolve="isActive" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="GsdFj4PZ29" role="1zxBo6">
+            <node concept="3clFbS" id="GsdFj4PZ2a" role="1wplMD">
+              <node concept="3clFbF" id="GsdFj4Q2PK" role="3cqZAp">
+                <node concept="2OqwBi" id="5nwfWGQcURo" role="3clFbG">
+                  <node concept="37vLTw" id="GsdFj4Q2PI" role="2Oq$k0">
+                    <ref role="3cqZAo" node="GsdFj4Q0$E" resolve="terminalToolWindow" />
+                  </node>
+                  <node concept="liA8E" id="GsdFj4Q3Hn" role="2OqNvi">
+                    <ref role="37wK5l" to="jkny:~ToolWindow.hide()" resolve="hide" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3LGAAek006N">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <property role="TrG5h" value="PlatformTestUtilWithModelAccess" />
+    <node concept="1LZb2c" id="4GRmlIZS0rH" role="1SL9yI">
+      <property role="TrG5h" value="directoriesEqual" />
+      <node concept="3cqZAl" id="4GRmlIZS0rI" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZS0rJ" role="3clF47">
+        <node concept="3cpWs8" id="2qPu2xqU1h8" role="3cqZAp">
+          <node concept="3cpWsn" id="2qPu2xqU1h9" role="3cpWs9">
+            <property role="TrG5h" value="dummyFS" />
+            <node concept="3uibUv" id="2qPu2xqU0k$" role="1tU5fm">
+              <ref role="3uigEE" to="4jk:~DummyFileSystem" resolve="DummyFileSystem" />
+            </node>
+            <node concept="2YIFZM" id="2qPu2xqU1ha" role="33vP2m">
+              <ref role="37wK5l" to="4jk:~DummyFileSystem.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="4jk:~DummyFileSystem" resolve="DummyFileSystem" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2qPu2xqTYxP" role="3cqZAp">
+          <node concept="3cpWsn" id="2qPu2xqTYxQ" role="3cpWs9">
+            <property role="TrG5h" value="root" />
+            <node concept="3uibUv" id="2qPu2xqTYxR" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2OqwBi" id="2qPu2xqTYxS" role="33vP2m">
+              <node concept="37vLTw" id="2qPu2xqTYxT" role="2Oq$k0">
+                <ref role="3cqZAo" node="2qPu2xqU1h9" resolve="dummyFS" />
+              </node>
+              <node concept="liA8E" id="2qPu2xqTYxU" role="2OqNvi">
+                <ref role="37wK5l" to="4jk:~DummyFileSystem.createRoot(java.lang.String)" resolve="createRoot" />
+                <node concept="Xl_RD" id="2qPu2xqTYxV" role="37wK5m">
+                  <property role="Xl_RC" value="" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2qPu2xqTXV2" role="3cqZAp" />
+        <node concept="3cpWs8" id="2qPu2xqTGMk" role="3cqZAp">
+          <node concept="3cpWsn" id="2qPu2xqTGMl" role="3cpWs9">
+            <property role="TrG5h" value="file1" />
+            <node concept="3uibUv" id="2qPu2xqTFCv" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2YIFZM" id="7gByDwHbjg8" role="33vP2m">
+              <ref role="1Pybhc" to="mqum:1f1xsR60WN7" resolve="TextComparison" />
+              <ref role="37wK5l" to="mqum:7gByDwH7pTm" resolve="createPath" />
+              <node concept="37vLTw" id="2qPu2xqU1hc" role="37wK5m">
+                <ref role="3cqZAo" node="2qPu2xqU1h9" resolve="dummyFS" />
+              </node>
+              <node concept="37vLTw" id="2qPu2xqTGMq" role="37wK5m">
+                <ref role="3cqZAo" node="2qPu2xqTYxQ" resolve="root" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZSYT1" role="37wK5m">
+                <property role="Xl_RC" value="/myFolder/file" />
+              </node>
+              <node concept="Xl_RD" id="2qPu2xqTGMs" role="37wK5m">
+                <property role="Xl_RC" value="some content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGPZKTP" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGPZKTQ" role="3cpWs9">
+            <property role="TrG5h" value="file2" />
+            <node concept="3uibUv" id="5nwfWGPZKTR" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2YIFZM" id="4GRmlIZTal2" role="33vP2m">
+              <ref role="1Pybhc" to="mqum:1f1xsR60WN7" resolve="TextComparison" />
+              <ref role="37wK5l" to="mqum:7gByDwH7pTm" resolve="createPath" />
+              <node concept="37vLTw" id="4GRmlIZTal3" role="37wK5m">
+                <ref role="3cqZAo" node="2qPu2xqU1h9" resolve="dummyFS" />
+              </node>
+              <node concept="37vLTw" id="4GRmlIZTal4" role="37wK5m">
+                <ref role="3cqZAo" node="2qPu2xqTYxQ" resolve="root" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZTal5" role="37wK5m">
+                <property role="Xl_RC" value="/myFolder/file2" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZTal6" role="37wK5m">
+                <property role="Xl_RC" value="some content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZS0s5" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlIZS0sz" role="3clFbG">
+            <ref role="37wK5l" to="anz6:~PlatformTestUtil.assertDirectoriesEqual(com.intellij.openapi.vfs.VirtualFile,com.intellij.openapi.vfs.VirtualFile)" resolve="assertDirectoriesEqual" />
+            <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+            <node concept="2OqwBi" id="4GRmlIZTdZo" role="37wK5m">
+              <node concept="37vLTw" id="4GRmlIZTavd" role="2Oq$k0">
+                <ref role="3cqZAo" node="2qPu2xqTGMl" resolve="file1" />
+              </node>
+              <node concept="liA8E" id="4GRmlIZTeOP" role="2OqNvi">
+                <ref role="37wK5l" to="jlff:~VirtualFile.getParent()" resolve="getParent" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4GRmlIZTeTu" role="37wK5m">
+              <node concept="37vLTw" id="4GRmlIZTa_b" role="2Oq$k0">
+                <ref role="3cqZAo" node="5nwfWGPZKTQ" resolve="file2" />
+              </node>
+              <node concept="liA8E" id="4GRmlIZTf1z" role="2OqNvi">
+                <ref role="37wK5l" to="jlff:~VirtualFile.getParent()" resolve="getParent" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4GRmlIZTaCk" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZThK0" role="1SL9yI">
+      <property role="TrG5h" value="filesEqual" />
+      <node concept="3cqZAl" id="4GRmlIZThK1" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZThK5" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlIZThO$" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZThO_" role="3cpWs9">
+            <property role="TrG5h" value="dummyFS" />
+            <node concept="3uibUv" id="4GRmlIZThOA" role="1tU5fm">
+              <ref role="3uigEE" to="4jk:~DummyFileSystem" resolve="DummyFileSystem" />
+            </node>
+            <node concept="2YIFZM" id="4GRmlIZThOB" role="33vP2m">
+              <ref role="37wK5l" to="4jk:~DummyFileSystem.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="4jk:~DummyFileSystem" resolve="DummyFileSystem" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlIZThOC" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZThOD" role="3cpWs9">
+            <property role="TrG5h" value="root" />
+            <node concept="3uibUv" id="4GRmlIZThOE" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2OqwBi" id="4GRmlIZThOF" role="33vP2m">
+              <node concept="37vLTw" id="4GRmlIZThOG" role="2Oq$k0">
+                <ref role="3cqZAo" node="4GRmlIZThO_" resolve="dummyFS" />
+              </node>
+              <node concept="liA8E" id="4GRmlIZThOH" role="2OqNvi">
+                <ref role="37wK5l" to="4jk:~DummyFileSystem.createRoot(java.lang.String)" resolve="createRoot" />
+                <node concept="Xl_RD" id="4GRmlIZThOI" role="37wK5m">
+                  <property role="Xl_RC" value="" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4GRmlIZThOJ" role="3cqZAp" />
+        <node concept="3cpWs8" id="4GRmlIZThOK" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZThOL" role="3cpWs9">
+            <property role="TrG5h" value="file1" />
+            <node concept="3uibUv" id="4GRmlIZThOM" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2YIFZM" id="4GRmlIZThON" role="33vP2m">
+              <ref role="1Pybhc" to="mqum:1f1xsR60WN7" resolve="TextComparison" />
+              <ref role="37wK5l" to="mqum:7gByDwH7pTm" resolve="createPath" />
+              <node concept="37vLTw" id="4GRmlIZThOO" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlIZThO_" resolve="dummyFS" />
+              </node>
+              <node concept="37vLTw" id="4GRmlIZThOP" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlIZThOD" resolve="root" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZThOQ" role="37wK5m">
+                <property role="Xl_RC" value="/myFolder/file" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZThOR" role="37wK5m">
+                <property role="Xl_RC" value="some content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlIZThOS" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZThOT" role="3cpWs9">
+            <property role="TrG5h" value="file2" />
+            <node concept="3uibUv" id="4GRmlIZThOU" role="1tU5fm">
+              <ref role="3uigEE" to="jlff:~VirtualFile" resolve="VirtualFile" />
+            </node>
+            <node concept="2YIFZM" id="4GRmlIZThOV" role="33vP2m">
+              <ref role="1Pybhc" to="mqum:1f1xsR60WN7" resolve="TextComparison" />
+              <ref role="37wK5l" to="mqum:7gByDwH7pTm" resolve="createPath" />
+              <node concept="37vLTw" id="4GRmlIZThOW" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlIZThO_" resolve="dummyFS" />
+              </node>
+              <node concept="37vLTw" id="4GRmlIZThOX" role="37wK5m">
+                <ref role="3cqZAo" node="4GRmlIZThOD" resolve="root" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZThOY" role="37wK5m">
+                <property role="Xl_RC" value="/myFolder/file2" />
+              </node>
+              <node concept="Xl_RD" id="4GRmlIZThOZ" role="37wK5m">
+                <property role="Xl_RC" value="some content" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZThND" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlIZThO8" role="3clFbG">
+            <ref role="37wK5l" to="anz6:~PlatformTestUtil.assertFilesEqual(com.intellij.openapi.vfs.VirtualFile,com.intellij.openapi.vfs.VirtualFile)" resolve="assertFilesEqual" />
+            <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+            <node concept="37vLTw" id="4GRmlIZTi8C" role="37wK5m">
+              <ref role="3cqZAo" node="4GRmlIZThOL" resolve="file1" />
+            </node>
+            <node concept="37vLTw" id="4GRmlIZTibA" role="37wK5m">
+              <ref role="3cqZAo" node="4GRmlIZThOT" resolve="file2" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4GRmlIZTieJ" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4GRmlIZS0rE">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="PlatformTestUtilWithoutModelAccess" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="4GRmlIZTl7L" role="1SL9yI">
+      <property role="TrG5h" value="pathsEqual" />
+      <node concept="3cqZAl" id="4GRmlIZTl7M" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZTl7Q" role="3clF47">
+        <node concept="3clFbF" id="4GRmlIZTlcj" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlIZTlcN" role="3clFbG">
+            <ref role="37wK5l" to="anz6:~PlatformTestUtil.assertPathsEqual(java.lang.String,java.lang.String)" resolve="assertPathsEqual" />
+            <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+            <node concept="Xl_RD" id="4GRmlIZTldY" role="37wK5m">
+              <property role="Xl_RC" value="folder1/file1" />
+            </node>
+            <node concept="Xl_RD" id="4GRmlIZTlj2" role="37wK5m">
+              <property role="Xl_RC" value="folder1/file1" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZTtNf" role="1SL9yI">
+      <property role="TrG5h" value="expandTree" />
+      <node concept="3cqZAl" id="4GRmlIZTtNg" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZTtNk" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlJ00kmK" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00kmL" role="3cpWs9">
+            <property role="TrG5h" value="tree" />
+            <node concept="3uibUv" id="4GRmlJ00kmM" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~JTree" resolve="JTree" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ00mGo" role="33vP2m">
+              <node concept="1pGfFk" id="4GRmlJ00ojG" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="dxuu:~JTree.&lt;init&gt;(javax.swing.tree.TreeNode)" resolve="JTree" />
+                <node concept="2OqwBi" id="4GRmlJ00ol4" role="37wK5m">
+                  <node concept="2WthIp" id="4GRmlJ00ol7" role="2Oq$k0" />
+                  <node concept="2XshWL" id="4GRmlJ00ol9" role="2OqNvi">
+                    <ref role="2WH_rO" node="4GRmlJ00gWW" resolve="createTestTreeContent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7f7wYMF3cvp" role="3cqZAp">
+          <node concept="1PaTwC" id="7f7wYMF3cvq" role="1aUNEU">
+            <node concept="3oM_SD" id="7f7wYMF3cyt" role="1PaTwD">
+              <property role="3oM_SC" value="To" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF3cyu" role="1PaTwD">
+              <property role="3oM_SC" value="test" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF3cyv" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF3cyw" role="1PaTwD">
+              <property role="3oM_SC" value="logical" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF3cyx" role="1PaTwD">
+              <property role="3oM_SC" value="view" />
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4GRmlJ00AZh" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="4GRmlJ00$$z" role="8Wnug">
+            <node concept="37vLTI" id="4GRmlJ00_Y2" role="3clFbG">
+              <node concept="37vLTw" id="4GRmlJ00$$x" role="37vLTJ">
+                <ref role="3cqZAo" node="4GRmlJ00kmL" resolve="tree" />
+              </node>
+              <node concept="2OqwBi" id="4GRmlJ00zEz" role="37vLTx">
+                <node concept="2YIFZM" id="4GRmlJ00wx5" role="2Oq$k0">
+                  <ref role="37wK5l" to="rvbb:~ProjectPane.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                  <ref role="1Pybhc" to="rvbb:~ProjectPane" resolve="ProjectPane" />
+                  <node concept="2YIFZM" id="4GRmlJ00xq9" role="37wK5m">
+                    <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                    <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                    <node concept="1jxXqW" id="4GRmlJ00xrU" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="4GRmlJ00$wm" role="2OqNvi">
+                  <ref role="37wK5l" to="rvbb:~ProjectPane.getTree()" resolve="getTree" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlJ00Fbg" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlJ00G2b" role="3clFbG">
+            <node concept="2YIFZM" id="4GRmlJ00Flw" role="2Oq$k0">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+            <node concept="liA8E" id="4GRmlJ00GBC" role="2OqNvi">
+              <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+              <node concept="1bVj0M" id="4GRmlJ00GEf" role="37wK5m">
+                <node concept="3clFbS" id="4GRmlJ00GEi" role="1bW5cS">
+                  <node concept="3clFbF" id="4GRmlJ003VR" role="3cqZAp">
+                    <node concept="2YIFZM" id="4GRmlJ003ZQ" role="3clFbG">
+                      <ref role="37wK5l" to="anz6:~PlatformTestUtil.expandAll(javax.swing.JTree)" resolve="expandAll" />
+                      <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+                      <node concept="37vLTw" id="4GRmlJ00koZ" role="37wK5m">
+                        <ref role="3cqZAo" node="4GRmlJ00kmL" resolve="tree" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="3LGAAejPnuy" role="3cqZAp">
+                    <node concept="2YIFZM" id="3LGAAejPnHw" role="3clFbG">
+                      <ref role="37wK5l" to="anz6:~PlatformTestUtil.waitWhileBusy(javax.swing.JTree)" resolve="waitWhileBusy" />
+                      <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+                      <node concept="37vLTw" id="3LGAAejPnKd" role="37wK5m">
+                        <ref role="3cqZAo" node="4GRmlJ00kmL" resolve="tree" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3LGAAejPpfg" role="3cqZAp" />
+        <node concept="3vlDli" id="4GRmlJ00ukG" role="3cqZAp">
+          <node concept="3cmrfG" id="4GRmlJ00uJJ" role="3tpDZB">
+            <property role="3cmrfH" value="6" />
+          </node>
+          <node concept="2OqwBi" id="4GRmlJ00uyf" role="3tpDZA">
+            <node concept="2WthIp" id="4GRmlJ00uyi" role="2Oq$k0" />
+            <node concept="2XshWL" id="4GRmlJ00uyk" role="2OqNvi">
+              <ref role="2WH_rO" node="4GRmlJ00rEK" resolve="getExpandedNodeCount" />
+              <node concept="37vLTw" id="4GRmlJ00uGN" role="2XxRq1">
+                <ref role="3cqZAo" node="4GRmlJ00kmL" resolve="tree" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlJ0199S" role="1SL9yI">
+      <property role="TrG5h" value="allUpperCase" />
+      <node concept="3cqZAl" id="4GRmlJ0199T" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlJ0199X" role="3clF47">
+        <node concept="3vwNmj" id="4GRmlJ019lS" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlJ019kB" role="3vwVQn">
+            <ref role="37wK5l" to="anz6:~PlatformTestUtil.isAllUppercaseName(java.lang.String)" resolve="isAllUppercaseName" />
+            <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+            <node concept="Xl_RD" id="4GRmlJ019mC" role="37wK5m">
+              <property role="Xl_RC" value="HELLO" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlJ01DMc" role="1SL9yI">
+      <property role="TrG5h" value="stdErrorSuppressed" />
+      <node concept="3cqZAl" id="4GRmlJ01DMd" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlJ01DMh" role="3clF47">
+        <node concept="3clFbF" id="4GRmlJ01EAP" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlJ01ESV" role="3clFbG">
+            <ref role="37wK5l" to="anz6:~PlatformTestUtil.withStdErrSuppressed(java.lang.Runnable)" resolve="withStdErrSuppressed" />
+            <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+            <node concept="1bVj0M" id="4GRmlJ01G8H" role="37wK5m">
+              <node concept="3clFbS" id="4GRmlJ01G8K" role="1bW5cS">
+                <node concept="3clFbF" id="4GRmlJ01I9v" role="3cqZAp">
+                  <node concept="2OqwBi" id="4GRmlJ01I9s" role="3clFbG">
+                    <node concept="10M0yZ" id="4GRmlJ01I9t" role="2Oq$k0">
+                      <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                    </node>
+                    <node concept="liA8E" id="4GRmlJ01I9u" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                      <node concept="Xl_RD" id="4GRmlJ01Ica" role="37wK5m">
+                        <property role="Xl_RC" value="normal output" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4GRmlJ01DWy" role="3cqZAp">
+                  <node concept="2OqwBi" id="4GRmlJ01DWv" role="3clFbG">
+                    <node concept="10M0yZ" id="4GRmlJ01Eyg" role="2Oq$k0">
+                      <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                      <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                    </node>
+                    <node concept="liA8E" id="4GRmlJ01DWx" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                      <node concept="Xl_RD" id="4GRmlJ01DXi" role="37wK5m">
+                        <property role="Xl_RC" value="error output" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="4GRmlJ00gWW" role="1qtyYc">
+      <property role="TrG5h" value="createTestTreeContent" />
+      <node concept="3uibUv" id="4GRmlJ00h2q" role="3clF45">
+        <ref role="3uigEE" to="rgfa:~DefaultMutableTreeNode" resolve="DefaultMutableTreeNode" />
+      </node>
+      <node concept="3clFbS" id="4GRmlJ00gWY" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlJ00h7e" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00h7d" role="3cpWs9">
+            <property role="TrG5h" value="root" />
+            <node concept="3uibUv" id="4GRmlJ00h7f" role="1tU5fm">
+              <ref role="3uigEE" to="rgfa:~DefaultMutableTreeNode" resolve="DefaultMutableTreeNode" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlJ00ijb" role="33vP2m">
+              <node concept="1pGfFk" id="4GRmlJ00ijr" role="2ShVmc">
+                <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.&lt;init&gt;(java.lang.Object)" resolve="DefaultMutableTreeNode" />
+                <node concept="Xl_RD" id="4GRmlJ00ijs" role="37wK5m">
+                  <property role="Xl_RC" value="Root" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlJ00h7n" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00h7m" role="3cpWs9">
+            <property role="TrG5h" value="numChildren" />
+            <node concept="10Oyi0" id="4GRmlJ00h7o" role="1tU5fm" />
+            <node concept="3cmrfG" id="4GRmlJ00jmc" role="33vP2m">
+              <property role="3cmrfH" value="5" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="4GRmlJ00h7t" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00h7u" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="4GRmlJ00h7w" role="1tU5fm" />
+            <node concept="3cmrfG" id="4GRmlJ00h7x" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="4GRmlJ00h7y" role="1Dwp0S">
+            <node concept="37vLTw" id="4GRmlJ00h7z" role="3uHU7B">
+              <ref role="3cqZAo" node="4GRmlJ00h7u" resolve="i" />
+            </node>
+            <node concept="37vLTw" id="4GRmlJ00h7$" role="3uHU7w">
+              <ref role="3cqZAo" node="4GRmlJ00h7m" resolve="numChildren" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="4GRmlJ00h7A" role="1Dwrff">
+            <node concept="37vLTw" id="4GRmlJ00h7B" role="2$L3a6">
+              <ref role="3cqZAo" node="4GRmlJ00h7u" resolve="i" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4GRmlJ00h7D" role="2LFqv$">
+            <node concept="3cpWs8" id="4GRmlJ00h7F" role="3cqZAp">
+              <node concept="3cpWsn" id="4GRmlJ00h7E" role="3cpWs9">
+                <property role="TrG5h" value="child" />
+                <node concept="3uibUv" id="4GRmlJ00h7G" role="1tU5fm">
+                  <ref role="3uigEE" to="rgfa:~DefaultMutableTreeNode" resolve="DefaultMutableTreeNode" />
+                </node>
+                <node concept="2ShNRf" id="4GRmlJ00hTd" role="33vP2m">
+                  <node concept="1pGfFk" id="4GRmlJ00iaa" role="2ShVmc">
+                    <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.&lt;init&gt;(java.lang.Object)" resolve="DefaultMutableTreeNode" />
+                    <node concept="3cpWs3" id="4GRmlJ00iab" role="37wK5m">
+                      <node concept="Xl_RD" id="4GRmlJ00iac" role="3uHU7B">
+                        <property role="Xl_RC" value="Child " />
+                      </node>
+                      <node concept="37vLTw" id="4GRmlJ00iad" role="3uHU7w">
+                        <ref role="3cqZAo" node="4GRmlJ00h7u" resolve="i" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4GRmlJ00h7M" role="3cqZAp">
+              <node concept="3cpWsn" id="4GRmlJ00h7L" role="3cpWs9">
+                <property role="TrG5h" value="numGrandChildren" />
+                <node concept="10Oyi0" id="4GRmlJ00h7N" role="1tU5fm" />
+                <node concept="3cmrfG" id="4GRmlJ00jqS" role="33vP2m">
+                  <property role="3cmrfH" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Dw8fO" id="4GRmlJ00h7Q" role="3cqZAp">
+              <node concept="3cpWsn" id="4GRmlJ00h7R" role="1Duv9x">
+                <property role="TrG5h" value="j" />
+                <node concept="10Oyi0" id="4GRmlJ00h7T" role="1tU5fm" />
+                <node concept="3cmrfG" id="4GRmlJ00h7U" role="33vP2m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+              </node>
+              <node concept="3eOVzh" id="4GRmlJ00h7V" role="1Dwp0S">
+                <node concept="37vLTw" id="4GRmlJ00h7W" role="3uHU7B">
+                  <ref role="3cqZAo" node="4GRmlJ00h7R" resolve="j" />
+                </node>
+                <node concept="37vLTw" id="4GRmlJ00h7X" role="3uHU7w">
+                  <ref role="3cqZAo" node="4GRmlJ00h7L" resolve="numGrandChildren" />
+                </node>
+              </node>
+              <node concept="3uNrnE" id="4GRmlJ00h7Z" role="1Dwrff">
+                <node concept="37vLTw" id="4GRmlJ00h80" role="2$L3a6">
+                  <ref role="3cqZAo" node="4GRmlJ00h7R" resolve="j" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="4GRmlJ00h82" role="2LFqv$">
+                <node concept="3cpWs8" id="4GRmlJ00h84" role="3cqZAp">
+                  <node concept="3cpWsn" id="4GRmlJ00h83" role="3cpWs9">
+                    <property role="TrG5h" value="grandChild" />
+                    <node concept="3uibUv" id="4GRmlJ00h85" role="1tU5fm">
+                      <ref role="3uigEE" to="rgfa:~DefaultMutableTreeNode" resolve="DefaultMutableTreeNode" />
+                    </node>
+                    <node concept="2ShNRf" id="4GRmlJ00ijt" role="33vP2m">
+                      <node concept="1pGfFk" id="4GRmlJ00izQ" role="2ShVmc">
+                        <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.&lt;init&gt;(java.lang.Object)" resolve="DefaultMutableTreeNode" />
+                        <node concept="3cpWs3" id="4GRmlJ00izR" role="37wK5m">
+                          <node concept="3cpWs3" id="4GRmlJ00izS" role="3uHU7B">
+                            <node concept="3cpWs3" id="4GRmlJ00izT" role="3uHU7B">
+                              <node concept="Xl_RD" id="4GRmlJ00izU" role="3uHU7B">
+                                <property role="Xl_RC" value="Grandchild " />
+                              </node>
+                              <node concept="37vLTw" id="4GRmlJ00izV" role="3uHU7w">
+                                <ref role="3cqZAo" node="4GRmlJ00h7u" resolve="i" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="4GRmlJ00izW" role="3uHU7w">
+                              <property role="Xl_RC" value="." />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="4GRmlJ00izX" role="3uHU7w">
+                            <ref role="3cqZAo" node="4GRmlJ00h7R" resolve="j" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4GRmlJ00h8e" role="3cqZAp">
+                  <node concept="2OqwBi" id="4GRmlJ00j7_" role="3clFbG">
+                    <node concept="37vLTw" id="4GRmlJ00ian" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4GRmlJ00h7E" resolve="child" />
+                    </node>
+                    <node concept="liA8E" id="4GRmlJ00j7A" role="2OqNvi">
+                      <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.add(javax.swing.tree.MutableTreeNode)" resolve="add" />
+                      <node concept="37vLTw" id="4GRmlJ00j7B" role="37wK5m">
+                        <ref role="3cqZAo" node="4GRmlJ00h83" resolve="grandChild" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4GRmlJ00h8h" role="3cqZAp">
+              <node concept="2OqwBi" id="4GRmlJ00ja9" role="3clFbG">
+                <node concept="37vLTw" id="4GRmlJ00iah" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4GRmlJ00h7d" resolve="root" />
+                </node>
+                <node concept="liA8E" id="4GRmlJ00jaa" role="2OqNvi">
+                  <ref role="37wK5l" to="rgfa:~DefaultMutableTreeNode.add(javax.swing.tree.MutableTreeNode)" resolve="add" />
+                  <node concept="37vLTw" id="4GRmlJ00jab" role="37wK5m">
+                    <ref role="3cqZAo" node="4GRmlJ00h7E" resolve="child" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlJ00jF1" role="3cqZAp">
+          <node concept="37vLTw" id="4GRmlJ00jEZ" role="3clFbG">
+            <ref role="3cqZAo" node="4GRmlJ00h7d" resolve="root" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="4GRmlJ00rEK" role="1qtyYc">
+      <property role="TrG5h" value="getExpandedNodeCount" />
+      <node concept="10Oyi0" id="4GRmlJ00rOK" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlJ00rEM" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlJ00sUD" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00sUC" role="3cpWs9">
+            <property role="TrG5h" value="count" />
+            <node concept="10Oyi0" id="4GRmlJ00sUE" role="1tU5fm" />
+            <node concept="3cmrfG" id="4GRmlJ00sUF" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4GRmlJ00sUH" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00sUG" role="3cpWs9">
+            <property role="TrG5h" value="rowCount" />
+            <node concept="10Oyi0" id="4GRmlJ00sUI" role="1tU5fm" />
+            <node concept="2OqwBi" id="4GRmlJ00tt8" role="33vP2m">
+              <node concept="37vLTw" id="4GRmlJ00sWJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="4GRmlJ00rPl" resolve="tree" />
+              </node>
+              <node concept="liA8E" id="4GRmlJ00tt9" role="2OqNvi">
+                <ref role="37wK5l" to="dxuu:~JTree.getRowCount()" resolve="getRowCount" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="4GRmlJ00sUK" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlJ00sUL" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="4GRmlJ00sUN" role="1tU5fm" />
+            <node concept="3cmrfG" id="4GRmlJ00sUO" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="4GRmlJ00sUP" role="1Dwp0S">
+            <node concept="37vLTw" id="4GRmlJ00sUQ" role="3uHU7B">
+              <ref role="3cqZAo" node="4GRmlJ00sUL" resolve="i" />
+            </node>
+            <node concept="37vLTw" id="4GRmlJ00sUR" role="3uHU7w">
+              <ref role="3cqZAo" node="4GRmlJ00sUG" resolve="rowCount" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="4GRmlJ00sUT" role="1Dwrff">
+            <node concept="37vLTw" id="4GRmlJ00sUU" role="2$L3a6">
+              <ref role="3cqZAo" node="4GRmlJ00sUL" resolve="i" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4GRmlJ00sUW" role="2LFqv$">
+            <node concept="3clFbJ" id="4GRmlJ00sUX" role="3cqZAp">
+              <node concept="2OqwBi" id="4GRmlJ00sY4" role="3clFbw">
+                <node concept="37vLTw" id="4GRmlJ00sWG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4GRmlJ00rPl" resolve="tree" />
+                </node>
+                <node concept="liA8E" id="4GRmlJ00sY5" role="2OqNvi">
+                  <ref role="37wK5l" to="dxuu:~JTree.isExpanded(int)" resolve="isExpanded" />
+                  <node concept="37vLTw" id="4GRmlJ00sY6" role="37wK5m">
+                    <ref role="3cqZAo" node="4GRmlJ00sUL" resolve="i" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="4GRmlJ00sV1" role="3clFbx">
+                <node concept="3clFbF" id="4GRmlJ00sV2" role="3cqZAp">
+                  <node concept="3uNrnE" id="4GRmlJ00sV3" role="3clFbG">
+                    <node concept="37vLTw" id="4GRmlJ00sV4" role="2$L3a6">
+                      <ref role="3cqZAo" node="4GRmlJ00sUC" resolve="count" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4GRmlJ00sV5" role="3cqZAp">
+          <node concept="37vLTw" id="4GRmlJ00sV6" role="3cqZAk">
+            <ref role="3cqZAo" node="4GRmlJ00sUC" resolve="count" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4GRmlJ00rPl" role="3clF46">
+        <property role="TrG5h" value="tree" />
+        <node concept="3uibUv" id="4GRmlJ00rPk" role="1tU5fm">
+          <ref role="3uigEE" to="dxuu:~JTree" resolve="JTree" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2$zHkrOwgvf">
+    <property role="TrG5h" value="Redo" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <property role="3YCmrE" value="Execute redo in the editor." />
+    <node concept="1qefOq" id="2$zHkrOwgvg" role="25YQCW">
+      <node concept="312cEu" id="2$zHkrOwgvh" role="1qenE9">
+        <property role="TrG5h" value="Class" />
+        <node concept="3Tm1VV" id="2$zHkrOwgvi" role="1B3o_S" />
+        <node concept="LIFWc" id="2$zHkrOwjuG" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="5" />
+          <property role="p6zMs" value="5" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOwgvl" role="25YQFr">
+      <node concept="312cEu" id="2$zHkrOwgvm" role="1qenE9">
+        <property role="TrG5h" value="ClassHi" />
+        <node concept="3Tm1VV" id="2$zHkrOwgvn" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="2$zHkrOwgvo" role="LjaKd">
+      <node concept="2TK7Tu" id="2$zHkrOwlM8" role="3cqZAp">
+        <property role="2TTd_B" value="Hi" />
+      </node>
+      <node concept="3cpWs8" id="2$zHkrOwgvq" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrOwgvr" role="3cpWs9">
+          <property role="TrG5h" value="ideaProject" />
+          <node concept="3uibUv" id="2$zHkrOwgvs" role="1tU5fm">
+            <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+          </node>
+          <node concept="2YIFZM" id="2$zHkrOwgvt" role="33vP2m">
+            <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+            <node concept="1jxXqW" id="2$zHkrOwgvu" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="2$zHkrOwgvv" role="3cqZAp">
+        <node concept="2OqwBi" id="2$zHkrOwgvw" role="3clFbG">
+          <node concept="2YIFZM" id="2$zHkrOwgvx" role="2Oq$k0">
+            <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+            <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+          </node>
+          <node concept="liA8E" id="2$zHkrOwgvy" role="2OqNvi">
+            <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+            <node concept="1bVj0M" id="2$zHkrOwgvz" role="37wK5m">
+              <node concept="3clFbS" id="2$zHkrOwgv$" role="1bW5cS">
+                <node concept="3cpWs8" id="2$zHkrOwoWM" role="3cqZAp">
+                  <node concept="3cpWsn" id="2$zHkrOwoWN" role="3cpWs9">
+                    <property role="TrG5h" value="undoManager" />
+                    <node concept="3uibUv" id="2$zHkrOwoUI" role="1tU5fm">
+                      <ref role="3uigEE" to="54q7:~UndoManager" resolve="UndoManager" />
+                    </node>
+                    <node concept="2YIFZM" id="2$zHkrOwoWO" role="33vP2m">
+                      <ref role="37wK5l" to="54q7:~UndoManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                      <ref role="1Pybhc" to="54q7:~UndoManager" resolve="UndoManager" />
+                      <node concept="37vLTw" id="2$zHkrOwoWP" role="37wK5m">
+                        <ref role="3cqZAo" node="2$zHkrOwgvr" resolve="ideaProject" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2$zHkrOwgv_" role="3cqZAp">
+                  <node concept="2OqwBi" id="2$zHkrOwgvA" role="3clFbG">
+                    <node concept="37vLTw" id="2$zHkrOwoWQ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2$zHkrOwoWN" resolve="undoManager" />
+                    </node>
+                    <node concept="liA8E" id="2$zHkrOwgvD" role="2OqNvi">
+                      <ref role="37wK5l" to="54q7:~UndoManager.undo(com.intellij.openapi.fileEditor.FileEditor)" resolve="undo" />
+                      <node concept="3tlvWP" id="2$zHkrOwgvE" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2$zHkrOwm0$" role="3cqZAp">
+                  <node concept="2OqwBi" id="2$zHkrOwm0_" role="3clFbG">
+                    <node concept="37vLTw" id="2$zHkrOwoWR" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2$zHkrOwoWN" resolve="undoManager" />
+                    </node>
+                    <node concept="liA8E" id="2$zHkrOwm0C" role="2OqNvi">
+                      <ref role="37wK5l" to="54q7:~UndoManager.redo(com.intellij.openapi.fileEditor.FileEditor)" resolve="redo" />
+                      <node concept="3tlvWP" id="2$zHkrOwm0D" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6cyqnzelau2">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ThemeSwitching" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="6cyqnzelaum" role="1SL9yI">
+      <property role="TrG5h" value="switchToDarkTheme" />
+      <node concept="3cqZAl" id="6cyqnzelaun" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzelaur" role="3clF47">
+        <node concept="3cpWs8" id="6cyqnzeldIn" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzeldIo" role="3cpWs9">
+            <property role="TrG5h" value="color" />
+            <node concept="3uibUv" id="6cyqnzeldHI" role="1tU5fm">
+              <ref role="3uigEE" to="lzb2:~JBColor" resolve="JBColor" />
+            </node>
+            <node concept="10M0yZ" id="6cyqnzeldIp" role="33vP2m">
+              <ref role="3cqZAo" to="lzb2:~JBColor.WHITE" resolve="WHITE" />
+              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="6cyqnzeldUz" role="3cqZAp">
+          <node concept="3cmrfG" id="6cyqnzellGy" role="3tpDZB">
+            <property role="3cmrfH" value="-1" />
+          </node>
+          <node concept="2OqwBi" id="6cyqnzeleT7" role="3tpDZA">
+            <node concept="37vLTw" id="6cyqnzeldV5" role="2Oq$k0">
+              <ref role="3cqZAo" node="6cyqnzeldIo" resolve="color" />
+            </node>
+            <node concept="liA8E" id="6cyqnzellFR" role="2OqNvi">
+              <ref role="37wK5l" to="lzb2:~JBColor.getRGB()" resolve="getRGB" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6cyqnzellHf" role="3cqZAp" />
+        <node concept="3cpWs8" id="6cyqnzellPV" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzellPU" role="3cpWs9">
+            <property role="TrG5h" value="lafManager" />
+            <node concept="3uibUv" id="6cyqnzellPW" role="1tU5fm">
+              <ref role="3uigEE" to="j936:~LafManager" resolve="LafManager" />
+            </node>
+            <node concept="2YIFZM" id="6cyqnzelm4l" role="33vP2m">
+              <ref role="1Pybhc" to="j936:~LafManager" resolve="LafManager" />
+              <ref role="37wK5l" to="j936:~LafManager.getInstance()" resolve="getInstance" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6cyqnzelTAF" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzelTAG" role="3cpWs9">
+            <property role="TrG5h" value="currentLookAndFeel" />
+            <node concept="3uibUv" id="6cyqnzelTAH" role="1tU5fm">
+              <ref role="3uigEE" to="dxuu:~UIManager$LookAndFeelInfo" resolve="UIManager.LookAndFeelInfo" />
+            </node>
+            <node concept="2OqwBi" id="6cyqnzelSqx" role="33vP2m">
+              <node concept="37vLTw" id="6cyqnzelSfi" role="2Oq$k0">
+                <ref role="3cqZAo" node="6cyqnzellPU" resolve="lafManager" />
+              </node>
+              <node concept="liA8E" id="6cyqnzelSBW" role="2OqNvi">
+                <ref role="37wK5l" to="j936:~LafManager.getCurrentLookAndFeel()" resolve="getCurrentLookAndFeel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6cyqnzelX_5" role="3cqZAp" />
+        <node concept="3J1_TO" id="6cyqnzelYEE" role="3cqZAp">
+          <node concept="3clFbS" id="6cyqnzelYEG" role="1zxBo7">
+            <node concept="3cpWs8" id="6cyqnzelV4$" role="3cqZAp">
+              <node concept="3cpWsn" id="6cyqnzelV4_" role="3cpWs9">
+                <property role="TrG5h" value="testInstance" />
+                <node concept="3uibUv" id="6cyqnzelV47" role="1tU5fm">
+                  <ref role="3uigEE" to="fdd1:~LafManagerImpl" resolve="LafManagerImpl" />
+                </node>
+                <node concept="2YIFZM" id="6cyqnzelV4A" role="33vP2m">
+                  <ref role="1Pybhc" to="fdd1:~LafManagerImpl" resolve="LafManagerImpl" />
+                  <ref role="37wK5l" to="fdd1:~LafManagerImpl.getTestInstance()" resolve="getTestInstance" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5nwfWGQ3UU2" role="3cqZAp">
+              <node concept="3clFbS" id="5nwfWGQ3UU4" role="3clFbx">
+                <node concept="3clFbF" id="6cyqnzellPY" role="3cqZAp">
+                  <node concept="2YIFZM" id="6cyqnzellQT" role="3clFbG">
+                    <ref role="1Pybhc" to="tqbz:~QuickChangeLookAndFeel" resolve="QuickChangeLookAndFeel" />
+                    <ref role="37wK5l" to="tqbz:~QuickChangeLookAndFeel.switchLafAndUpdateUI(com.intellij.ide.ui.LafManager,javax.swing.UIManager$LookAndFeelInfo,boolean)" resolve="switchLafAndUpdateUI" />
+                    <node concept="37vLTw" id="6cyqnzellQU" role="37wK5m">
+                      <ref role="3cqZAo" node="6cyqnzellPU" resolve="lafManager" />
+                    </node>
+                    <node concept="2OqwBi" id="6cyqnzeln7S" role="37wK5m">
+                      <node concept="37vLTw" id="6cyqnzelV4B" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6cyqnzelV4_" resolve="testInstance" />
+                      </node>
+                      <node concept="liA8E" id="6cyqnzeln7T" role="2OqNvi">
+                        <ref role="37wK5l" to="fdd1:~LafManagerImpl.getDefaultDarkLaf()" resolve="getDefaultDarkLaf" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="6cyqnzellQX" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="5nwfWGQ3Wk2" role="3clFbw">
+                <node concept="10Nm6u" id="5nwfWGQ3Wxe" role="3uHU7w" />
+                <node concept="37vLTw" id="5nwfWGQ3UXa" role="3uHU7B">
+                  <ref role="3cqZAo" node="6cyqnzelV4_" resolve="testInstance" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="6cyqnzellHU" role="3cqZAp" />
+            <node concept="3vFxKo" id="6cyqnzelo2B" role="3cqZAp">
+              <node concept="17R0WA" id="6cyqnzelsMj" role="3vFALc">
+                <node concept="3cmrfG" id="6cyqnzelsOd" role="3uHU7w">
+                  <property role="3cmrfH" value="-1" />
+                </node>
+                <node concept="2OqwBi" id="6cyqnzelp3z" role="3uHU7B">
+                  <node concept="37vLTw" id="6cyqnzelo4t" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6cyqnzeldIo" resolve="color" />
+                  </node>
+                  <node concept="liA8E" id="6cyqnzelqvd" role="2OqNvi">
+                    <ref role="37wK5l" to="lzb2:~JBColor.getRGB()" resolve="getRGB" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="6cyqnzelYHA" role="1zxBo6">
+            <node concept="3clFbS" id="6cyqnzelYHB" role="1wplMD">
+              <node concept="3clFbF" id="6cyqnzelYQD" role="3cqZAp">
+                <node concept="2YIFZM" id="6cyqnzelYQE" role="3clFbG">
+                  <ref role="1Pybhc" to="tqbz:~QuickChangeLookAndFeel" resolve="QuickChangeLookAndFeel" />
+                  <ref role="37wK5l" to="tqbz:~QuickChangeLookAndFeel.switchLafAndUpdateUI(com.intellij.ide.ui.LafManager,javax.swing.UIManager$LookAndFeelInfo,boolean)" resolve="switchLafAndUpdateUI" />
+                  <node concept="37vLTw" id="6cyqnzelYQF" role="37wK5m">
+                    <ref role="3cqZAo" node="6cyqnzellPU" resolve="lafManager" />
+                  </node>
+                  <node concept="37vLTw" id="6cyqnzelYYl" role="37wK5m">
+                    <ref role="3cqZAo" node="6cyqnzelTAG" resolve="currentLookAndFeel" />
+                  </node>
+                  <node concept="3clFbT" id="6cyqnzelYQJ" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="4GRmlJ04VXg">
+    <property role="TrG5h" value="Undo" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <property role="3YCmrE" value="Execude undo in the editor." />
+    <node concept="1qefOq" id="4GRmlJ04VYj" role="25YQCW">
+      <node concept="312cEu" id="4GRmlJ04VYh" role="1qenE9">
+        <property role="TrG5h" value="Class" />
+        <node concept="3Tm1VV" id="4GRmlJ04VYi" role="1B3o_S" />
+        <node concept="LIFWc" id="4GRmlJ04W1X" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="5" />
+          <property role="p6zMs" value="5" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4GRmlJ04VZ6" role="25YQFr">
+      <node concept="312cEu" id="4GRmlJ04VZo" role="1qenE9">
+        <property role="TrG5h" value="Class" />
+        <node concept="3Tm1VV" id="4GRmlJ04VZp" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="4GRmlJ04W0R" role="LjaKd">
+      <node concept="2TK7Tu" id="4GRmlJ04W0Q" role="3cqZAp">
+        <property role="2TTd_B" value="Hi" />
+      </node>
+      <node concept="3cpWs8" id="2$zHkrOr$RS" role="3cqZAp">
+        <node concept="3cpWsn" id="2$zHkrOr$RT" role="3cpWs9">
+          <property role="TrG5h" value="ideaProject" />
+          <node concept="3uibUv" id="2$zHkrOr$gd" role="1tU5fm">
+            <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+          </node>
+          <node concept="2YIFZM" id="2$zHkrOr$RU" role="33vP2m">
+            <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+            <node concept="1jxXqW" id="2$zHkrOr$RV" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="2$zHkrOrzA7" role="3cqZAp">
+        <node concept="2OqwBi" id="2$zHkrOr$fB" role="3clFbG">
+          <node concept="2YIFZM" id="2$zHkrOrzAU" role="2Oq$k0">
+            <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+            <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+          </node>
+          <node concept="liA8E" id="2$zHkrOr$OO" role="2OqNvi">
+            <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+            <node concept="1bVj0M" id="2$zHkrOr$PV" role="37wK5m">
+              <node concept="3clFbS" id="2$zHkrOr$PY" role="1bW5cS">
+                <node concept="3clFbF" id="4GRmlJ04ZGd" role="3cqZAp">
+                  <node concept="2OqwBi" id="2$zHkrOr_ok" role="3clFbG">
+                    <node concept="2YIFZM" id="4GRmlJ04ZGF" role="2Oq$k0">
+                      <ref role="37wK5l" to="54q7:~UndoManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                      <ref role="1Pybhc" to="54q7:~UndoManager" resolve="UndoManager" />
+                      <node concept="37vLTw" id="2$zHkrOr$RW" role="37wK5m">
+                        <ref role="3cqZAo" node="2$zHkrOr$RT" resolve="ideaProject" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2$zHkrOr_yy" role="2OqNvi">
+                      <ref role="37wK5l" to="54q7:~UndoManager.undo(com.intellij.openapi.fileEditor.FileEditor)" resolve="undo" />
+                      <node concept="3tlvWP" id="2$zHkrOuwix" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4ZU$2lrX$D1">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="Various" />
+    <property role="3GE5qa" value="ideaPlatform" />
+    <node concept="1LZb2c" id="4ZU$2lrX$D5" role="1SL9yI">
+      <property role="TrG5h" value="powerSaveMode" />
+      <node concept="3cqZAl" id="4ZU$2lrX$D6" role="3clF45" />
+      <node concept="3clFbS" id="4ZU$2lrX$Da" role="3clF47">
+        <node concept="3clFbF" id="5nwfWGQ0iNT" role="3cqZAp">
+          <node concept="2OqwBi" id="5nwfWGQ0Xmu" role="3clFbG">
+            <node concept="2ShNRf" id="5nwfWGQ0iNP" role="2Oq$k0">
+              <node concept="1pGfFk" id="5nwfWGQ0WPU" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXHgJ5" resolve="PlatformTestHelper" />
+                <node concept="1jxXqW" id="5nwfWGQ0WQi" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5nwfWGQ0XBs" role="2OqNvi">
+              <ref role="37wK5l" to="m531:5nwfWGQ0hqb" resolve="withPowerSaveModelEnabled" />
+              <node concept="1bVj0M" id="5nwfWGQ0XE8" role="37wK5m">
+                <node concept="3clFbS" id="5nwfWGQ0XEc" role="1bW5cS">
+                  <node concept="3vwNmj" id="4GRmlIZMGxF" role="3cqZAp">
+                    <node concept="2YIFZM" id="4GRmlIZMG$A" role="3vwVQn">
+                      <ref role="37wK5l" to="ddhc:~PowerSaveMode.isEnabled()" resolve="isEnabled" />
+                      <ref role="1Pybhc" to="ddhc:~PowerSaveMode" resolve="PowerSaveMode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZMKOT" role="1SL9yI">
+      <property role="TrG5h" value="fatalError" />
+      <node concept="3cqZAl" id="4GRmlIZMKOU" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZMKOY" role="3clF47">
+        <node concept="3clFbF" id="4GRmlIZN2fz" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZN2oR" role="3clFbG">
+            <node concept="2YIFZM" id="4GRmlIZN2hq" role="2Oq$k0">
+              <ref role="37wK5l" to="al1t:~MessagePool.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="al1t:~MessagePool" resolve="MessagePool" />
+            </node>
+            <node concept="liA8E" id="4GRmlIZN2wy" role="2OqNvi">
+              <ref role="37wK5l" to="al1t:~MessagePool.addIdeFatalMessage(com.intellij.openapi.diagnostic.IdeaLoggingEvent)" resolve="addIdeFatalMessage" />
+              <node concept="2ShNRf" id="4GRmlIZN2xg" role="37wK5m">
+                <node concept="1pGfFk" id="4GRmlIZN7Z$" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="uzhr:~IdeaLoggingEvent.&lt;init&gt;(java.lang.String,java.lang.Throwable)" resolve="IdeaLoggingEvent" />
+                  <node concept="Xl_RD" id="4GRmlIZN85J" role="37wK5m">
+                    <property role="Xl_RC" value="my error" />
+                  </node>
+                  <node concept="2ShNRf" id="4GRmlIZN8b_" role="37wK5m">
+                    <node concept="1pGfFk" id="4GRmlIZN8b$" role="2ShVmc">
+                      <ref role="37wK5l" to="wyt6:~Throwable.&lt;init&gt;()" resolve="Throwable" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ1tiU" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ1tiV" role="3cpWs9">
+            <property role="TrG5h" value="platformTestHelper" />
+            <node concept="3uibUv" id="5nwfWGQ1rgp" role="1tU5fm">
+              <ref role="3uigEE" to="m531:6HRhZeXHgJ0" resolve="PlatformTestHelper" />
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ1tiW" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ1tiX" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXHgJ5" resolve="PlatformTestHelper" />
+                <node concept="1jxXqW" id="5nwfWGQ1tiY" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5nwfWGQ1oeL" role="3cqZAp">
+          <node concept="2OqwBi" id="5nwfWGQ1red" role="3clFbG">
+            <node concept="37vLTw" id="5nwfWGQ1tiZ" role="2Oq$k0">
+              <ref role="3cqZAo" node="5nwfWGQ1tiV" resolve="platformTestHelper" />
+            </node>
+            <node concept="liA8E" id="5nwfWGQ1rya" role="2OqNvi">
+              <ref role="37wK5l" to="m531:5nwfWGQ10Ho" resolve="assertHasFatalError" />
+              <node concept="10Nm6u" id="5nwfWGQ1rA9" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5nwfWGQ1wX8" role="3cqZAp">
+          <node concept="2OqwBi" id="5nwfWGQ1xvd" role="3clFbG">
+            <node concept="37vLTw" id="5nwfWGQ1wX6" role="2Oq$k0">
+              <ref role="3cqZAo" node="5nwfWGQ1tiV" resolve="platformTestHelper" />
+            </node>
+            <node concept="liA8E" id="5nwfWGQ1xMQ" role="2OqNvi">
+              <ref role="37wK5l" to="m531:5nwfWGQ10Ho" resolve="assertHasFatalError" />
+              <node concept="Xl_RD" id="5nwfWGQ1xRO" role="37wK5m">
+                <property role="Xl_RC" value="my error" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZNo8S" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZNoP6" role="3clFbG">
+            <node concept="2YIFZM" id="4GRmlIZNobm" role="2Oq$k0">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+            <node concept="liA8E" id="4GRmlIZNpr5" role="2OqNvi">
+              <ref role="37wK5l" to="bd8o:~Application.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+              <node concept="1bVj0M" id="4GRmlIZNptv" role="37wK5m">
+                <node concept="3clFbS" id="4GRmlIZNpty" role="1bW5cS">
+                  <node concept="3clFbF" id="4GRmlIZNhUA" role="3cqZAp">
+                    <node concept="2OqwBi" id="4GRmlIZNyeA" role="3clFbG">
+                      <node concept="2YIFZM" id="4GRmlIZNy5w" role="2Oq$k0">
+                        <ref role="37wK5l" to="al1t:~MessagePool.getInstance()" resolve="getInstance" />
+                        <ref role="1Pybhc" to="al1t:~MessagePool" resolve="MessagePool" />
+                      </node>
+                      <node concept="liA8E" id="4GRmlIZNyof" role="2OqNvi">
+                        <ref role="37wK5l" to="al1t:~MessagePool.clearErrors()" resolve="clearErrors" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZNLNe" role="1SL9yI">
+      <property role="TrG5h" value="isEDTThread" />
+      <node concept="3cqZAl" id="4GRmlIZNLNf" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZNLNj" role="3clF47">
+        <node concept="3clFbF" id="4GRmlIZNPqw" role="3cqZAp">
+          <node concept="2YIFZM" id="4GRmlIZNPsw" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.assertEDT()" resolve="assertEDT" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZNLU6" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZNMFQ" role="3clFbG">
+            <node concept="2YIFZM" id="4GRmlIZNLUW" role="2Oq$k0">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+            <node concept="liA8E" id="4GRmlIZNNgB" role="2OqNvi">
+              <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+              <node concept="1bVj0M" id="4GRmlIZNNij" role="37wK5m">
+                <node concept="3clFbS" id="4GRmlIZNNim" role="1bW5cS">
+                  <node concept="3clFbF" id="4GRmlIZNLSQ" role="3cqZAp">
+                    <node concept="2YIFZM" id="4GRmlIZNLTk" role="3clFbG">
+                      <ref role="37wK5l" to="3a50:~ThreadUtils.assertEDT()" resolve="assertEDT" />
+                      <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZOClw" role="1SL9yI">
+      <property role="TrG5h" value="isCustomThread" />
+      <node concept="3cqZAl" id="4GRmlIZOClx" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZOCly" role="3clF47">
+        <node concept="3cpWs8" id="4GRmlIZOGv2" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZOGv0" role="3cpWs9">
+            <property role="3TUv4t" value="true" />
+            <property role="TrG5h" value="threadFailure" />
+            <node concept="10Q1$e" id="4GRmlIZOGxp" role="1tU5fm">
+              <node concept="3uibUv" id="4GRmlIZOGwc" role="10Q1$1">
+                <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="4GRmlIZOGAM" role="33vP2m">
+              <node concept="3$_iS1" id="4GRmlIZOGU7" role="2ShVmc">
+                <node concept="3$GHV9" id="4GRmlIZOGU9" role="3$GQph">
+                  <node concept="3cmrfG" id="4GRmlIZOGVM" role="3$I4v7">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                </node>
+                <node concept="3uibUv" id="4GRmlIZOGR7" role="3$_nBY">
+                  <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4GRmlIZOGtM" role="3cqZAp" />
+        <node concept="3cpWs8" id="4GRmlIZOEAE" role="3cqZAp">
+          <node concept="3cpWsn" id="4GRmlIZOEAF" role="3cpWs9">
+            <property role="TrG5h" value="thread" />
+            <node concept="3uibUv" id="4GRmlIZOEst" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Thread" resolve="Thread" />
+            </node>
+            <node concept="2ShNRf" id="4GRmlIZOEAG" role="33vP2m">
+              <node concept="1pGfFk" id="4GRmlIZOEAH" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~Thread.&lt;init&gt;(java.lang.Runnable,java.lang.String)" resolve="Thread" />
+                <node concept="1bVj0M" id="4GRmlIZOEAI" role="37wK5m">
+                  <node concept="3clFbS" id="4GRmlIZOEAJ" role="1bW5cS">
+                    <node concept="3J1_TO" id="4GRmlIZOHed" role="3cqZAp">
+                      <node concept="3uVAMA" id="4GRmlIZOHgA" role="1zxBo5">
+                        <node concept="XOnhg" id="4GRmlIZOHgB" role="1zc67B">
+                          <property role="TrG5h" value="t" />
+                          <node concept="nSUau" id="4GRmlIZOHgC" role="1tU5fm">
+                            <node concept="3uibUv" id="4GRmlIZOIpC" role="nSUat">
+                              <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="4GRmlIZOHgD" role="1zc67A">
+                          <node concept="3clFbF" id="4GRmlIZOINn" role="3cqZAp">
+                            <node concept="37vLTI" id="4GRmlIZOJWL" role="3clFbG">
+                              <node concept="37vLTw" id="4GRmlIZOK90" role="37vLTx">
+                                <ref role="3cqZAo" node="4GRmlIZOHgB" resolve="t" />
+                              </node>
+                              <node concept="AH0OO" id="4GRmlIZOJgv" role="37vLTJ">
+                                <node concept="3cmrfG" id="4GRmlIZOJsC" role="AHEQo">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                                <node concept="37vLTw" id="4GRmlIZOINm" role="AHHXb">
+                                  <ref role="3cqZAo" node="4GRmlIZOGv0" resolve="threadFailure" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4GRmlIZOHee" role="1zxBo7">
+                        <node concept="3vlDli" id="4GRmlIZOHm4" role="3cqZAp">
+                          <node concept="Xl_RD" id="4GRmlIZOH$D" role="3tpDZB">
+                            <property role="Xl_RC" value="myname" />
+                          </node>
+                          <node concept="2OqwBi" id="4GRmlIZOHSo" role="3tpDZA">
+                            <node concept="2YIFZM" id="4GRmlIZOHDy" role="2Oq$k0">
+                              <ref role="37wK5l" to="wyt6:~Thread.currentThread()" resolve="currentThread" />
+                              <ref role="1Pybhc" to="wyt6:~Thread" resolve="Thread" />
+                            </node>
+                            <node concept="liA8E" id="4GRmlIZOI97" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Thread.getName()" resolve="getName" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4GRmlIZOEAK" role="37wK5m">
+                  <property role="Xl_RC" value="myname" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZOEDj" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZOESz" role="3clFbG">
+            <node concept="37vLTw" id="4GRmlIZOEDh" role="2Oq$k0">
+              <ref role="3cqZAo" node="4GRmlIZOEAF" resolve="thread" />
+            </node>
+            <node concept="liA8E" id="4GRmlIZOF7b" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Thread.start()" resolve="start" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZOF99" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZOFoA" role="3clFbG">
+            <node concept="37vLTw" id="4GRmlIZOF97" role="2Oq$k0">
+              <ref role="3cqZAo" node="4GRmlIZOEAF" resolve="thread" />
+            </node>
+            <node concept="liA8E" id="4GRmlIZOFB_" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Thread.join()" resolve="join" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4GRmlIZOKoo" role="3cqZAp" />
+        <node concept="3clFbJ" id="4GRmlIZOKpW" role="3cqZAp">
+          <node concept="3clFbS" id="4GRmlIZOKpY" role="3clFbx">
+            <node concept="3xETmq" id="4GRmlIZOKQA" role="3cqZAp">
+              <node concept="3_1$Yv" id="4GRmlIZOKT2" role="3_9lra">
+                <node concept="2OqwBi" id="4GRmlIZOLjX" role="3_1BAH">
+                  <node concept="AH0OO" id="4GRmlIZOL1R" role="2Oq$k0">
+                    <node concept="3cmrfG" id="4GRmlIZOL6l" role="AHEQo">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="37vLTw" id="4GRmlIZOKU5" role="AHHXb">
+                      <ref role="3cqZAo" node="4GRmlIZOGv0" resolve="threadFailure" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4GRmlIZOL_k" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="4GRmlIZOKOV" role="3clFbw">
+            <node concept="10Nm6u" id="4GRmlIZOKOY" role="3uHU7w" />
+            <node concept="AH0OO" id="4GRmlIZOKyP" role="3uHU7B">
+              <node concept="3cmrfG" id="4GRmlIZOKBj" role="AHEQo">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="37vLTw" id="4GRmlIZOKr_" role="AHHXb">
+                <ref role="3cqZAo" node="4GRmlIZOGv0" resolve="threadFailure" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4GRmlIZOFG9" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZNUTz" role="1SL9yI">
+      <property role="TrG5h" value="writeAccess" />
+      <node concept="3cqZAl" id="4GRmlIZNUT$" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZNUTC" role="3clF47">
+        <node concept="3SKdUt" id="4GRmlIZO0Yu" role="3cqZAp">
+          <node concept="1PaTwC" id="4GRmlIZO0Yv" role="1aUNEU">
+            <node concept="3oM_SD" id="4GRmlIZO0ZB" role="1PaTwD">
+              <property role="3oM_SC" value="change" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZC" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZD" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZE" role="1PaTwD">
+              <property role="3oM_SC" value="access" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZF" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZG" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZH" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZI" role="1PaTwD">
+              <property role="3oM_SC" value="inspector" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZJ" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZK" role="1PaTwD">
+              <property role="3oM_SC" value="simulate" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZL" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZM" role="1PaTwD">
+              <property role="3oM_SC" value="failure" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZNUWs" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZNX5l" role="3clFbG">
+            <node concept="2OqwBi" id="4GRmlIZNWf_" role="2Oq$k0">
+              <node concept="1jxXqW" id="4GRmlIZNUWr" role="2Oq$k0" />
+              <node concept="liA8E" id="4GRmlIZNWXJ" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getModelAccess()" resolve="getModelAccess" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4GRmlIZNXdV" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.checkWriteAccess()" resolve="checkWriteAccess" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZO$KH" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZO_J8" role="3clFbG">
+            <node concept="2OqwBi" id="4GRmlIZO_sE" role="2Oq$k0">
+              <node concept="2OqwBi" id="4GRmlIZO_c6" role="2Oq$k0">
+                <node concept="2JrnkZ" id="4GRmlIZO_45" role="2Oq$k0">
+                  <node concept="1jGwE1" id="4GRmlIZO$KF" role="2JrQYb" />
+                </node>
+                <node concept="liA8E" id="4GRmlIZO_kE" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4GRmlIZO_A1" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SRepository.getModelAccess()" resolve="getModelAccess" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4GRmlIZO_TC" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.checkWriteAccess()" resolve="checkWriteAccess" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZO0ZN" role="1SL9yI">
+      <property role="TrG5h" value="readAccess" />
+      <node concept="3cqZAl" id="4GRmlIZO0ZO" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZO0ZP" role="3clF47">
+        <node concept="3SKdUt" id="4GRmlIZO0ZQ" role="3cqZAp">
+          <node concept="1PaTwC" id="4GRmlIZO0ZR" role="1aUNEU">
+            <node concept="3oM_SD" id="4GRmlIZO0ZS" role="1PaTwD">
+              <property role="3oM_SC" value="change" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZT" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZU" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZV" role="1PaTwD">
+              <property role="3oM_SC" value="access" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZW" role="1PaTwD">
+              <property role="3oM_SC" value="model" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZX" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZY" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO0ZZ" role="1PaTwD">
+              <property role="3oM_SC" value="inspector" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO100" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO101" role="1PaTwD">
+              <property role="3oM_SC" value="simulate" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO102" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="4GRmlIZO103" role="1PaTwD">
+              <property role="3oM_SC" value="failure" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZO104" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZO105" role="3clFbG">
+            <node concept="2OqwBi" id="4GRmlIZO106" role="2Oq$k0">
+              <node concept="1jxXqW" id="4GRmlIZO107" role="2Oq$k0" />
+              <node concept="liA8E" id="4GRmlIZO108" role="2OqNvi">
+                <ref role="37wK5l" to="z1c3:~Project.getModelAccess()" resolve="getModelAccess" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4GRmlIZO109" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.checkReadAccess()" resolve="checkReadAccess" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4GRmlIZOA0q" role="3cqZAp">
+          <node concept="2OqwBi" id="4GRmlIZOA0r" role="3clFbG">
+            <node concept="2OqwBi" id="4GRmlIZOA0s" role="2Oq$k0">
+              <node concept="2OqwBi" id="4GRmlIZOA0t" role="2Oq$k0">
+                <node concept="2JrnkZ" id="4GRmlIZOA0u" role="2Oq$k0">
+                  <node concept="1jGwE1" id="4GRmlIZOA0v" role="2JrQYb" />
+                </node>
+                <node concept="liA8E" id="4GRmlIZOA0w" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4GRmlIZOA0x" role="2OqNvi">
+                <ref role="37wK5l" to="lui2:~SRepository.getModelAccess()" resolve="getModelAccess" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4GRmlIZOA0y" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~ModelAccess.checkReadAccess()" resolve="checkReadAccess" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="4GRmlIZPFjr" role="1SL9yI">
+      <property role="TrG5h" value="brokenEditor" />
+      <node concept="3cqZAl" id="4GRmlIZPFjs" role="3clF45" />
+      <node concept="3clFbS" id="4GRmlIZPFjw" role="3clF47">
+        <node concept="3clFbF" id="4GRmlIZRHVT" role="3cqZAp">
+          <node concept="37vLTI" id="4GRmlIZRKXw" role="3clFbG">
+            <node concept="3clFbT" id="4GRmlIZRLGL" role="37vLTx">
+              <property role="3clFbU" value="true" />
+            </node>
+            <node concept="2OqwBi" id="4GRmlIZRIgf" role="37vLTJ">
+              <node concept="3xONca" id="4GRmlIZRHVR" role="2Oq$k0">
+                <ref role="3xOPvv" node="4GRmlIZPTjx" resolve="brokenEditor" />
+              </node>
+              <node concept="3TrcHB" id="4GRmlIZRJ8S" role="2OqNvi">
+                <ref role="3TsBF5" to="jv43:4GRmlIZQoXl" resolve="break" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ9hry" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ9hrz" role="3cpWs9">
+            <property role="TrG5h" value="helper" />
+            <node concept="3uibUv" id="5nwfWGQ9hqT" role="1tU5fm">
+              <ref role="3uigEE" to="m531:6HRhZeXG281" resolve="ProjectTestHelper" />
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ9hr$" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ9hr_" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXG2y3" resolve="ProjectTestHelper" />
+                <node concept="1jxXqW" id="5nwfWGQ9hrA" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5nwfWGQ9jbe" role="3cqZAp">
+          <node concept="2YIFZM" id="2d4iuOOGEAd" role="3clFbG">
+            <ref role="37wK5l" to="m531:5nwfWGQ3NG7" resolve="assertFails" />
+            <ref role="1Pybhc" to="m531:5nwfWGQ3LWe" resolve="Asserts" />
+            <node concept="1bVj0M" id="5nwfWGQ9juF" role="37wK5m">
+              <node concept="3clFbS" id="5nwfWGQ9juK" role="1bW5cS">
+                <node concept="3clFbF" id="5nwfWGQ7aeV" role="3cqZAp">
+                  <node concept="2OqwBi" id="5nwfWGQ7dsA" role="3clFbG">
+                    <node concept="37vLTw" id="5nwfWGQ9hrC" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nwfWGQ9hrz" resolve="helper" />
+                    </node>
+                    <node concept="liA8E" id="5nwfWGQ7dGy" role="2OqNvi">
+                      <ref role="37wK5l" to="m531:5nwfWGQ13On" resolve="assertEditorNotBroken" />
+                      <node concept="3xONca" id="5nwfWGQ7dHQ" role="37wK5m">
+                        <ref role="3xOPvv" node="4GRmlIZPTjx" resolve="brokenEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4GRmlIZQDtb" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="4GRmlIZPTcQ" role="1SKRRt">
+      <node concept="3OSR2o" id="4GRmlIZPTcP" role="1qenE9">
+        <node concept="3xLA65" id="4GRmlIZPTjx" role="lGtFl">
+          <property role="TrG5h" value="brokenEditor" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2lJO3n" id="2$zHkrOzJdR">
+    <property role="TrG5h" value="Migration" />
+    <property role="3GE5qa" value="migration" />
+    <node concept="1qefOq" id="2$zHkrO$h9_" role="2lJO3o">
+      <node concept="312cEu" id="2$zHkrO$h9B" role="1qenE9">
+        <property role="TrG5h" value="C" />
+        <node concept="3clFbW" id="2$zHkrO$hiR" role="jymVt">
+          <node concept="15s5l7" id="2$zHkrO$nQE" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_CLASS=&quot;class jetbrains.mps.project.validation.ConceptFeatureCardinalityError&quot;;FLAVOUR_MESSAGE=&quot;No child in the obligatory role 'returnType'&quot;;FLAVOUR_NODE_FEATURE=&quot;returnType&quot;;" />
+            <property role="huDt6" value="No child in the obligatory role 'returnType'" />
+          </node>
+          <node concept="3clFbS" id="2$zHkrO$hiU" role="3clF47" />
+          <node concept="3Tm1VV" id="2$zHkrO$hiV" role="1B3o_S" />
+          <node concept="3cqZAl" id="7nS6IN7PiyS" role="3clF45" />
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrO$h9C" role="1B3o_S" />
+      </node>
+    </node>
+    <node concept="3ea_Bc" id="2$zHkrOzJdS" role="3ea0P7">
+      <ref role="3ea_Bf" to="bk90:6EV6$79vCe8" resolve="AddReturnTypeToConstructorDeclaration" />
+    </node>
+    <node concept="1qefOq" id="2$zHkrO$cNk" role="2lJPY$">
+      <node concept="312cEu" id="2$zHkrO$hjm" role="1qenE9">
+        <property role="TrG5h" value="C" />
+        <node concept="3clFbW" id="2$zHkrO$hjn" role="jymVt">
+          <node concept="15s5l7" id="2$zHkrO$ulV" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_CLASS=&quot;class jetbrains.mps.project.validation.ConceptFeatureCardinalityError&quot;;FLAVOUR_MESSAGE=&quot;No child in the obligatory role 'returnType'&quot;;FLAVOUR_NODE_FEATURE=&quot;returnType&quot;;" />
+            <property role="huDt6" value="No child in the obligatory role 'returnType'" />
+          </node>
+          <node concept="3clFbS" id="2$zHkrO$hjp" role="3clF47" />
+          <node concept="3Tm1VV" id="2$zHkrO$hjq" role="1B3o_S" />
+          <node concept="3cqZAl" id="2$zHkrO$z_l" role="3clF45" />
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrO$hjr" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2$zHkrOxZsG">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="model" />
+    <property role="TrG5h" value="Constraint" />
+    <node concept="1qefOq" id="2$zHkrOxZt1" role="1SKRRt">
+      <node concept="312cEu" id="2$zHkrOxZsZ" role="1qenE9">
+        <property role="TrG5h" value="Invalid Name" />
+        <node concept="3Tm1VV" id="2$zHkrOxZt0" role="1B3o_S" />
+        <node concept="7CXmI" id="2$zHkrOy2T4" role="lGtFl">
+          <node concept="39XrGg" id="2$zHkrOy2Te" role="7EUXB">
+            <node concept="2u4KIi" id="2$zHkrOy2Tf" role="39rjcI">
+              <ref role="39XzEq" to="tpel:hDMFLSv" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOy5Tq" role="1SKRRt">
+      <node concept="1gjucp" id="2$zHkrOy6oi" role="1qenE9">
+        <property role="TrG5h" value="var" />
+        <node concept="10Oyi0" id="2$zHkrOy6oj" role="1tU5fm" />
+        <node concept="7CXmI" id="2$zHkrOy6ok" role="lGtFl">
+          <node concept="39XrGg" id="2$zHkrOy6ou" role="7EUXB">
+            <node concept="2u4KIi" id="2$zHkrOy6ov" role="39rjcI">
+              <ref role="39XzEq" to="tpel:147CB3QsTQi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2$zHkrOybDd">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="model" />
+    <property role="TrG5h" value="DataFlow" />
+    <node concept="1qefOq" id="2$zHkrOybEb" role="1SKRRt">
+      <node concept="3clFbJ" id="2$zHkrOybE8" role="1qenE9">
+        <node concept="3clFbT" id="2$zHkrOybEi" role="3clFbw">
+          <property role="3clFbU" value="true" />
+          <node concept="7CXmI" id="2$zHkrOybEp" role="lGtFl">
+            <node concept="3A7TAB" id="4k0nQshxL3N" role="7EUXB">
+              <node concept="3A7QsG" id="4k0nQshxL3V" role="3A7QLS">
+                <ref role="39XzEq" to="tpeh:3xaCLCsVRI_" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="2$zHkrOybEa" role="3clFbx" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOybEH" role="1SKRRt">
+      <node concept="3clFbJ" id="2$zHkrOybEJ" role="1qenE9">
+        <node concept="3clFbT" id="2$zHkrOybES" role="3clFbw">
+          <property role="3clFbU" value="true" />
+        </node>
+        <node concept="3clFbS" id="2$zHkrOybEL" role="3clFbx" />
+        <node concept="9aQIb" id="2$zHkrOybF0" role="9aQIa">
+          <node concept="3clFbS" id="2$zHkrOybF1" role="9aQI4">
+            <node concept="3clFbF" id="2$zHkrOyc77" role="3cqZAp">
+              <node concept="2OqwBi" id="2$zHkrOyc74" role="3clFbG">
+                <node concept="10M0yZ" id="2$zHkrOyc75" role="2Oq$k0">
+                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                </node>
+                <node concept="liA8E" id="2$zHkrOyc76" role="2OqNvi">
+                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                  <node concept="Xl_RD" id="2$zHkrOyc7B" role="37wK5m">
+                    <property role="Xl_RC" value="test" />
+                  </node>
+                </node>
+              </node>
+              <node concept="7CXmI" id="2$zHkrOycVp" role="lGtFl">
+                <node concept="29bkU" id="2$zHkrOydeB" role="7EUXB">
+                  <node concept="2PQEqo" id="2$zHkrOydeC" role="3lydCh">
+                    <ref role="39XzEq" to="tpeh:7JTVFHZ38gn" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2$zHkrOyoQc">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="model" />
+    <property role="TrG5h" value="Scope" />
+    <node concept="1qefOq" id="2$zHkrOyoQx" role="1SKRRt">
+      <node concept="312cEu" id="2$zHkrOyoQv" role="1qenE9">
+        <property role="TrG5h" value="Scope" />
+        <node concept="2YIFZL" id="2$zHkrOz44a" role="jymVt">
+          <property role="TrG5h" value="m" />
+          <node concept="3clFbS" id="2$zHkrOz44c" role="3clF47">
+            <node concept="3clFbF" id="2$zHkrOz44d" role="3cqZAp">
+              <node concept="2OqwBi" id="2$zHkrOz44e" role="3clFbG">
+                <node concept="2ShNRf" id="2$zHkrOz44f" role="2Oq$k0">
+                  <node concept="HV5vD" id="2$zHkrOz44g" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" node="2$zHkrOyoQv" resolve="Scope" />
+                  </node>
+                </node>
+                <node concept="2PDubS" id="2$zHkrOz52c" role="2OqNvi">
+                  <ref role="37wK5l" node="2$zHkrOz44a" resolve="m" />
+                  <node concept="2rqxmr" id="2$zHkrOz54s" role="lGtFl">
+                    <ref role="1BTHP0" node="2$zHkrOz44a" resolve="m" />
+                    <node concept="3KTrbX" id="2$zHkrOz54D" role="3KTr4d">
+                      <ref role="3AHY9a" node="2$zHkrOz44a" resolve="m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cqZAl" id="2$zHkrOz44j" role="3clF45" />
+          <node concept="3Tm1VV" id="2$zHkrOz44i" role="1B3o_S" />
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrOyoQw" role="1B3o_S" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2$zHkrOydfB">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="model" />
+    <property role="TrG5h" value="Typesystem" />
+    <node concept="1LZb2c" id="6J17ghv22Zx" role="1SL9yI">
+      <property role="TrG5h" value="assertType" />
+      <node concept="3cqZAl" id="6J17ghv22Zy" role="3clF45" />
+      <node concept="3clFbS" id="6J17ghv22ZA" role="3clF47">
+        <node concept="JA50E" id="6J17ghv2uNp" role="3cqZAp">
+          <node concept="2OqwBi" id="6J17ghv2v2T" role="JAdkl">
+            <node concept="3xONca" id="6J17ghv2v2U" role="2Oq$k0">
+              <ref role="3xOPvv" node="6J17ghv230s" resolve="a" />
+            </node>
+            <node concept="3JvlWi" id="6J17ghv2v2V" role="2OqNvi" />
+          </node>
+          <node concept="2c44tf" id="6J17ghv2v1R" role="JA92f">
+            <node concept="10Oyi0" id="6J17ghv2v1S" role="2c44tc" />
+          </node>
+        </node>
+        <node concept="JA50E" id="6J17ghv2v2s" role="3cqZAp">
+          <node concept="2OqwBi" id="6J17ghv2v3_" role="JAdkl">
+            <node concept="3xONca" id="6J17ghv2v3A" role="2Oq$k0">
+              <ref role="3xOPvv" node="6J17ghv2313" resolve="b" />
+            </node>
+            <node concept="3JvlWi" id="6J17ghv2v3B" role="2OqNvi" />
+          </node>
+          <node concept="2c44tf" id="6J17ghv2v2t" role="JA92f">
+            <node concept="10Oyi0" id="6J17ghv2v2u" role="2c44tc" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6J17ghv62pf" role="1SL9yI">
+      <property role="TrG5h" value="performance" />
+      <node concept="3cqZAl" id="6J17ghv62pg" role="3clF45" />
+      <node concept="3clFbS" id="6J17ghv62pk" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ3cBj" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ3cBm" role="3cpWs9">
+            <property role="TrG5h" value="methodsCount" />
+            <node concept="10Oyi0" id="5nwfWGQ3cBh" role="1tU5fm" />
+            <node concept="3cmrfG" id="5nwfWGQ3cDb" role="33vP2m">
+              <property role="3cmrfH" value="100" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5nwfWGQ3bQR" role="3cqZAp" />
+        <node concept="1Dw8fO" id="5nwfWGQ37JW" role="3cqZAp">
+          <node concept="3clFbS" id="5nwfWGQ37JX" role="2LFqv$">
+            <node concept="3clFbF" id="5nwfWGQ37JY" role="3cqZAp">
+              <node concept="2OqwBi" id="5nwfWGQ37JZ" role="3clFbG">
+                <node concept="2OqwBi" id="5nwfWGQ37K0" role="2Oq$k0">
+                  <node concept="3xONca" id="5nwfWGQ37K1" role="2Oq$k0">
+                    <ref role="3xOPvv" node="6J17ghv3cMV" resolve="cls" />
+                  </node>
+                  <node concept="3Tsc0h" id="5nwfWGQ37K2" role="2OqNvi">
+                    <ref role="3TtcxE" to="tpee:4EqhHTp4Mw3" resolve="member" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="5nwfWGQ37K3" role="2OqNvi">
+                  <node concept="2c44tf" id="5nwfWGQ37K4" role="25WWJ7">
+                    <node concept="3clFb_" id="5nwfWGQ37K5" role="2c44tc">
+                      <property role="TrG5h" value="test" />
+                      <node concept="3clFbS" id="5nwfWGQ37K6" role="3clF47" />
+                      <node concept="3cqZAl" id="5nwfWGQ37K7" role="3clF45" />
+                      <node concept="3Tm1VV" id="5nwfWGQ37K8" role="1B3o_S" />
+                      <node concept="2EMmih" id="5nwfWGQ37K9" role="lGtFl">
+                        <property role="3qcH_f" value="true" />
+                        <property role="2qtEX9" value="name" />
+                        <property role="P4ACc" value="ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001" />
+                        <node concept="3cpWs3" id="5nwfWGQ37Ka" role="2c44t1">
+                          <node concept="Xl_RD" id="5nwfWGQ37Kb" role="3uHU7B">
+                            <property role="Xl_RC" value="method" />
+                          </node>
+                          <node concept="2YIFZM" id="5nwfWGQ37Kc" role="3uHU7w">
+                            <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                            <node concept="37vLTw" id="5nwfWGQ37Kd" role="37wK5m">
+                              <ref role="3cqZAo" node="5nwfWGQ37Ke" resolve="i" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="5nwfWGQ37Ke" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="5nwfWGQ37Kf" role="1tU5fm" />
+            <node concept="3cmrfG" id="5nwfWGQ37Kg" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="5nwfWGQ37Kh" role="1Dwp0S">
+            <node concept="37vLTw" id="5nwfWGQ37Ki" role="3uHU7w">
+              <ref role="3cqZAo" node="5nwfWGQ3cBm" resolve="methodsCount" />
+            </node>
+            <node concept="37vLTw" id="5nwfWGQ37Kj" role="3uHU7B">
+              <ref role="3cqZAo" node="5nwfWGQ37Ke" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="5nwfWGQ37Kk" role="1Dwrff">
+            <node concept="37vLTw" id="5nwfWGQ37Kl" role="2$L3a6">
+              <ref role="3cqZAo" node="5nwfWGQ37Ke" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ37Km" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ37Kn" role="3cpWs9">
+            <property role="TrG5h" value="modelToCheck" />
+            <node concept="H_c77" id="5nwfWGQ37Ko" role="1tU5fm" />
+            <node concept="2OqwBi" id="5nwfWGQ37Kp" role="33vP2m">
+              <node concept="3xONca" id="5nwfWGQ37Kq" role="2Oq$k0">
+                <ref role="3xOPvv" node="6J17ghv3cMV" resolve="cls" />
+              </node>
+              <node concept="I4A8Y" id="5nwfWGQ37Kr" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6J17ghv62F7" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv62F8" role="3cpWs9">
+            <property role="TrG5h" value="duration" />
+            <node concept="3uibUv" id="6J17ghv62F9" role="1tU5fm">
+              <ref role="3uigEE" to="28m1:~Duration" resolve="Duration" />
+            </node>
+            <node concept="2YIFZM" id="2d4iuOOGEAn" role="33vP2m">
+              <ref role="37wK5l" to="m531:5nwfWGQ31Bx" resolve="measureTypesystemPerformance" />
+              <ref role="1Pybhc" to="m531:5nwfWGQ2Sfl" resolve="TypesystemTestUtil" />
+              <node concept="37vLTw" id="5nwfWGQ3dcz" role="37wK5m">
+                <ref role="3cqZAo" node="5nwfWGQ37Kn" resolve="modelToCheck" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="6J17ghv65My" role="3cqZAp">
+          <node concept="3eOVzh" id="6J17ghv6t4H" role="3vwVQn">
+            <node concept="3cmrfG" id="6J17ghv6t5X" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="6J17ghv66qI" role="3uHU7B">
+              <node concept="37vLTw" id="6J17ghv65N2" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv62F8" resolve="duration" />
+              </node>
+              <node concept="liA8E" id="6J17ghv677H" role="2OqNvi">
+                <ref role="37wK5l" to="28m1:~Duration.compareTo(java.time.Duration)" resolve="compareTo" />
+                <node concept="2YIFZM" id="6J17ghv679E" role="37wK5m">
+                  <ref role="37wK5l" to="28m1:~Duration.ofMillis(long)" resolve="ofMillis" />
+                  <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
+                  <node concept="3cmrfG" id="6J17ghv67aL" role="37wK5m">
+                    <property role="3cmrfH" value="10000" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="6J17ghv6eLc" role="3_9lra">
+            <node concept="Xl_RD" id="6J17ghv6hJ6" role="3_1BAH">
+              <property role="Xl_RC" value="check executed in more than 1000ms" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2$zHkrOyeIR" role="1SKRRt">
+      <node concept="312cEu" id="2$zHkrOyeIP" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="312cEg" id="2$zHkrOyfgJ" role="jymVt">
+          <property role="TrG5h" value="a" />
+          <node concept="10Oyi0" id="2$zHkrOyfgz" role="1tU5fm" />
+          <node concept="3clFbT" id="2$zHkrOyfB3" role="33vP2m">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="7CXmI" id="2$zHkrOyfOs" role="lGtFl">
+            <node concept="2DdRWr" id="2$zHkrOyfOJ" role="7EUXB" />
+          </node>
+          <node concept="3Tm1VV" id="2$zHkrOyk$R" role="1B3o_S" />
+          <node concept="3xLA65" id="6J17ghv230s" role="lGtFl">
+            <property role="TrG5h" value="a" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="2$zHkrOyeIQ" role="1B3o_S" />
+        <node concept="312cEg" id="2$zHkrOykjG" role="jymVt">
+          <property role="TrG5h" value="b" />
+          <node concept="10Oyi0" id="2$zHkrOykjw" role="1tU5fm" />
+          <node concept="3cmrfG" id="2$zHkrOykpg" role="33vP2m">
+            <property role="3cmrfH" value="10" />
+          </node>
+          <node concept="3Tm1VV" id="2$zHkrOyk_a" role="1B3o_S" />
+          <node concept="7CXmI" id="2$zHkrOyk_v" role="lGtFl">
+            <node concept="30Omv" id="2$zHkrOyk_M" role="7EUXB">
+              <node concept="10Oyi0" id="2$zHkrOykA6" role="31d$z" />
+            </node>
+          </node>
+          <node concept="3xLA65" id="6J17ghv2313" role="lGtFl">
+            <property role="TrG5h" value="b" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5nwfWGQ3nTo" role="1SKRRt">
+      <node concept="312cEu" id="6J17ghv3bYo" role="1qenE9">
+        <property role="TrG5h" value="Test" />
+        <node concept="3Tm1VV" id="6J17ghv3bYp" role="1B3o_S" />
+        <node concept="3xLA65" id="6J17ghv3cMV" role="lGtFl">
+          <property role="TrG5h" value="cls" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6cyqnzennVN">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ExtensionPoint" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <node concept="1LZb2c" id="6cyqnzennXf" role="1SL9yI">
+      <property role="TrG5h" value="enableExtensionPoint" />
+      <node concept="3cqZAl" id="6cyqnzennXg" role="3clF45" />
+      <node concept="3clFbS" id="6cyqnzennXh" role="3clF47">
+        <node concept="3cpWs8" id="6cyqnzenrbc" role="3cqZAp">
+          <node concept="3cpWsn" id="6cyqnzenrbd" role="3cpWs9">
+            <property role="TrG5h" value="intf" />
+            <node concept="3uibUv" id="6cyqnzenraw" role="1tU5fm">
+              <ref role="3uigEE" to="eo0e:6cyqnzemVwE" resolve="ExtensionInterface" />
+            </node>
+            <node concept="2OqwBi" id="6cyqnzenrbe" role="33vP2m">
+              <node concept="2OqwBi" id="6cyqnzenrbf" role="2Oq$k0">
+                <node concept="2O5UvJ" id="6cyqnzenrbg" role="2Oq$k0">
+                  <ref role="2O5UnU" to="eo0e:6cyqnzemVvp" resolve="TestExtensionPoint" />
+                </node>
+                <node concept="SfwO_" id="6cyqnzenrbh" role="2OqNvi" />
+              </node>
+              <node concept="1uHKPH" id="6cyqnzenrbi" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6cyqnzenrf9" role="3cqZAp" />
+        <node concept="3vFxKo" id="6cyqnzenrrd" role="3cqZAp">
+          <node concept="2OqwBi" id="6cyqnzenrN0" role="3vFALc">
+            <node concept="37vLTw" id="6cyqnzenrrI" role="2Oq$k0">
+              <ref role="3cqZAo" node="6cyqnzenrbd" resolve="intf" />
+            </node>
+            <node concept="liA8E" id="6cyqnzenso0" role="2OqNvi">
+              <ref role="37wK5l" to="eo0e:6cyqnzemXM_" resolve="enabled" />
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="6cyqnzens$0" role="3cqZAp">
+          <node concept="3clFbS" id="6cyqnzens$2" role="1zxBo7">
+            <node concept="3clFbF" id="6cyqnzensL$" role="3cqZAp">
+              <node concept="2YIFZM" id="3OVhQEUIfmI" role="3clFbG">
+                <ref role="37wK5l" to="eo0e:6cyqnzen5wB" resolve="enable" />
+                <ref role="1Pybhc" to="eo0e:6cyqnzemZ68" resolve="TestExtensionImpl" />
+              </node>
+            </node>
+            <node concept="1gVbGN" id="6cyqnzentXR" role="3cqZAp">
+              <node concept="2OqwBi" id="6cyqnzenupy" role="1gVkn0">
+                <node concept="37vLTw" id="6cyqnzentYW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6cyqnzenrbd" resolve="intf" />
+                </node>
+                <node concept="liA8E" id="6cyqnzenuUW" role="2OqNvi">
+                  <ref role="37wK5l" to="eo0e:6cyqnzemXM_" resolve="enabled" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="6cyqnzens_6" role="1zxBo6">
+            <node concept="3clFbS" id="6cyqnzens_7" role="1wplMD">
+              <node concept="3clFbF" id="6cyqnzensNx" role="3cqZAp">
+                <node concept="2YIFZM" id="3OVhQEUIfmJ" role="3clFbG">
+                  <ref role="37wK5l" to="eo0e:6cyqnzengBR" resolve="disable" />
+                  <ref role="1Pybhc" to="eo0e:6cyqnzemZ68" resolve="TestExtensionImpl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6J17ghv6Gpd">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <property role="TrG5h" value="JavaCommand" />
+    <node concept="1LZb2c" id="6J17ghv6Gqn" role="1SL9yI">
+      <property role="TrG5h" value="startJavaByNode" />
+      <node concept="3cqZAl" id="6J17ghv6Gqo" role="3clF45" />
+      <node concept="3clFbS" id="6J17ghv6Gqs" role="3clF47">
+        <node concept="3cpWs8" id="6J17ghv7dl4" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv7dl7" role="3cpWs9">
+            <property role="TrG5h" value="process" />
+            <node concept="50ouk" id="6J17ghv7dl2" role="1tU5fm">
+              <ref role="50ouj" to="go48:14R2qyOBxa1" resolve="java" />
+            </node>
+            <node concept="2LYoGx" id="6J17ghv7eyr" role="33vP2m">
+              <ref role="3rFKlk" to="go48:14R2qyOBxeG" resolve="java" />
+              <node concept="2LYoGL" id="6J17ghv7f4$" role="2LYoGw">
+                <ref role="2LYoGK" to="go48:14R2qyOBxeH" resolve="nodePointer" />
+                <node concept="2JrnkZ" id="6J17ghv7iwY" role="2LYoGN">
+                  <node concept="2tJFMh" id="6J17ghv78UZ" role="2JrQYb">
+                    <node concept="ZC_QK" id="6J17ghv799u" role="2tJFKM">
+                      <ref role="2aWVGs" node="6J17ghv6Dxe" resolve="TestJavaClass" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2LYoGL" id="6J17ghv7iHp" role="2LYoGw">
+                <ref role="2LYoGK" to="go48:1CVOLqONYr_" resolve="repository" />
+                <node concept="2OqwBi" id="6J17ghv7jUD" role="2LYoGN">
+                  <node concept="1jxXqW" id="6J17ghv7iZQ" role="2Oq$k0" />
+                  <node concept="liA8E" id="6J17ghv7l7s" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6J17ghvaZmB" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghvaZmC" role="3cpWs9">
+            <property role="TrG5h" value="processRunner" />
+            <node concept="3uibUv" id="6J17ghvaZmD" role="1tU5fm">
+              <ref role="3uigEE" to="m531:6J17ghv7mbt" resolve="ProcessRunnerForConfigurationTests" />
+            </node>
+            <node concept="2OqwBi" id="6J17ghvbq3r" role="33vP2m">
+              <node concept="2OqwBi" id="6J17ghvblSh" role="2Oq$k0">
+                <node concept="2OqwBi" id="6J17ghvb0Ij" role="2Oq$k0">
+                  <node concept="2ShNRf" id="6J17ghvaZp8" role="2Oq$k0">
+                    <node concept="1pGfFk" id="5nwfWGQ2wRb" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="m531:6J17ghv7mc5" resolve="ProcessRunnerForConfigurationTests.Builder" />
+                      <node concept="37vLTw" id="5nwfWGQ2xZb" role="37wK5m">
+                        <ref role="3cqZAo" node="6J17ghv7dl7" resolve="process" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6J17ghvb0Vl" role="2OqNvi">
+                    <ref role="37wK5l" to="m531:6J17ghv7mcs" resolve="addExpectedPaterns" />
+                    <node concept="2YIFZM" id="6J17ghvb0Zs" role="37wK5m">
+                      <ref role="37wK5l" to="33ny:~Collections.singletonList(java.lang.Object)" resolve="singletonList" />
+                      <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                      <node concept="2YIFZM" id="6J17ghvb14p" role="37wK5m">
+                        <ref role="37wK5l" to="ni5j:~Pattern.compile(java.lang.String)" resolve="compile" />
+                        <ref role="1Pybhc" to="ni5j:~Pattern" resolve="Pattern" />
+                        <node concept="3cpWs3" id="6J17ghvbll8" role="37wK5m">
+                          <node concept="Xl_RD" id="6J17ghvbllb" role="3uHU7w">
+                            <property role="Xl_RC" value="\n*" />
+                          </node>
+                          <node concept="10M0yZ" id="6J17ghvbk2q" role="3uHU7B">
+                            <ref role="3cqZAo" node="6J17ghvbiTQ" resolve="MESSAGE" />
+                            <ref role="1PxDUh" node="6J17ghv6Dxe" resolve="TestJavaClass" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6J17ghvbndi" role="2OqNvi">
+                  <ref role="37wK5l" to="m531:6J17ghv7mcD" resolve="addAllowedErrorPaterns" />
+                  <node concept="2YIFZM" id="6J17ghvbobp" role="37wK5m">
+                    <ref role="37wK5l" to="33ny:~Collections.singletonList(java.lang.Object)" resolve="singletonList" />
+                    <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                    <node concept="2YIFZM" id="6J17ghvbp90" role="37wK5m">
+                      <ref role="37wK5l" to="ni5j:~Pattern.compile(java.lang.String)" resolve="compile" />
+                      <ref role="1Pybhc" to="ni5j:~Pattern" resolve="Pattern" />
+                      <node concept="Xl_RD" id="6J17ghvbpdy" role="37wK5m">
+                        <property role="Xl_RC" value="Picked up JAVA_TOOL_OPTIONS.*\n" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="6J17ghvbrKz" role="2OqNvi">
+                <ref role="37wK5l" to="m531:6J17ghv7mdf" resolve="build" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghvbty_" role="3cqZAp">
+          <node concept="2OqwBi" id="6J17ghvbuCx" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghvbtyz" role="2Oq$k0">
+              <ref role="3cqZAo" node="6J17ghvaZmC" resolve="processRunner" />
+            </node>
+            <node concept="liA8E" id="6J17ghvbuTd" role="2OqNvi">
+              <ref role="37wK5l" to="m531:6J17ghv7mj0" resolve="startAndCheckProcess" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4k0nQshg1uq">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="MessagesView" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <node concept="1LZb2c" id="4k0nQshg1ur" role="1SL9yI">
+      <property role="TrG5h" value="errorMessage" />
+      <node concept="3cqZAl" id="4k0nQshg1us" role="3clF45" />
+      <node concept="3clFbS" id="4k0nQshg1ut" role="3clF47">
+        <node concept="3cpWs8" id="4k0nQshg95C" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshg95D" role="3cpWs9">
+            <property role="TrG5h" value="tool" />
+            <node concept="3uibUv" id="4k0nQshg95k" role="1tU5fm">
+              <ref role="3uigEE" to="57ty:~MessagesViewTool" resolve="MessagesViewTool" />
+            </node>
+            <node concept="2YIFZM" id="4k0nQshg95E" role="33vP2m">
+              <ref role="37wK5l" to="57ty:~MessagesViewTool.getInstance(jetbrains.mps.project.Project)" resolve="getInstance" />
+              <ref role="1Pybhc" to="57ty:~MessagesViewTool" resolve="MessagesViewTool" />
+              <node concept="1jxXqW" id="4k0nQshg95F" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQshgaJT" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshgaJU" role="3cpWs9">
+            <property role="TrG5h" value="messageList" />
+            <node concept="3uibUv" id="4k0nQshgawp" role="1tU5fm">
+              <ref role="3uigEE" to="57ty:~MessageList" resolve="MessageList" />
+            </node>
+            <node concept="10QFUN" id="4k0nQshggol" role="33vP2m">
+              <node concept="3uibUv" id="4k0nQshggEF" role="10QFUM">
+                <ref role="3uigEE" to="57ty:~MessageList" resolve="MessageList" />
+              </node>
+              <node concept="2EnYce" id="5nwfWGQbcsI" role="10QFUP">
+                <node concept="37vLTw" id="4k0nQshgaJW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4k0nQshg95D" resolve="tool" />
+                </node>
+                <node concept="liA8E" id="4k0nQshgaJX" role="2OqNvi">
+                  <ref role="37wK5l" to="57ty:~MessagesViewTool.getMessageList(java.lang.String,jetbrains.mps.ide.messages.MessageListOptions...)" resolve="getMessageList" />
+                  <node concept="Xl_RD" id="4k0nQshgaJY" role="37wK5m">
+                    <property role="Xl_RC" value="DEFAULT_LIST" />
+                  </node>
+                  <node concept="Rm8GO" id="4k0nQshgaJZ" role="37wK5m">
+                    <ref role="Rm8GQ" to="57ty:~MessageListOptions.ReuseExisting" resolve="ReuseExisting" />
+                    <ref role="1Px2BO" to="57ty:~MessageListOptions" resolve="MessageListOptions" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4k0nQshgXsS" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshgXsV" role="3cpWs9">
+            <property role="TrG5h" value="testMessage" />
+            <node concept="17QB3L" id="4k0nQshgXsQ" role="1tU5fm" />
+            <node concept="Xl_RD" id="4k0nQshgXSK" role="33vP2m">
+              <property role="Xl_RC" value="Testmessage" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="7f7wYMF2jhp" role="3cqZAp">
+          <node concept="1PaTwC" id="7f7wYMF2jhq" role="1aUNEU">
+            <node concept="3oM_SD" id="7f7wYMF2jpE" role="1PaTwD">
+              <property role="3oM_SC" value="execute" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF2jBQ" role="1PaTwD">
+              <property role="3oM_SC" value="adding" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF2jBR" role="1PaTwD">
+              <property role="3oM_SC" value="messages" />
+            </node>
+            <node concept="3oM_SD" id="7f7wYMF2jEh" role="1PaTwD">
+              <property role="3oM_SC" value="immediately" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7f7wYMEZONb" role="3cqZAp">
+          <node concept="2EnYce" id="7f7wYMF2l52" role="3clFbG">
+            <node concept="2EnYce" id="7f7wYMF2kKU" role="2Oq$k0">
+              <node concept="37vLTw" id="7f7wYMEZONe" role="2Oq$k0">
+                <ref role="3cqZAo" node="4k0nQshgaJU" resolve="messageList" />
+              </node>
+              <node concept="1PnCL0" id="7f7wYMEZONf" role="2OqNvi">
+                <ref role="2Oxat5" to="57ty:~MessageList.myUpdateQueue" resolve="myUpdateQueue" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7f7wYMEZRpA" role="2OqNvi">
+              <ref role="37wK5l" to="t335:~MergingUpdateQueue.setPassThrough(boolean)" resolve="setPassThrough" />
+              <node concept="3clFbT" id="7f7wYMEZRuG" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2xdQw9" id="4k0nQshg5LV" role="3cqZAp">
+          <property role="2xdLsb" value="gZ5fh_4/error" />
+          <node concept="37vLTw" id="4k0nQshgY7w" role="9lYJi">
+            <ref role="3cqZAo" node="4k0nQshgXsV" resolve="testMessage" />
+          </node>
+          <node concept="1jxXqW" id="4k0nQshhIWR" role="9lYEk" />
+        </node>
+        <node concept="3cpWs8" id="4k0nQshiAE8" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshiAE9" role="3cpWs9">
+            <property role="TrG5h" value="model" />
+            <node concept="3uibUv" id="4k0nQshi$oK" role="1tU5fm">
+              <ref role="3uigEE" to="57ty:~MessageList$FastListModel" resolve="MessageList.FastListModel" />
+              <node concept="3uibUv" id="4k0nQshi$oN" role="11_B2D">
+                <ref role="3uigEE" to="et5u:~IMessage" resolve="IMessage" />
+              </node>
+            </node>
+            <node concept="2EnYce" id="5nwfWGQbewV" role="33vP2m">
+              <node concept="37vLTw" id="4k0nQshiAEb" role="2Oq$k0">
+                <ref role="3cqZAo" node="4k0nQshgaJU" resolve="messageList" />
+              </node>
+              <node concept="1PnCL0" id="4k0nQshiAEc" role="2OqNvi">
+                <ref role="2Oxat5" to="57ty:~MessageList.myModel" resolve="myModel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="4k0nQshiBQz" role="3cqZAp">
+          <node concept="3clFbS" id="4k0nQshiBQ_" role="2LFqv$">
+            <node concept="3clFbJ" id="4k0nQshiQ6K" role="3cqZAp">
+              <node concept="3clFbS" id="4k0nQshiQ6M" role="3clFbx">
+                <node concept="3cpWs6" id="4k0nQshj0hI" role="3cqZAp" />
+              </node>
+              <node concept="17R0WA" id="4k0nQshiUHq" role="3clFbw">
+                <node concept="2EnYce" id="5nwfWGQbkMO" role="3uHU7B">
+                  <node concept="2EnYce" id="5nwfWGQbfM7" role="2Oq$k0">
+                    <node concept="37vLTw" id="4k0nQshiQa2" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4k0nQshiAE9" resolve="model" />
+                    </node>
+                    <node concept="liA8E" id="4k0nQshiS6M" role="2OqNvi">
+                      <ref role="37wK5l" to="57ty:~MessageList$FastListModel.getElementAt(int)" resolve="getElementAt" />
+                      <node concept="37vLTw" id="4k0nQshiScK" role="37wK5m">
+                        <ref role="3cqZAo" node="4k0nQshiBQA" resolve="i" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4k0nQshiU$P" role="2OqNvi">
+                    <ref role="37wK5l" to="et5u:~IMessage.getText()" resolve="getText" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4k0nQshiV2g" role="3uHU7w">
+                  <ref role="3cqZAo" node="4k0nQshgXsV" resolve="testMessage" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="4k0nQshiBQA" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="4k0nQshiCqP" role="1tU5fm" />
+            <node concept="3cmrfG" id="4k0nQshiCxD" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="4k0nQshiFBR" role="1Dwp0S">
+            <node concept="2EnYce" id="5nwfWGQbfGn" role="3uHU7w">
+              <node concept="37vLTw" id="4k0nQshiFEj" role="2Oq$k0">
+                <ref role="3cqZAo" node="4k0nQshiAE9" resolve="model" />
+              </node>
+              <node concept="liA8E" id="4k0nQshiI9E" role="2OqNvi">
+                <ref role="37wK5l" to="57ty:~MessageList$FastListModel.getSize()" resolve="getSize" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4k0nQshiC$2" role="3uHU7B">
+              <ref role="3cqZAo" node="4k0nQshiBQA" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="4k0nQshiMTU" role="1Dwrff">
+            <node concept="37vLTw" id="4k0nQshiMTW" role="2$L3a6">
+              <ref role="3cqZAo" node="4k0nQshiBQA" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3xETmq" id="4k0nQshj1HN" role="3cqZAp">
+          <node concept="3_1$Yv" id="4k0nQshj1We" role="3_9lra">
+            <node concept="3cpWs3" id="4k0nQshj3C9" role="3_1BAH">
+              <node concept="37vLTw" id="4k0nQshj3GD" role="3uHU7w">
+                <ref role="3cqZAo" node="4k0nQshgXsV" resolve="testMessage" />
+              </node>
+              <node concept="Xl_RD" id="4k0nQshj2g6" role="3uHU7B">
+                <property role="Xl_RC" value="Message not found:" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="2$zHkrOwwr_">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="OpenEditor" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <node concept="1LZb2c" id="2$zHkrOwwsK" role="1SL9yI">
+      <property role="TrG5h" value="openEditor" />
+      <node concept="3cqZAl" id="2$zHkrOwwsL" role="3clF45" />
+      <node concept="3clFbS" id="2$zHkrOwwsP" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ2ALE" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ2ALF" role="3cpWs9">
+            <property role="TrG5h" value="helper" />
+            <node concept="3uibUv" id="5nwfWGQ2ALG" role="1tU5fm">
+              <ref role="3uigEE" to="m531:6HRhZeXG281" resolve="ProjectTestHelper" />
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ2AV5" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ2CuW" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="m531:6HRhZeXG2y3" resolve="ProjectTestHelper" />
+                <node concept="1jxXqW" id="5nwfWGQ2CAI" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2$zHkrOxvZc" role="3cqZAp">
+          <node concept="3cpWsn" id="2$zHkrOxvZd" role="3cpWs9">
+            <property role="TrG5h" value="currentTestCase" />
+            <node concept="2sp9CU" id="2$zHkrOxvTl" role="1tU5fm">
+              <ref role="2sp9C9" to="tp5g:hHlH9T6" resolve="NodesTestCase" />
+            </node>
+            <node concept="2tJFMh" id="2$zHkrOxvZe" role="33vP2m">
+              <node concept="ZC_QK" id="2$zHkrOxvZf" role="2tJFKM">
+                <ref role="2aWVGs" node="2$zHkrOwwr_" resolve="OpenEditor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3VsXe2prvC4" role="3cqZAp">
+          <node concept="2OqwBi" id="3VsXe2prwu3" role="3clFbG">
+            <node concept="2YIFZM" id="3VsXe2prvKE" role="2Oq$k0">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+            <node concept="liA8E" id="3VsXe2prxAK" role="2OqNvi">
+              <ref role="37wK5l" to="bd8o:~Application.invokeAndWait(java.lang.Runnable)" resolve="invokeAndWait" />
+              <node concept="1bVj0M" id="3VsXe2prxGC" role="37wK5m">
+                <node concept="3clFbS" id="3VsXe2prxGF" role="1bW5cS">
+                  <node concept="3clFbF" id="4eRsqTHcVSs" role="3cqZAp">
+                    <node concept="2OqwBi" id="5nwfWGQ3DfK" role="3clFbG">
+                      <node concept="37vLTw" id="5nwfWGQ3CYu" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5nwfWGQ2ALF" resolve="helper" />
+                      </node>
+                      <node concept="liA8E" id="5nwfWGQ3DJx" role="2OqNvi">
+                        <ref role="37wK5l" to="m531:5nwfWGQ3xXM" resolve="closeOpenEditors" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="4RDqXGCHcHo" role="3cqZAp">
+                    <node concept="2OqwBi" id="4RDqXGCIchY" role="3clFbG">
+                      <node concept="2ShNRf" id="4RDqXGCHcHk" role="2Oq$k0">
+                        <node concept="1pGfFk" id="4RDqXGCIbUa" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="kz9k:~EditorNavigator.&lt;init&gt;(jetbrains.mps.project.Project)" resolve="EditorNavigator" />
+                          <node concept="1jxXqW" id="4RDqXGCIc2N" role="37wK5m" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4RDqXGCIc_I" role="2OqNvi">
+                        <ref role="37wK5l" to="kz9k:~EditorNavigator.open(org.jetbrains.mps.openapi.model.SNodeReference)" resolve="open" />
+                        <node concept="37vLTw" id="4RDqXGCIdHO" role="37wK5m">
+                          <ref role="3cqZAo" node="2$zHkrOxvZd" resolve="currentTestCase" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="4RDqXGCIdgh" role="3cqZAp">
+                    <node concept="2YIFZM" id="4RDqXGCIdnn" role="3clFbG">
+                      <ref role="37wK5l" to="anz6:~PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()" resolve="dispatchAllInvocationEventsInIdeEventQueue" />
+                      <ref role="1Pybhc" to="anz6:~PlatformTestUtil" resolve="PlatformTestUtil" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2$zHkrOwFko" role="3cqZAp" />
+        <node concept="3cpWs8" id="2$zHkrOxmWe" role="3cqZAp">
+          <node concept="3cpWsn" id="2$zHkrOxmWf" role="3cpWs9">
+            <property role="TrG5h" value="openEditors" />
+            <node concept="_YKpA" id="2$zHkrOxmQo" role="1tU5fm">
+              <node concept="3uibUv" id="2$zHkrOxmQr" role="_ZDj9">
+                <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5nwfWGQ2O30" role="33vP2m">
+              <node concept="37vLTw" id="5nwfWGQ2NOQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="5nwfWGQ2ALF" resolve="helper" />
+              </node>
+              <node concept="liA8E" id="5nwfWGQ2OuR" role="2OqNvi">
+                <ref role="37wK5l" to="m531:5nwfWGQ2_bv" resolve="getOpenEditors" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2$zHkrOxmKY" role="3cqZAp" />
+        <node concept="3vlDli" id="2$zHkrOxmAS" role="3cqZAp">
+          <node concept="3cmrfG" id="2$zHkrOxnfe" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrOxoxC" role="3tpDZA">
+            <node concept="37vLTw" id="2$zHkrOxnl1" role="2Oq$k0">
+              <ref role="3cqZAo" node="2$zHkrOxmWf" resolve="openEditors" />
+            </node>
+            <node concept="34oBXx" id="2$zHkrOxq8g" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3vlDli" id="2$zHkrOxxuV" role="3cqZAp">
+          <node concept="37vLTw" id="2$zHkrOxxF$" role="3tpDZB">
+            <ref role="3cqZAo" node="2$zHkrOxvZd" resolve="currentTestCase" />
+          </node>
+          <node concept="2OqwBi" id="2$zHkrOxvtO" role="3tpDZA">
+            <node concept="2OqwBi" id="2$zHkrOxu8r" role="2Oq$k0">
+              <node concept="2OqwBi" id="2$zHkrOxrHl" role="2Oq$k0">
+                <node concept="37vLTw" id="2$zHkrOxqoB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2$zHkrOxmWf" resolve="openEditors" />
+                </node>
+                <node concept="1uHKPH" id="2$zHkrOxtc_" role="2OqNvi" />
+              </node>
+              <node concept="liA8E" id="2$zHkrOxvgU" role="2OqNvi">
+                <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2$zHkrOxvO7" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~Editor.getCurrentlyEditedNode()" resolve="getCurrentlyEditedNode" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6J17ghv2B7y">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <property role="TrG5h" value="StubLoading" />
+    <node concept="1qefOq" id="6J17ghv2Bn0" role="1SKRRt">
+      <node concept="1XD0fY" id="6J17ghv2BmZ" role="1qenE9">
+        <property role="TrG5h" value="kotlinUiUsage" />
+        <node concept="1XD09Q" id="6J17ghv2Bn1" role="1XD0Tu">
+          <property role="1Xb$ne" value="true" />
+          <node concept="1XD0eA" id="6J17ghv2Bn2" role="TDYyH">
+            <property role="TrG5h" value="builder" />
+          </node>
+          <node concept="1XD0mK" id="6J17ghv2Bn4" role="1XD05H">
+            <node concept="1NbEFs" id="6J17ghv31$f" role="1XD0cX">
+              <ref role="AarEw" to="x6hl:~.panel(kotlin/Function1&lt;Panel,kotlin/Unit&gt;)" resolve="panel" />
+              <node concept="1XD0f0" id="6J17ghv31$i" role="1XD06E">
+                <node concept="gXE$l" id="6J17ghv31$s" role="THmaL">
+                  <node concept="1PaTwC" id="6J17ghv31$u" role="gXG0x">
+                    <node concept="3oM_SD" id="6J17ghv31$w" role="1PaTwD">
+                      <property role="3oM_SC" value="panel" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$x" role="1PaTwD">
+                      <property role="3oM_SC" value="is" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$y" role="1PaTwD">
+                      <property role="3oM_SC" value="a" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$z" role="1PaTwD">
+                      <property role="3oM_SC" value="class" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$$" role="1PaTwD">
+                      <property role="3oM_SC" value="loaded" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$_" role="1PaTwD">
+                      <property role="3oM_SC" value="from" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$A" role="1PaTwD">
+                      <property role="3oM_SC" value="Kotlin" />
+                    </node>
+                    <node concept="3oM_SD" id="6J17ghv31$B" role="1PaTwD">
+                      <property role="3oM_SC" value="stubs" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="7CXmI" id="6J17ghv31$D" role="lGtFl">
+          <node concept="7OXhh" id="6J17ghv31$E" role="7EUXB">
+            <property role="GvXf4" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6J17ghv6Dxe">
+    <property role="3GE5qa" value="mpsPlatform" />
+    <property role="TrG5h" value="TestJavaClass" />
+    <node concept="Wx3nA" id="6J17ghvbiTQ" role="jymVt">
+      <property role="TrG5h" value="MESSAGE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="6J17ghvbbvP" role="1B3o_S" />
+      <node concept="17QB3L" id="6J17ghvbiSp" role="1tU5fm" />
+      <node concept="Xl_RD" id="6J17ghvbjj$" role="33vP2m">
+        <property role="Xl_RC" value="PASS" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6J17ghvbaim" role="jymVt" />
+    <node concept="2YIFZL" id="6J17ghv6EjL" role="jymVt">
+      <property role="TrG5h" value="main" />
+      <node concept="37vLTG" id="6J17ghv6EjM" role="3clF46">
+        <property role="TrG5h" value="args" />
+        <node concept="10Q1$e" id="6J17ghv6EjN" role="1tU5fm">
+          <node concept="17QB3L" id="6J17ghv6EjO" role="10Q1$1" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6J17ghv6EjP" role="3clF45" />
+      <node concept="3Tm1VV" id="6J17ghv6EjQ" role="1B3o_S" />
+      <node concept="3clFbS" id="6J17ghv6EjR" role="3clF47">
+        <node concept="3clFbF" id="6J17ghv6FpJ" role="3cqZAp">
+          <node concept="2OqwBi" id="6J17ghv6FpG" role="3clFbG">
+            <node concept="10M0yZ" id="6J17ghv6FpH" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="6J17ghv6FpI" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="6J17ghvbjvI" role="37wK5m">
+                <ref role="3cqZAo" node="6J17ghvbiTQ" resolve="MESSAGE" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6J17ghv6Dxf" role="1B3o_S" />
+  </node>
+  <node concept="1lH9Xt" id="5yhCTaasX_M">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="VCSCustomization" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <node concept="1LZb2c" id="5yhCTaasXA6" role="1SL9yI">
+      <property role="TrG5h" value="vcsCustomization" />
+      <node concept="3cqZAl" id="5yhCTaasXA7" role="3clF45" />
+      <node concept="3clFbS" id="5yhCTaasXAb" role="3clF47">
+        <node concept="3vlDli" id="5yhCTaasXME" role="3cqZAp">
+          <node concept="Rm8GO" id="5yhCTaat4r2" role="3tpDZB">
+            <ref role="Rm8GQ" to="ur19:16TciwZIYFC" resolve="THEIRS" />
+            <ref role="1Px2BO" to="ur19:16TciwZIYCr" resolve="MergeStrategy" />
+          </node>
+          <node concept="2YIFZM" id="5yhCTaasZbn" role="3tpDZA">
+            <ref role="37wK5l" to="86l:4WGKd_KChIk" resolve="getDefaultMergeStrategy" />
+            <ref role="1Pybhc" to="86l:4WGKd_K_XbQ" resolve="VCSAspectUtil" />
+            <node concept="35c_gC" id="5yhCTaat1qi" role="37wK5m">
+              <ref role="35c_gD" to="jv43:5yhCTaasJqs" resolve="VCSCustomization" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6H1$aDlmM9B">
+    <property role="3GE5qa" value="ideaPlatform" />
+    <property role="TrG5h" value="Disposable" />
+    <node concept="Wx3nA" id="6H1$aDlmOZV" role="jymVt">
+      <property role="TrG5h" value="disposable" />
+      <node concept="3Tm1VV" id="6H1$aDlmNnG" role="1B3o_S" />
+      <node concept="3uibUv" id="6H1$aDlmOZL" role="1tU5fm">
+        <ref role="3uigEE" to="v23q:~Disposable" resolve="Disposable" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6H1$aDlmM9C" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.inputModel@tests.mps
+++ b/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.inputModel@tests.mps
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:7a418de5-925b-4367-b95e-862bf70ebd19(nl.f1re.testing.inputModel@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="2$zHkrOz9br">
+    <property role="TrG5h" value="A" />
+    <node concept="2YIFZL" id="2$zHkrOz9ct" role="jymVt">
+      <property role="TrG5h" value="main" />
+      <node concept="37vLTG" id="2$zHkrOz9cu" role="3clF46">
+        <property role="TrG5h" value="args" />
+        <node concept="10Q1$e" id="2$zHkrOz9cv" role="1tU5fm">
+          <node concept="17QB3L" id="2$zHkrOz9cw" role="10Q1$1" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2$zHkrOz9cx" role="3clF45" />
+      <node concept="3Tm1VV" id="2$zHkrOz9cy" role="1B3o_S" />
+      <node concept="3clFbS" id="2$zHkrOz9cz" role="3clF47">
+        <node concept="3clFbF" id="2$zHkrOz9eR" role="3cqZAp">
+          <node concept="2EnYce" id="2$zHkrOz9Ej" role="3clFbG">
+            <node concept="2ShNRf" id="2$zHkrOz9eP" role="2Oq$k0">
+              <node concept="HV5vD" id="2$zHkrOz9iy" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="2$zHkrOz9br" resolve="A" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2$zHkrOz9K1" role="2OqNvi">
+              <ref role="37wK5l" node="2$zHkrOz9p6" resolve="hello" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2$zHkrOz9jw" role="jymVt" />
+    <node concept="3clFb_" id="2$zHkrOz9p6" role="jymVt">
+      <property role="TrG5h" value="hello" />
+      <node concept="3clFbS" id="2$zHkrOz9p9" role="3clF47" />
+      <node concept="3Tm1VV" id="2$zHkrOz9mg" role="1B3o_S" />
+      <node concept="3cqZAl" id="2$zHkrOz9o5" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2$zHkrOz9bs" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.outputModel@tests.mps
+++ b/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.outputModel@tests.mps
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:91c69ca8-29b0-4099-b66a-9bee418254ed(nl.f1re.testing.outputModel@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+  </languages>
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="2$zHkrOz9br">
+    <property role="TrG5h" value="A" />
+    <node concept="2YIFZL" id="2$zHkrOz9ct" role="jymVt">
+      <property role="TrG5h" value="main" />
+      <node concept="37vLTG" id="2$zHkrOz9cu" role="3clF46">
+        <property role="TrG5h" value="args" />
+        <node concept="10Q1$e" id="2$zHkrOz9cv" role="1tU5fm">
+          <node concept="3uibUv" id="2$zHkrOzH3k" role="10Q1$1">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2$zHkrOz9cx" role="3clF45" />
+      <node concept="3Tm1VV" id="2$zHkrOz9cy" role="1B3o_S" />
+      <node concept="3clFbS" id="2$zHkrOz9cz" role="3clF47">
+        <node concept="3clFbF" id="2$zHkrOz9eR" role="3cqZAp">
+          <node concept="1rXfSq" id="2$zHkrOzH3l" role="3clFbG">
+            <ref role="37wK5l" node="2$zHkrOzH3m" resolve="check_w_a0a0" />
+            <node concept="2ShNRf" id="2$zHkrOz9eP" role="37wK5m">
+              <node concept="HV5vD" id="2$zHkrOz9iy" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="2$zHkrOz9br" resolve="A" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2$zHkrOz9jw" role="jymVt" />
+    <node concept="3clFb_" id="2$zHkrOz9p6" role="jymVt">
+      <property role="TrG5h" value="hello" />
+      <node concept="3clFbS" id="2$zHkrOz9p9" role="3clF47" />
+      <node concept="3Tm1VV" id="2$zHkrOz9mg" role="1B3o_S" />
+      <node concept="3cqZAl" id="2$zHkrOz9o5" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2$zHkrOz9bs" role="1B3o_S" />
+    <node concept="2YIFZL" id="2$zHkrOzH3m" role="jymVt">
+      <property role="TrG5h" value="check_w_a0a0" />
+      <node concept="37vLTG" id="2$zHkrOzH38" role="3clF46">
+        <property role="TrG5h" value="checkedDotOperand" />
+        <node concept="3uibUv" id="2$zHkrOzH3i" role="1tU5fm">
+          <ref role="3uigEE" node="2$zHkrOz9br" resolve="A" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="2$zHkrOzH37" role="3clF45" />
+      <node concept="3Tm6S6" id="2$zHkrOzH2f" role="1B3o_S" />
+      <node concept="3clFbS" id="2$zHkrOzH2g" role="3clF47">
+        <node concept="3clFbJ" id="2$zHkrOzH2h" role="3cqZAp">
+          <node concept="3clFbS" id="2$zHkrOzH2i" role="3clFbx">
+            <node concept="3clFbF" id="2$zHkrOzH2y" role="3cqZAp">
+              <node concept="2OqwBi" id="2$zHkrOzH2z" role="3clFbG">
+                <node concept="37vLTw" id="2$zHkrOzH2$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2$zHkrOzH38" resolve="checkedDotOperand" />
+                </node>
+                <node concept="liA8E" id="2$zHkrOz9K1" role="2OqNvi">
+                  <ref role="37wK5l" node="2$zHkrOz9p6" resolve="hello" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2$zHkrOzH2_" role="3clFbw">
+            <node concept="37vLTw" id="2$zHkrOzH2A" role="3uHU7w">
+              <ref role="3cqZAo" node="2$zHkrOzH38" resolve="checkedDotOperand" />
+            </node>
+            <node concept="10Nm6u" id="2$zHkrOzH2B" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2$zHkrOzH2R" role="3cqZAp" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/solutions/nl.f1re.testing.examples/nl.f1re.testing.examples.msd
+++ b/code/testing/solutions/nl.f1re.testing.examples/nl.f1re.testing.examples.msd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="nl.f1re.testing.examples" uuid="aade93d7-c51c-4471-a883-01aa02ec2bc2" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="yes" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+    <facet type="tests" />
+  </facets>
+  <dependencies>
+    <dependency reexport="false">c0080a47-7e37-4558-bee9-9ae18e690549(jetbrains.mps.lang.extension)</dependency>
+    <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)</dependency>
+    <dependency reexport="false">d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)</dependency>
+    <dependency reexport="false">87e083b3-d1b3-4c3f-9d8c-b24d74710f49(nl.f1re.testing.examples.lang)</dependency>
+    <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
+    <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
+    <dependency reexport="false">c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)</dependency>
+    <dependency reexport="false">73a71448-99c6-4925-ae2a-2cb0801adee3(jetbrains.mps.ide.tools.todo)</dependency>
+    <dependency reexport="false">86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)</dependency>
+    <dependency reexport="false">22250116-183c-4e90-8450-b6a13dd8998b(jetbrains.mps.baseLanguage.execution.util)</dependency>
+    <dependency reexport="false">14abba35-d008-451b-8562-9bfe66c43bd0(de.itemis.mps.debug.runtime)</dependency>
+    <dependency reexport="false">398d67d2-c2e9-11e2-ad49-6cf049e62ea4(jetbrains.mps.kotin.ui.dsl)</dependency>
+    <dependency reexport="false">85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)</dependency>
+    <dependency reexport="false">63089e65-5c76-4c44-9eb6-15698b4444cf(jetbrains.mps.vcs.mergehints.runtime)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:de.itemis.mps.compare" version="0" />
+    <language slang="l:f7e353e6-c7a8-4110-a263-1a2503e8b13c:de.itemis.mps.debug" version="0" />
+    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:f3347d8a-0e79-4f35-8ac9-1574f25c986f:jetbrains.mps.execution.commands" version="0" />
+    <language slang="l:73c1a490-99fa-4d0d-8292-b8985697c74b:jetbrains.mps.execution.common" version="0" />
+    <language slang="l:4caf0310-491e-41f5-8a9b-2006b3a94898:jetbrains.mps.execution.util" version="0" />
+    <language slang="l:6b3888c1-9802-44d8-8baf-f8e6c33ed689:jetbrains.mps.kotlin" version="11" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="6" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:68015e26-cc4d-49db-8715-b643faea1769:jetbrains.mps.lang.test.generator" version="0" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+    <language slang="l:953e4089-c643-455b-8629-636de7085d1c:nl.f1re.testing" version="0" />
+    <language slang="l:87e083b3-d1b3-4c3f-9d8c-b24d74710f49:nl.f1re.testing.examples.lang" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="847a3235-09f9-403c-b6a9-1c294a212e92(Ant)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
+    <module reference="86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)" version="0" />
+    <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
+    <module reference="c6420b75-4569-420d-aaf7-9bc590ad7b2a(de.itemis.mps.comparator)" version="0" />
+    <module reference="14abba35-d008-451b-8562-9bfe66c43bd0(de.itemis.mps.debug.runtime)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
+    <module reference="22250116-183c-4e90-8450-b6a13dd8998b(jetbrains.mps.baseLanguage.execution.util)" version="0" />
+    <module reference="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67(jetbrains.mps.baseLanguage.lightweightdsl)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
+    <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
+    <module reference="73a71448-99c6-4925-ae2a-2cb0801adee3(jetbrains.mps.ide.tools.todo)" version="0" />
+    <module reference="85836058-a162-41d7-bb1d-52e99d873f28(jetbrains.mps.ide.vcs.core)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="398d67d2-c2e9-11e2-ad49-6cf049e62ea4(jetbrains.mps.kotin.ui.dsl)" version="0" />
+    <module reference="b50d89c0-0fb9-4105-b652-222148c26a9b(jetbrains.mps.kotlin.stdlib)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="c0080a47-7e37-4558-bee9-9ae18e690549(jetbrains.mps.lang.extension)" version="0" />
+    <module reference="d7a92d38-f7db-40d0-8431-763b0c3c9f20(jetbrains.mps.lang.intentions)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
+    <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="63089e65-5c76-4c44-9eb6-15698b4444cf(jetbrains.mps.vcs.mergehints.runtime)" version="0" />
+    <module reference="aade93d7-c51c-4471-a883-01aa02ec2bc2(nl.f1re.testing.examples)" version="0" />
+    <module reference="87e083b3-d1b3-4c3f-9d8c-b24d74710f49(nl.f1re.testing.examples.lang)" version="0" />
+    <module reference="f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/testing/solutions/nl.f1re.testing.runtime/models/nl.f1re.testing.runtime.mps
+++ b/code/testing/solutions/nl.f1re.testing.runtime/models/nl.f1re.testing.runtime.mps
@@ -1,0 +1,4280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e0971d7a-26cb-4f9b-923b-022db20993f1(nl.f1re.testing.runtime)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="2" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
+  </languages>
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="iwsx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.fileEditor(MPS.IDEA/)" />
+    <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
+    <import index="v7e1" ref="r:3458bb8b-fecd-4f7c-841e-325717a43789(jetbrains.mps.lang.editor.tooltips.runtime)" />
+    <import index="2rdi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.assist(MPS.Editor/)" />
+    <import index="y49u" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.util(MPS.OpenAPI/)" />
+    <import index="nddn" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.intentions(MPS.Editor/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="91lp" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.intentions(MPS.Editor/)" />
+    <import index="ddhc" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide(MPS.IDEA/)" />
+    <import index="kt01" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.datatransfer(JDK/)" />
+    <import index="i5cy" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent.atomic(JDK/)" />
+    <import index="fnpx" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.notification(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="4b2m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.messages(MPS.IDEA/)" />
+    <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" />
+    <import index="al1t" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.diagnostic(MPS.IDEA/)" />
+    <import index="3qmy" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.classloading(MPS.Core/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
+    <import index="7a0s" ref="r:2af017c2-293f-4ebb-99f3-81e353b3d6e6(jetbrains.mps.editor.runtime)" />
+    <import index="et5u" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.messages(MPS.Core/)" />
+    <import index="wsw7" ref="r:ba41e9c6-15ca-4a47-95f2-6a81c2318547(jetbrains.mps.checkers)" />
+    <import index="d6hs" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors.item(MPS.Core/)" />
+    <import index="6if8" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.validation(MPS.Core/)" />
+    <import index="mk8z" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.progress(MPS.Core/)" />
+    <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
+    <import index="uu3z" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.execution.process(MPS.IDEA/)" />
+    <import index="ni5j" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.regex(JDK/)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="lk2n" ref="r:da044acc-81a4-4fd8-b89a-91df4cfe6214(jetbrains.mps.execution.api.commands)" />
+    <import index="rjhg" ref="49808fad-9d41-4b96-83fa-9231640f6b2b/java:org.junit(JUnit/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="zdap" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util.text(MPS.IDEA/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+  </imports>
+  <registry>
+    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
+      <concept id="8473566765277240526" name="de.slisson.mps.reflection.structure.ReflectionMethodCall" flags="ng" index="1PvZjq" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+        <child id="1160998916832" name="message" index="1gVpfI" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
+      <concept id="8974276187400348177" name="jetbrains.mps.lang.access.structure.ExecuteCommandStatement" flags="nn" index="1QHqEO" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+        <child id="1235746996653" name="function" index="2SgG2M" />
+        <child id="1235747002942" name="parameter" index="2SgHGx" />
+      </concept>
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+      <concept id="1172017222794" name="jetbrains.mps.baseLanguage.unitTest.structure.Fail" flags="nn" index="3xETmq" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
+        <child id="1225711182005" name="list" index="1y566C" />
+        <child id="1225711191269" name="index" index="1y58nS" />
+      </concept>
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+        <child id="5686963296372573084" name="elementType" index="3O5elw" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="5nwfWGQ3LWe">
+    <property role="TrG5h" value="Asserts" />
+    <node concept="2YIFZL" id="5nwfWGQ3NG7" role="jymVt">
+      <property role="TrG5h" value="assertFails" />
+      <node concept="3clFbS" id="5nwfWGQ3NG9" role="3clF47">
+        <node concept="3J1_TO" id="5nwfWGQ3NGa" role="3cqZAp">
+          <node concept="3uVAMA" id="5nwfWGQ3NGb" role="1zxBo5">
+            <node concept="XOnhg" id="5nwfWGQ3NGc" role="1zc67B">
+              <property role="TrG5h" value="throwable" />
+              <node concept="nSUau" id="5nwfWGQ3NGd" role="1tU5fm">
+                <node concept="3uibUv" id="5nwfWGQ3NGe" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5nwfWGQ3NGf" role="1zc67A">
+              <node concept="3cpWs6" id="5nwfWGQ3NGg" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5nwfWGQ3NGh" role="1zxBo7">
+            <node concept="3clFbF" id="5nwfWGQ3NGi" role="3cqZAp">
+              <node concept="2OqwBi" id="5nwfWGQ5ZA9" role="3clFbG">
+                <node concept="37vLTw" id="5nwfWGQ3NGk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5nwfWGQ3NGp" resolve="block" />
+                </node>
+                <node concept="liA8E" id="5nwfWGQ60bO" role="2OqNvi">
+                  <ref role="37wK5l" to="9w4s:~ThrowableRunnable.run()" resolve="run" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3xETmq" id="5nwfWGQ3NGl" role="3cqZAp">
+          <node concept="3_1$Yv" id="5nwfWGQ3NGm" role="3_9lra">
+            <node concept="Xl_RD" id="5nwfWGQ3NGn" role="3_1BAH">
+              <property role="Xl_RC" value="The block didn't fail" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="5nwfWGQ3NGo" role="3clF45" />
+      <node concept="37vLTG" id="5nwfWGQ3NGp" role="3clF46">
+        <property role="TrG5h" value="block" />
+        <node concept="3uibUv" id="5nwfWGQ3QdR" role="1tU5fm">
+          <ref role="3uigEE" to="9w4s:~ThrowableRunnable" resolve="ThrowableRunnable" />
+          <node concept="3uibUv" id="5nwfWGQ3Quo" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ3NGs" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="5nwfWGQ3LWf" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="6HRhZeXDGqv">
+    <property role="TrG5h" value="EditorCellTestHelper" />
+    <node concept="312cEg" id="6HRhZeXDHpl" role="jymVt">
+      <property role="TrG5h" value="editorCell" />
+      <node concept="3Tm6S6" id="6HRhZeXDHoJ" role="1B3o_S" />
+      <node concept="3uibUv" id="6HRhZeXDHpb" role="1tU5fm">
+        <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXDHol" role="jymVt" />
+    <node concept="3clFbW" id="6HRhZeXDHY2" role="jymVt">
+      <node concept="3cqZAl" id="6HRhZeXDHY3" role="3clF45" />
+      <node concept="3clFbS" id="6HRhZeXDHY5" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXDHtz" role="3cqZAp">
+          <node concept="37vLTI" id="6HRhZeXDHOb" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXDHPg" role="37vLTx">
+              <ref role="3cqZAo" node="6HRhZeXDHYJ" resolve="editorCell" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXDH_c" role="37vLTJ">
+              <node concept="Xjq3P" id="6HRhZeXDHty" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6HRhZeXDHFF" role="2OqNvi">
+                <ref role="2Oxat5" node="6HRhZeXDHpl" resolve="editorCell" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXDHY6" role="1B3o_S" />
+      <node concept="37vLTG" id="6HRhZeXDHYJ" role="3clF46">
+        <property role="TrG5h" value="editorCell" />
+        <node concept="3uibUv" id="6HRhZeXDHYI" role="1tU5fm">
+          <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXDHXC" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXDGPN" role="jymVt">
+      <property role="TrG5h" value="getLinkedNode" />
+      <node concept="3clFbS" id="6HRhZeXDGPP" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXJBU6" role="3cqZAp">
+          <node concept="2YIFZM" id="2$zHkrO$QCf" role="3clFbG">
+            <ref role="37wK5l" to="g51k:~APICellAdapter.getSNodeWRTReference(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="getSNodeWRTReference" />
+            <ref role="1Pybhc" to="g51k:~APICellAdapter" resolve="APICellAdapter" />
+            <node concept="37vLTw" id="6HRhZeXJC6c" role="37wK5m">
+              <ref role="3cqZAo" node="6HRhZeXDHpl" resolve="editorCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6HRhZeXDGPR" role="3clF45" />
+      <node concept="3Tm1VV" id="6HRhZeXDGPQ" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXJvpS" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXJvtM" role="jymVt">
+      <property role="TrG5h" value="focus" />
+      <node concept="3clFbS" id="6HRhZeXJvtP" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXJvPv" role="3cqZAp">
+          <node concept="2YIFZM" id="6HRhZeXJvV0" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="6HRhZeXJw3w" role="37wK5m">
+              <node concept="3clFbS" id="6HRhZeXJw3z" role="1bW5cS">
+                <node concept="3clFbF" id="6HRhZeXJwyU" role="3cqZAp">
+                  <node concept="2OqwBi" id="6HRhZeXJxab" role="3clFbG">
+                    <node concept="0kSF2" id="6HRhZeXJxwy" role="2Oq$k0">
+                      <node concept="3uibUv" id="6HRhZeXJxw$" role="0kSFW">
+                        <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                      </node>
+                      <node concept="2OqwBi" id="6HRhZeXJwHV" role="0kSFX">
+                        <node concept="37vLTw" id="6HRhZeXJwyT" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6HRhZeXDHpl" resolve="editorCell" />
+                        </node>
+                        <node concept="liA8E" id="6HRhZeXJwYM" role="2OqNvi">
+                          <ref role="37wK5l" to="f4zo:~EditorCell.getEditorComponent()" resolve="getEditorComponent" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6HRhZeXJzQp" role="2OqNvi">
+                      <ref role="37wK5l" to="exr9:~EditorComponent.changeSelectionWRTFocusPolicy(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="changeSelectionWRTFocusPolicy" />
+                      <node concept="37vLTw" id="6HRhZeXJzYj" role="37wK5m">
+                        <ref role="3cqZAo" node="6HRhZeXDHpl" resolve="editorCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXJvso" role="1B3o_S" />
+      <node concept="3cqZAl" id="6HRhZeXJvtE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXDGDj" role="jymVt" />
+    <node concept="3clFb_" id="7PTDMdvgIBe" role="jymVt">
+      <property role="TrG5h" value="getToolTipCell" />
+      <node concept="3clFbS" id="7PTDMdvgIBh" role="3clF47">
+        <node concept="3cpWs8" id="2$zHkrO_82z" role="3cqZAp">
+          <node concept="3cpWsn" id="2$zHkrO_82$" role="3cpWs9">
+            <property role="TrG5h" value="tooltip" />
+            <node concept="3uibUv" id="2$zHkrO_7IM" role="1tU5fm">
+              <ref role="3uigEE" to="v7e1:7XU1fOGnsmR" resolve="TooltipWrapper" />
+            </node>
+            <node concept="0kSF2" id="2$zHkrO_82_" role="33vP2m">
+              <node concept="3uibUv" id="2$zHkrO_82A" role="0kSFW">
+                <ref role="3uigEE" to="v7e1:7XU1fOGnsmR" resolve="TooltipWrapper" />
+              </node>
+              <node concept="2OqwBi" id="2$zHkrO_82B" role="0kSFX">
+                <node concept="37vLTw" id="2$zHkrO_82C" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXDHpl" resolve="editorCell" />
+                </node>
+                <node concept="liA8E" id="2$zHkrO_82D" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~EditorCell.getParent()" resolve="getParent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2$zHkrO_gkK" role="3cqZAp">
+          <node concept="3cpWsn" id="2$zHkrO_gkL" role="3cpWs9">
+            <property role="TrG5h" value="tooltipCell" />
+            <node concept="3uibUv" id="2$zHkrO_gca" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7PTDMdvgNb1" role="3cqZAp">
+          <node concept="2YIFZM" id="7PTDMdvgNlS" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="7PTDMdvgNyA" role="37wK5m">
+              <node concept="3clFbS" id="7PTDMdvgNyD" role="1bW5cS">
+                <node concept="3clFbF" id="7PTDMdvgOf8" role="3cqZAp">
+                  <node concept="37vLTI" id="7PTDMdvgOC9" role="3clFbG">
+                    <node concept="2OqwBi" id="7PTDMdvgPTf" role="37vLTx">
+                      <node concept="37vLTw" id="7PTDMdvgOLJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2$zHkrO_82$" resolve="tooltip" />
+                      </node>
+                      <node concept="liA8E" id="7PTDMdvgRx0" role="2OqNvi">
+                        <ref role="37wK5l" to="v7e1:7XU1fOGnU0V" resolve="getTooltipCell" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="7PTDMdvgOoF" role="37vLTJ">
+                      <ref role="3cqZAo" node="2$zHkrO_gkL" resolve="tooltipCell" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7PTDMdvgRUv" role="3cqZAp">
+          <node concept="10QFUN" id="7PTDMdvjKBa" role="3cqZAk">
+            <node concept="3uibUv" id="7PTDMdvjKJN" role="10QFUM">
+              <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+            </node>
+            <node concept="37vLTw" id="7PTDMdvgSdl" role="10QFUP">
+              <ref role="3cqZAo" node="2$zHkrO_gkL" resolve="tooltipCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7PTDMdvgIx8" role="1B3o_S" />
+      <node concept="3uibUv" id="7PTDMdvgLt1" role="3clF45">
+        <ref role="3uigEE" to="f4zo:~EditorCell_Collection" resolve="EditorCell_Collection" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6HRhZeXDGqw" role="1B3o_S" />
+    <node concept="3UR2Jj" id="6HRhZeXG7hQ" role="lGtFl">
+      <node concept="TZ5HA" id="6HRhZeXG7hR" role="TZ5H$">
+        <node concept="1dT_AC" id="6HRhZeXG7hS" role="1dT_Ay">
+          <property role="1dT_AB" value="This class can be called from places where there is no write/read access to the model like editor node test cases." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6HRhZeXDGGn">
+    <property role="TrG5h" value="EditorComponentTestHelper" />
+    <node concept="2tJIrI" id="6HRhZeXDGQm" role="jymVt" />
+    <node concept="312cEg" id="6HRhZeXDGSq" role="jymVt">
+      <property role="TrG5h" value="editorComponent" />
+      <node concept="3Tm6S6" id="6HRhZeXDGSg" role="1B3o_S" />
+      <node concept="3uibUv" id="6HRhZeXDGSG" role="1tU5fm">
+        <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXDGS8" role="jymVt" />
+    <node concept="3clFbW" id="6HRhZeXDGQF" role="jymVt">
+      <node concept="3cqZAl" id="6HRhZeXDGQG" role="3clF45" />
+      <node concept="3clFbS" id="6HRhZeXDGQI" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXDH1q" role="3cqZAp">
+          <node concept="37vLTI" id="6HRhZeXDHgy" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXDHhw" role="37vLTx">
+              <ref role="3cqZAo" node="6HRhZeXDGR8" resolve="editorComponent" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXDH7s" role="37vLTJ">
+              <node concept="Xjq3P" id="6HRhZeXDH1p" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6HRhZeXDHdT" role="2OqNvi">
+                <ref role="2Oxat5" node="6HRhZeXDGSq" resolve="editorComponent" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXDGQJ" role="1B3o_S" />
+      <node concept="37vLTG" id="6HRhZeXDGR8" role="3clF46">
+        <property role="TrG5h" value="editorComponent" />
+        <node concept="3uibUv" id="6HRhZeXDGR7" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXDGQn" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXDIAg" role="jymVt">
+      <property role="TrG5h" value="increaseUIScale" />
+      <node concept="3clFbS" id="6HRhZeXDIAj" role="3clF47">
+        <node concept="3cpWs8" id="3NYwjf33DW_" role="3cqZAp">
+          <node concept="3cpWsn" id="3NYwjf33DWA" role="3cpWs9">
+            <property role="TrG5h" value="settings" />
+            <node concept="3uibUv" id="3NYwjf33DPW" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+            </node>
+            <node concept="10QFUN" id="3NYwjf33DWB" role="33vP2m">
+              <node concept="3uibUv" id="3NYwjf33DWC" role="10QFUM">
+                <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+              </node>
+              <node concept="2OqwBi" id="3NYwjf33DWD" role="10QFUP">
+                <node concept="37vLTw" id="3NYwjf33DWE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="3NYwjf33DWF" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3NYwjf33Jmp" role="3cqZAp">
+          <node concept="2OqwBi" id="3NYwjf33JWK" role="3clFbG">
+            <node concept="37vLTw" id="3NYwjf33Jmn" role="2Oq$k0">
+              <ref role="3cqZAo" node="3NYwjf33DWA" resolve="settings" />
+            </node>
+            <node concept="1PvZjq" id="3NYwjf33KZw" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponentSettingsImpl.increaseUIScale()" resolve="increaseUIScale" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXEHiQ" role="3cqZAp">
+          <node concept="2YIFZM" id="6HRhZeXEHrr" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="6HRhZeXEHxJ" role="37wK5m">
+              <node concept="3clFbS" id="6HRhZeXEHxM" role="1bW5cS">
+                <node concept="1QHqEK" id="1LcZBjPCR9z" role="3cqZAp">
+                  <node concept="1QHqEC" id="1LcZBjPCR9_" role="1QHqEI">
+                    <node concept="3clFbS" id="1LcZBjPCR9B" role="1bW5cS">
+                      <node concept="3clFbF" id="1LcZBjPBiDD" role="3cqZAp">
+                        <node concept="2OqwBi" id="1LcZBjPBkKe" role="3clFbG">
+                          <node concept="37vLTw" id="6HRhZeXDSRG" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                          </node>
+                          <node concept="liA8E" id="1LcZBjPBnTS" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorComponent.rebuildEditorContent()" resolve="rebuildEditorContent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6HRhZeXDKE$" role="ukAjM">
+                    <node concept="2OqwBi" id="6HRhZeXDKji" role="2Oq$k0">
+                      <node concept="37vLTw" id="6HRhZeXDK69" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                      </node>
+                      <node concept="liA8E" id="6HRhZeXDKy9" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="6HRhZeXDKTK" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6HRhZeXDI_m" role="3clF45" />
+      <node concept="3Tm1VV" id="6HRhZeXDIBr" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3NYwjf33BTe" role="jymVt" />
+    <node concept="3clFb_" id="3NYwjf33Lf0" role="jymVt">
+      <property role="TrG5h" value="decreaseUIScale" />
+      <node concept="3clFbS" id="3NYwjf33Lf1" role="3clF47">
+        <node concept="3cpWs8" id="3NYwjf33Lf2" role="3cqZAp">
+          <node concept="3cpWsn" id="3NYwjf33Lf3" role="3cpWs9">
+            <property role="TrG5h" value="settings" />
+            <node concept="3uibUv" id="3NYwjf33Lf4" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+            </node>
+            <node concept="10QFUN" id="3NYwjf33Lf5" role="33vP2m">
+              <node concept="3uibUv" id="3NYwjf33Lf6" role="10QFUM">
+                <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+              </node>
+              <node concept="2OqwBi" id="3NYwjf33Lf7" role="10QFUP">
+                <node concept="37vLTw" id="3NYwjf33Lf8" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="3NYwjf33Lf9" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3NYwjf33Lfa" role="3cqZAp">
+          <node concept="2OqwBi" id="3NYwjf33Lfb" role="3clFbG">
+            <node concept="37vLTw" id="3NYwjf33Lfc" role="2Oq$k0">
+              <ref role="3cqZAo" node="3NYwjf33Lf3" resolve="settings" />
+            </node>
+            <node concept="1PvZjq" id="3NYwjf33Lfd" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponentSettingsImpl.decreaseUIScale()" resolve="decreaseUIScale" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3NYwjf33Lfe" role="3cqZAp">
+          <node concept="2YIFZM" id="3NYwjf33Lff" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="3NYwjf33Lfg" role="37wK5m">
+              <node concept="3clFbS" id="3NYwjf33Lfh" role="1bW5cS">
+                <node concept="1QHqEK" id="3NYwjf33Lfi" role="3cqZAp">
+                  <node concept="1QHqEC" id="3NYwjf33Lfj" role="1QHqEI">
+                    <node concept="3clFbS" id="3NYwjf33Lfk" role="1bW5cS">
+                      <node concept="3clFbF" id="3NYwjf33Lfl" role="3cqZAp">
+                        <node concept="2OqwBi" id="3NYwjf33Lfm" role="3clFbG">
+                          <node concept="37vLTw" id="3NYwjf33Lfn" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                          </node>
+                          <node concept="liA8E" id="3NYwjf33Lfo" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorComponent.rebuildEditorContent()" resolve="rebuildEditorContent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3NYwjf33Lfp" role="ukAjM">
+                    <node concept="2OqwBi" id="3NYwjf33Lfq" role="2Oq$k0">
+                      <node concept="37vLTw" id="3NYwjf33Lfr" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                      </node>
+                      <node concept="liA8E" id="3NYwjf33Lfs" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3NYwjf33Lft" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="3NYwjf33Lfu" role="3clF45" />
+      <node concept="3Tm1VV" id="3NYwjf33Lfv" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3NYwjf33LCi" role="jymVt" />
+    <node concept="3clFb_" id="3NYwjf33MCw" role="jymVt">
+      <property role="TrG5h" value="resetUIScale" />
+      <node concept="3clFbS" id="3NYwjf33MCx" role="3clF47">
+        <node concept="3cpWs8" id="3NYwjf33MCy" role="3cqZAp">
+          <node concept="3cpWsn" id="3NYwjf33MCz" role="3cpWs9">
+            <property role="TrG5h" value="settings" />
+            <node concept="3uibUv" id="3NYwjf33MC$" role="1tU5fm">
+              <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+            </node>
+            <node concept="10QFUN" id="3NYwjf33MC_" role="33vP2m">
+              <node concept="3uibUv" id="3NYwjf33MCA" role="10QFUM">
+                <ref role="3uigEE" to="exr9:~EditorComponentSettingsImpl" resolve="EditorComponentSettingsImpl" />
+              </node>
+              <node concept="2OqwBi" id="3NYwjf33MCB" role="10QFUP">
+                <node concept="37vLTw" id="3NYwjf33MCC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="3NYwjf33MCD" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorComponentSettings()" resolve="getEditorComponentSettings" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3NYwjf33MCE" role="3cqZAp">
+          <node concept="2OqwBi" id="3NYwjf33MCF" role="3clFbG">
+            <node concept="37vLTw" id="3NYwjf33MCG" role="2Oq$k0">
+              <ref role="3cqZAo" node="3NYwjf33MCz" resolve="settings" />
+            </node>
+            <node concept="1PvZjq" id="3NYwjf33MCH" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponentSettingsImpl.reset()" resolve="reset" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3NYwjf33MCI" role="3cqZAp">
+          <node concept="2YIFZM" id="3NYwjf33MCJ" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="3NYwjf33MCK" role="37wK5m">
+              <node concept="3clFbS" id="3NYwjf33MCL" role="1bW5cS">
+                <node concept="1QHqEK" id="3NYwjf33MCM" role="3cqZAp">
+                  <node concept="1QHqEC" id="3NYwjf33MCN" role="1QHqEI">
+                    <node concept="3clFbS" id="3NYwjf33MCO" role="1bW5cS">
+                      <node concept="3clFbF" id="3NYwjf33MCP" role="3cqZAp">
+                        <node concept="2OqwBi" id="3NYwjf33MCQ" role="3clFbG">
+                          <node concept="37vLTw" id="3NYwjf33MCR" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                          </node>
+                          <node concept="liA8E" id="3NYwjf33MCS" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorComponent.rebuildEditorContent()" resolve="rebuildEditorContent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3NYwjf33MCT" role="ukAjM">
+                    <node concept="2OqwBi" id="3NYwjf33MCU" role="2Oq$k0">
+                      <node concept="37vLTw" id="3NYwjf33MCV" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                      </node>
+                      <node concept="liA8E" id="3NYwjf33MCW" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3NYwjf33MCX" role="2OqNvi">
+                      <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="3NYwjf33MCY" role="3clF45" />
+      <node concept="3Tm1VV" id="3NYwjf33MCZ" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXH0qX" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXH0Jw" role="jymVt">
+      <property role="TrG5h" value="openContextAssistant" />
+      <node concept="3clFbS" id="6HRhZeXH0Jz" role="3clF47">
+        <node concept="3cpWs8" id="2$zHkrO_DVI" role="3cqZAp">
+          <node concept="3cpWsn" id="2$zHkrO_DVJ" role="3cpWs9">
+            <property role="TrG5h" value="manager" />
+            <node concept="3uibUv" id="2$zHkrO_DUU" role="1tU5fm">
+              <ref role="3uigEE" to="2rdi:~ContextAssistantManager" resolve="ContextAssistantManager" />
+            </node>
+            <node concept="2OqwBi" id="2$zHkrO_DVK" role="33vP2m">
+              <node concept="2OqwBi" id="2$zHkrO_DVL" role="2Oq$k0">
+                <node concept="37vLTw" id="6HRhZeXH1cd" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                </node>
+                <node concept="liA8E" id="2$zHkrO_DVN" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
+                </node>
+              </node>
+              <node concept="liA8E" id="2$zHkrO_DVO" role="2OqNvi">
+                <ref role="37wK5l" to="cj4x:~EditorContext.getContextAssistantManager()" resolve="getContextAssistantManager" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2$zHkrOA0a3" role="3cqZAp">
+          <node concept="2OqwBi" id="2$zHkrOA0kU" role="3clFbG">
+            <node concept="37vLTw" id="2$zHkrOA0a1" role="2Oq$k0">
+              <ref role="3cqZAo" node="2$zHkrO_DVJ" resolve="manager" />
+            </node>
+            <node concept="liA8E" id="2$zHkrOA0vX" role="2OqNvi">
+              <ref role="37wK5l" to="2rdi:~ContextAssistantManager.updateImmediately()" resolve="updateImmediately" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXH6v7" role="3cqZAp">
+          <node concept="37vLTw" id="6HRhZeXH6v5" role="3clFbG">
+            <ref role="3cqZAo" node="2$zHkrO_DVJ" resolve="manager" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXH0Cj" role="1B3o_S" />
+      <node concept="3uibUv" id="6HRhZeXH66V" role="3clF45">
+        <ref role="3uigEE" to="2rdi:~ContextAssistantManager" resolve="ContextAssistantManager" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6HRhZeXDGGo" role="1B3o_S" />
+    <node concept="3UR2Jj" id="6HRhZeXG7rR" role="lGtFl">
+      <node concept="TZ5HA" id="6HRhZeXG7rS" role="TZ5H$">
+        <node concept="1dT_AC" id="6HRhZeXG7rT" role="1dT_Ay">
+          <property role="1dT_AB" value="This class can be called from places where there is no write/read access to the model like editor node test cases." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="wUiM63PS_P">
+    <property role="TrG5h" value="IntentionTester" />
+    <node concept="312cEg" id="4k0nQshmFs5" role="jymVt">
+      <property role="TrG5h" value="myEditorContext" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="4k0nQshmB3w" role="1B3o_S" />
+      <node concept="3uibUv" id="4k0nQshmCzd" role="1tU5fm">
+        <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+      </node>
+    </node>
+    <node concept="312cEg" id="1488IJS8PGu" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="mySurroundWith" />
+      <node concept="3Tm6S6" id="1488IJS8PGv" role="1B3o_S" />
+      <node concept="10P_77" id="1488IJS8Rfr" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="wUiM63PSJ7" role="jymVt" />
+    <node concept="3Tm1VV" id="wUiM63PS_Q" role="1B3o_S" />
+    <node concept="3clFbW" id="wUiM63PSJn" role="jymVt">
+      <node concept="3cqZAl" id="wUiM63PSJo" role="3clF45" />
+      <node concept="3Tm1VV" id="wUiM63PSJp" role="1B3o_S" />
+      <node concept="3clFbS" id="wUiM63PSJr" role="3clF47">
+        <node concept="1VxSAg" id="1488IJS8UV0" role="3cqZAp">
+          <ref role="37wK5l" node="1488IJS8Ixx" resolve="IntentionTester" />
+          <node concept="37vLTw" id="4k0nQshmIaa" role="37wK5m">
+            <ref role="3cqZAo" node="4k0nQshmyub" resolve="editorContext" />
+          </node>
+          <node concept="3clFbT" id="1488IJS8Wdd" role="37wK5m">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4k0nQshmyub" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="4k0nQshmyua" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1488IJS8GkM" role="jymVt" />
+    <node concept="3clFbW" id="1488IJS8Ixx" role="jymVt">
+      <node concept="37vLTG" id="4k0nQshmId7" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="4k0nQshmId8" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1488IJS8K11" role="3clF46">
+        <property role="TrG5h" value="surroundWith" />
+        <node concept="10P_77" id="1488IJS8K36" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="1488IJS8Ixz" role="3clF45" />
+      <node concept="3Tm1VV" id="1488IJS8Ix$" role="1B3o_S" />
+      <node concept="3clFbS" id="1488IJS8Ix_" role="3clF47">
+        <node concept="3clFbF" id="wUiM63PSJv" role="3cqZAp">
+          <node concept="37vLTI" id="wUiM63PSJx" role="3clFbG">
+            <node concept="37vLTw" id="wUiM63PSJ_" role="37vLTJ">
+              <ref role="3cqZAo" node="4k0nQshmFs5" resolve="myEditorContext" />
+            </node>
+            <node concept="37vLTw" id="wUiM63PSJA" role="37vLTx">
+              <ref role="3cqZAo" node="4k0nQshmId7" resolve="editorContext" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1488IJS8Sdl" role="3cqZAp">
+          <node concept="37vLTI" id="1488IJS8SZu" role="3clFbG">
+            <node concept="37vLTw" id="1488IJS8TV$" role="37vLTx">
+              <ref role="3cqZAo" node="1488IJS8K11" resolve="surroundWith" />
+            </node>
+            <node concept="37vLTw" id="1488IJS8Sdj" role="37vLTJ">
+              <ref role="3cqZAo" node="1488IJS8PGu" resolve="mySurroundWith" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="wUiM63PU8B" role="jymVt" />
+    <node concept="3clFb_" id="wUiM63PU8C" role="jymVt">
+      <property role="TrG5h" value="getSingleMatchingIntention" />
+      <node concept="3Tm1VV" id="4k0nQshnfYR" role="1B3o_S" />
+      <node concept="37vLTG" id="wUiM63PU8E" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="wUiM63PU8F" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="wUiM63PU8G" role="3clF46">
+        <property role="TrG5h" value="intentionCondition" />
+        <node concept="3uibUv" id="wUiM63PU8H" role="1tU5fm">
+          <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+          <node concept="3uibUv" id="E4JlmYtfFW" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="wUiM63PU8J" role="3clF47">
+        <node concept="3cpWs8" id="wUiM63PU8T" role="3cqZAp">
+          <node concept="3cpWsn" id="wUiM63PU8U" role="3cpWs9">
+            <property role="TrG5h" value="matches" />
+            <node concept="_YKpA" id="wUiM63PU8V" role="1tU5fm">
+              <node concept="3uibUv" id="wUiM63PU8W" role="_ZDj9">
+                <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+                <node concept="3uibUv" id="E4JlmYtgky" role="11_B2D">
+                  <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+                </node>
+                <node concept="3uibUv" id="wUiM63PU8Y" role="11_B2D">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="wUiM63PU8Z" role="33vP2m">
+              <node concept="1rXfSq" id="wUiM63SBO1" role="2Oq$k0">
+                <ref role="37wK5l" node="wUiM63S$iO" resolve="getMatchingIntentions" />
+                <node concept="37vLTw" id="wUiM63SC_i" role="37wK5m">
+                  <ref role="3cqZAo" node="wUiM63PU8E" resolve="node" />
+                </node>
+                <node concept="37vLTw" id="wUiM63SEbp" role="37wK5m">
+                  <ref role="3cqZAo" node="wUiM63PU8G" resolve="intentionCondition" />
+                </node>
+              </node>
+              <node concept="ANE8D" id="wUiM63PU9e" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="wUiM63PU9f" role="3cqZAp" />
+        <node concept="3clFbJ" id="wUiM63PU9g" role="3cqZAp">
+          <node concept="3clFbS" id="wUiM63PU9h" role="3clFbx">
+            <node concept="YS8fn" id="wUiM63PU9i" role="3cqZAp">
+              <node concept="2ShNRf" id="wUiM63PU9j" role="YScLw">
+                <node concept="1pGfFk" id="wUiM63PU9k" role="2ShVmc">
+                  <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                  <node concept="3cpWs3" id="wUiM63PU9l" role="37wK5m">
+                    <node concept="37vLTw" id="wUiM63PU9m" role="3uHU7w">
+                      <ref role="3cqZAo" node="wUiM63PU8G" resolve="intentionCondition" />
+                    </node>
+                    <node concept="3cpWs3" id="wUiM63PU9n" role="3uHU7B">
+                      <node concept="Xl_RD" id="wUiM63PU9o" role="3uHU7w">
+                        <property role="Xl_RC" value=" intentions matching " />
+                      </node>
+                      <node concept="3cpWs3" id="wUiM63PU9p" role="3uHU7B">
+                        <node concept="Xl_RD" id="wUiM63PU9q" role="3uHU7B">
+                          <property role="Xl_RC" value="Expected one, found " />
+                        </node>
+                        <node concept="2OqwBi" id="wUiM63PU9r" role="3uHU7w">
+                          <node concept="37vLTw" id="wUiM63PU9s" role="2Oq$k0">
+                            <ref role="3cqZAo" node="wUiM63PU8U" resolve="matches" />
+                          </node>
+                          <node concept="34oBXx" id="wUiM63PU9t" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="wUiM63PU9u" role="3clFbw">
+            <node concept="3cmrfG" id="wUiM63PU9v" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="wUiM63PU9w" role="3uHU7B">
+              <node concept="37vLTw" id="wUiM63PU9x" role="2Oq$k0">
+                <ref role="3cqZAo" node="wUiM63PU8U" resolve="matches" />
+              </node>
+              <node concept="34oBXx" id="wUiM63PU9y" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="wUiM63PU9z" role="3cqZAp" />
+        <node concept="3cpWs6" id="wUiM63PU9$" role="3cqZAp">
+          <node concept="1y4W85" id="wUiM63PU9_" role="3cqZAk">
+            <node concept="3cmrfG" id="wUiM63PU9A" role="1y58nS">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="wUiM63PU9B" role="1y566C">
+              <ref role="3cqZAo" node="wUiM63PU8U" resolve="matches" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="wUiM63PU9C" role="3clF45">
+        <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+        <node concept="3uibUv" id="E4JlmYtiy8" role="11_B2D">
+          <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+        </node>
+        <node concept="3uibUv" id="wUiM63PU9E" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="wUiM63SyGh" role="jymVt" />
+    <node concept="3clFb_" id="wUiM63S$iO" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="getMatchingIntentions" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="wUiM63S$iR" role="3clF47">
+        <node concept="3cpWs8" id="wUiM63S_HW" role="3cqZAp">
+          <node concept="3cpWsn" id="wUiM63S_HX" role="3cpWs9">
+            <property role="TrG5h" value="intentions" />
+            <node concept="3vKaQO" id="wUiM63S_HY" role="1tU5fm">
+              <node concept="3uibUv" id="wUiM63S_HZ" role="3O5elw">
+                <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+                <node concept="3uibUv" id="E4JlmYtb7w" role="11_B2D">
+                  <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+                </node>
+                <node concept="3uibUv" id="wUiM63S_I1" role="11_B2D">
+                  <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="wUiM63S_I2" role="33vP2m">
+              <ref role="37wK5l" node="wUiM63PU9G" resolve="getAvailableIntentions" />
+              <node concept="37vLTw" id="wUiM63S_I3" role="37wK5m">
+                <ref role="3cqZAo" node="wUiM63S_3k" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="wUiM63SAB6" role="3cqZAp">
+          <node concept="2OqwBi" id="wUiM63SAB8" role="3clFbG">
+            <node concept="37vLTw" id="wUiM63SAB9" role="2Oq$k0">
+              <ref role="3cqZAo" node="wUiM63S_HX" resolve="intentions" />
+            </node>
+            <node concept="3zZkjj" id="wUiM63SABa" role="2OqNvi">
+              <node concept="1bVj0M" id="wUiM63SABb" role="23t8la">
+                <node concept="3clFbS" id="wUiM63SABc" role="1bW5cS">
+                  <node concept="3clFbF" id="wUiM63SABd" role="3cqZAp">
+                    <node concept="2OqwBi" id="wUiM63SABe" role="3clFbG">
+                      <node concept="37vLTw" id="wUiM63SABf" role="2Oq$k0">
+                        <ref role="3cqZAo" node="wUiM63S_LQ" resolve="condition" />
+                      </node>
+                      <node concept="liA8E" id="wUiM63SABg" role="2OqNvi">
+                        <ref role="37wK5l" to="y49u:~Condition.met(java.lang.Object)" resolve="met" />
+                        <node concept="2OqwBi" id="wUiM63SABh" role="37wK5m">
+                          <node concept="37vLTw" id="wUiM63SABi" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5W7E4fV0X$m" resolve="it" />
+                          </node>
+                          <node concept="2OwXpG" id="wUiM63SABj" role="2OqNvi">
+                            <ref role="2Oxat5" to="18ew:~Pair.o1" resolve="o1" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="5W7E4fV0X$m" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5W7E4fV0X$n" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="wUiM63SzuS" role="1B3o_S" />
+      <node concept="A3Dl8" id="wUiM63S$fS" role="3clF45">
+        <node concept="3uibUv" id="wUiM63S$hK" role="A3Ik2">
+          <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+          <node concept="3uibUv" id="E4JlmYte8k" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+          <node concept="3uibUv" id="wUiM63S$hM" role="11_B2D">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="wUiM63S_3k" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="wUiM63S_3j" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="wUiM63S_LQ" role="3clF46">
+        <property role="TrG5h" value="condition" />
+        <node concept="3uibUv" id="wUiM63SAvJ" role="1tU5fm">
+          <ref role="3uigEE" to="y49u:~Condition" resolve="Condition" />
+          <node concept="3uibUv" id="E4JlmYtdvB" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="wUiM63PU9F" role="jymVt" />
+    <node concept="3clFb_" id="wUiM63PU9G" role="jymVt">
+      <property role="TrG5h" value="getAvailableIntentions" />
+      <node concept="3Tm6S6" id="wUiM63PU9H" role="1B3o_S" />
+      <node concept="37vLTG" id="wUiM63PU9I" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tqbb2" id="wUiM63PU9J" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="wUiM63PU9K" role="3clF47">
+        <node concept="3cpWs8" id="wUiM63PU9L" role="3cqZAp">
+          <node concept="3cpWsn" id="wUiM63PU9M" role="3cpWs9">
+            <property role="TrG5h" value="query" />
+            <node concept="2ShNRf" id="wUiM63PU9N" role="33vP2m">
+              <node concept="1pGfFk" id="wUiM63PU9O" role="2ShVmc">
+                <ref role="37wK5l" to="91lp:~IntentionsManager$QueryDescriptor.&lt;init&gt;()" resolve="IntentionsManager.QueryDescriptor" />
+              </node>
+            </node>
+            <node concept="3uibUv" id="wUiM63PU9P" role="1tU5fm">
+              <ref role="3uigEE" to="91lp:~IntentionsManager$QueryDescriptor" resolve="IntentionsManager.QueryDescriptor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="wUiM63PU9Q" role="3cqZAp">
+          <node concept="2OqwBi" id="wUiM63PU9R" role="3clFbG">
+            <node concept="37vLTw" id="wUiM63PU9S" role="2Oq$k0">
+              <ref role="3cqZAo" node="wUiM63PU9M" resolve="query" />
+            </node>
+            <node concept="liA8E" id="wUiM63PU9T" role="2OqNvi">
+              <ref role="37wK5l" to="91lp:~IntentionsManager$QueryDescriptor.setCurrentNodeOnly(boolean)" resolve="setCurrentNodeOnly" />
+              <node concept="3clFbT" id="wUiM63PU9U" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1488IJS8Y3w" role="3cqZAp">
+          <node concept="2OqwBi" id="1488IJS8YOp" role="3clFbG">
+            <node concept="37vLTw" id="1488IJS8Y3u" role="2Oq$k0">
+              <ref role="3cqZAo" node="wUiM63PU9M" resolve="query" />
+            </node>
+            <node concept="liA8E" id="1488IJS90vh" role="2OqNvi">
+              <ref role="37wK5l" to="91lp:~IntentionsManager$QueryDescriptor.setSurroundWith(boolean)" resolve="setSurroundWith" />
+              <node concept="37vLTw" id="1488IJS90Da" role="37wK5m">
+                <ref role="3cqZAo" node="1488IJS8PGu" resolve="mySurroundWith" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="wUiM63PU9V" role="3cqZAp">
+          <node concept="2OqwBi" id="wUiM63PU9W" role="3cqZAk">
+            <node concept="liA8E" id="wUiM63PU9X" role="2OqNvi">
+              <ref role="37wK5l" to="91lp:~IntentionsManager.getAvailableIntentions(jetbrains.mps.intentions.IntentionsManager$QueryDescriptor,org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.openapi.editor.EditorContext)" resolve="getAvailableIntentions" />
+              <node concept="37vLTw" id="wUiM63PU9Y" role="37wK5m">
+                <ref role="3cqZAo" node="wUiM63PU9M" resolve="query" />
+              </node>
+              <node concept="37vLTw" id="wUiM63PU9Z" role="37wK5m">
+                <ref role="3cqZAo" node="wUiM63PU9I" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="4k0nQshngXJ" role="37wK5m">
+                <ref role="3cqZAo" node="4k0nQshmFs5" resolve="myEditorContext" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="wUiM63PUa3" role="2Oq$k0">
+              <ref role="1Pybhc" to="91lp:~IntentionsManager" resolve="IntentionsManager" />
+              <ref role="37wK5l" to="91lp:~IntentionsManager.getInstance()" resolve="getInstance" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vKaQO" id="wUiM63PUa4" role="3clF45">
+        <node concept="3uibUv" id="wUiM63PUa5" role="3O5elw">
+          <ref role="3uigEE" to="18ew:~Pair" resolve="Pair" />
+          <node concept="3uibUv" id="E4JlmYt9h3" role="11_B2D">
+            <ref role="3uigEE" to="nddn:~IntentionExecutable" resolve="IntentionExecutable" />
+          </node>
+          <node concept="3uibUv" id="wUiM63PUa7" role="11_B2D">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6HRhZeXHgJ0">
+    <property role="TrG5h" value="PlatformTestHelper" />
+    <node concept="312cEg" id="6HRhZeXHgJ1" role="jymVt">
+      <property role="TrG5h" value="ideaProject" />
+      <node concept="3uibUv" id="6HRhZeXHgJ2" role="1tU5fm">
+        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+      </node>
+      <node concept="3Tm6S6" id="6HRhZeXHgJ3" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6HRhZeXHlZZ" role="jymVt">
+      <property role="TrG5h" value="project" />
+      <node concept="3Tm6S6" id="6HRhZeXHlVv" role="1B3o_S" />
+      <node concept="3uibUv" id="6HRhZeXHlZq" role="1tU5fm">
+        <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXHgJ4" role="jymVt" />
+    <node concept="3clFbW" id="6HRhZeXHgJ5" role="jymVt">
+      <node concept="3cqZAl" id="6HRhZeXHgJ6" role="3clF45" />
+      <node concept="3clFbS" id="6HRhZeXHgJ7" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXHgJ8" role="3cqZAp">
+          <node concept="37vLTI" id="6HRhZeXHgJ9" role="3clFbG">
+            <node concept="2YIFZM" id="6HRhZeXHn26" role="37vLTx">
+              <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="37vLTw" id="6HRhZeXHn3W" role="37wK5m">
+                <ref role="3cqZAo" node="6HRhZeXHgJf" resolve="project" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXHgJb" role="37vLTJ">
+              <node concept="Xjq3P" id="6HRhZeXHgJc" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6HRhZeXHgJd" role="2OqNvi">
+                <ref role="2Oxat5" node="6HRhZeXHgJ1" resolve="ideaProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXHpaJ" role="3cqZAp">
+          <node concept="37vLTI" id="6HRhZeXHqeU" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXHqhY" role="37vLTx">
+              <ref role="3cqZAo" node="6HRhZeXHgJf" resolve="project" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXHpkU" role="37vLTJ">
+              <node concept="Xjq3P" id="6HRhZeXHpaH" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6HRhZeXHpyu" role="2OqNvi">
+                <ref role="2Oxat5" node="6HRhZeXHlZZ" resolve="project" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXHgJe" role="1B3o_S" />
+      <node concept="37vLTG" id="6HRhZeXHgJf" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="6HRhZeXHgJg" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXHgJh" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXHgJG" role="jymVt">
+      <property role="TrG5h" value="withClipboardData" />
+      <node concept="3clFbS" id="6HRhZeXHgJH" role="3clF47">
+        <node concept="3cpWs8" id="6HRhZeXHgJI" role="3cqZAp">
+          <node concept="3cpWsn" id="6HRhZeXHgJJ" role="3cpWs9">
+            <property role="TrG5h" value="manager" />
+            <node concept="3uibUv" id="6HRhZeXHgJK" role="1tU5fm">
+              <ref role="3uigEE" to="ddhc:~CopyPasteManagerEx" resolve="CopyPasteManagerEx" />
+            </node>
+            <node concept="2YIFZM" id="6HRhZeXHgJL" role="33vP2m">
+              <ref role="37wK5l" to="ddhc:~CopyPasteManagerEx.getInstanceEx()" resolve="getInstanceEx" />
+              <ref role="1Pybhc" to="ddhc:~CopyPasteManagerEx" resolve="CopyPasteManagerEx" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6HRhZeXHgJM" role="3cqZAp">
+          <node concept="3cpWsn" id="6HRhZeXHgJN" role="3cpWs9">
+            <property role="TrG5h" value="oldContents" />
+            <node concept="3uibUv" id="6HRhZeXHgJO" role="1tU5fm">
+              <ref role="3uigEE" to="kt01:~Transferable" resolve="Transferable" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXHgJP" role="33vP2m">
+              <node concept="37vLTw" id="6HRhZeXHgJQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="6HRhZeXHgJJ" resolve="manager" />
+              </node>
+              <node concept="liA8E" id="6HRhZeXHgJR" role="2OqNvi">
+                <ref role="37wK5l" to="ddhc:~CopyPasteManagerEx.getContents()" resolve="getContents" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXHgJS" role="3cqZAp">
+          <node concept="2OqwBi" id="6HRhZeXHgJT" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXHgJU" role="2Oq$k0">
+              <ref role="3cqZAo" node="6HRhZeXHgJJ" resolve="manager" />
+            </node>
+            <node concept="liA8E" id="6HRhZeXHgJV" role="2OqNvi">
+              <ref role="37wK5l" to="ddhc:~CopyPasteManagerEx.setContents(java.awt.datatransfer.Transferable)" resolve="setContents" />
+              <node concept="2ShNRf" id="6HRhZeXHgJW" role="37wK5m">
+                <node concept="1pGfFk" id="6HRhZeXHgJX" role="2ShVmc">
+                  <ref role="37wK5l" to="kt01:~StringSelection.&lt;init&gt;(java.lang.String)" resolve="StringSelection" />
+                  <node concept="37vLTw" id="6HRhZeXHgJY" role="37wK5m">
+                    <ref role="3cqZAo" node="6HRhZeXHgKc" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXHgJZ" role="3cqZAp">
+          <node concept="2Sg_IR" id="6HRhZeXHgK0" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXHgK1" role="2SgG2M">
+              <ref role="3cqZAo" node="6HRhZeXHgK9" resolve="action" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6HRhZeXHikP" role="3cqZAp">
+          <node concept="3clFbS" id="6HRhZeXHikR" role="3clFbx">
+            <node concept="3clFbF" id="6HRhZeXHgK2" role="3cqZAp">
+              <node concept="2OqwBi" id="6HRhZeXHgK3" role="3clFbG">
+                <node concept="37vLTw" id="6HRhZeXHgK4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXHgJJ" resolve="manager" />
+                </node>
+                <node concept="liA8E" id="6HRhZeXHgK5" role="2OqNvi">
+                  <ref role="37wK5l" to="ddhc:~CopyPasteManagerEx.setContents(java.awt.datatransfer.Transferable)" resolve="setContents" />
+                  <node concept="37vLTw" id="6HRhZeXHgK6" role="37wK5m">
+                    <ref role="3cqZAo" node="6HRhZeXHgJN" resolve="oldContents" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6HRhZeXHiCz" role="3clFbw">
+            <node concept="10Nm6u" id="6HRhZeXHiJY" role="3uHU7w" />
+            <node concept="37vLTw" id="6HRhZeXHioO" role="3uHU7B">
+              <ref role="3cqZAo" node="6HRhZeXHgJN" resolve="oldContents" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXHgK7" role="1B3o_S" />
+      <node concept="3cqZAl" id="6HRhZeXHgK8" role="3clF45" />
+      <node concept="37vLTG" id="6HRhZeXHgK9" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="6HRhZeXHgKa" role="1tU5fm">
+          <node concept="3cqZAl" id="6HRhZeXHgKb" role="1ajl9A" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6HRhZeXHgKc" role="3clF46">
+        <property role="TrG5h" value="data" />
+        <node concept="17QB3L" id="6HRhZeXHgKd" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXL2IO" role="jymVt" />
+    <node concept="3clFb_" id="6HRhZeXL36l" role="jymVt">
+      <property role="TrG5h" value="findNotification" />
+      <node concept="3clFbS" id="6HRhZeXL36o" role="3clF47">
+        <node concept="3cpWs8" id="6HRhZeXLmtb" role="3cqZAp">
+          <node concept="3cpWsn" id="6HRhZeXLmtc" role="3cpWs9">
+            <property role="TrG5h" value="notificationFound" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="6HRhZeXLmtd" role="1tU5fm">
+              <ref role="3uigEE" to="i5cy:~AtomicBoolean" resolve="AtomicBoolean" />
+            </node>
+            <node concept="2ShNRf" id="6HRhZeXLVaD" role="33vP2m">
+              <node concept="1pGfFk" id="6HRhZeXLVSf" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="i5cy:~AtomicBoolean.&lt;init&gt;(boolean)" resolve="AtomicBoolean" />
+                <node concept="3clFbT" id="6HRhZeXLVWg" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6HRhZeXLoPs" role="3cqZAp" />
+        <node concept="3cpWs8" id="1LcZBjPHP4R" role="3cqZAp">
+          <node concept="3cpWsn" id="1LcZBjPHP4S" role="3cpWs9">
+            <property role="TrG5h" value="notifications" />
+            <node concept="3uibUv" id="1LcZBjPHP4Q" role="1tU5fm">
+              <ref role="3uigEE" to="fnpx:~Notifications" resolve="Notifications" />
+            </node>
+            <node concept="2ShNRf" id="1LcZBjPHP4T" role="33vP2m">
+              <node concept="YeOm9" id="1LcZBjPHP4U" role="2ShVmc">
+                <node concept="1Y3b0j" id="1LcZBjPHP4V" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="1Y3XeK" to="fnpx:~Notifications" resolve="Notifications" />
+                  <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                  <node concept="3Tm1VV" id="1LcZBjPHP4W" role="1B3o_S" />
+                  <node concept="3clFb_" id="1LcZBjPHP4X" role="jymVt">
+                    <property role="TrG5h" value="notify" />
+                    <node concept="3Tm1VV" id="1LcZBjPHP4Y" role="1B3o_S" />
+                    <node concept="3cqZAl" id="1LcZBjPHP4Z" role="3clF45" />
+                    <node concept="37vLTG" id="1LcZBjPHP50" role="3clF46">
+                      <property role="TrG5h" value="notification" />
+                      <node concept="3uibUv" id="1LcZBjPHP51" role="1tU5fm">
+                        <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+                      </node>
+                      <node concept="2AHcQZ" id="1LcZBjPHP52" role="2AJF6D">
+                        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="1LcZBjPHP53" role="3clF47">
+                      <node concept="3clFbF" id="6HRhZeXLGlt" role="3cqZAp">
+                        <node concept="2Sg_IR" id="6HRhZeXLH0v" role="3clFbG">
+                          <node concept="37vLTw" id="6HRhZeXLH0w" role="2SgG2M">
+                            <ref role="3cqZAo" node="6HRhZeXL3Lz" resolve="action" />
+                          </node>
+                          <node concept="37vLTw" id="6HRhZeXLHf3" role="2SgHGx">
+                            <ref role="3cqZAo" node="1LcZBjPHP50" resolve="notification" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="6HRhZeXLpxd" role="3cqZAp">
+                        <node concept="2OqwBi" id="6HRhZeXLpUX" role="3clFbG">
+                          <node concept="37vLTw" id="6HRhZeXLpxb" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6HRhZeXLmtc" resolve="notificationFound" />
+                          </node>
+                          <node concept="liA8E" id="6HRhZeXLDDO" role="2OqNvi">
+                            <ref role="37wK5l" to="i5cy:~AtomicBoolean.set(boolean)" resolve="set" />
+                            <node concept="3clFbT" id="6HRhZeXLE4E" role="37wK5m">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="1LcZBjPHP57" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6HRhZeXL6F1" role="3cqZAp">
+          <node concept="3cpWsn" id="6HRhZeXL6F2" role="3cpWs9">
+            <property role="TrG5h" value="connection" />
+            <node concept="3uibUv" id="6HRhZeXL5HF" role="1tU5fm">
+              <ref role="3uigEE" to="4b2m:~MessageBusConnection" resolve="MessageBusConnection" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXL6F3" role="33vP2m">
+              <node concept="2OqwBi" id="6HRhZeXL6F4" role="2Oq$k0">
+                <node concept="37vLTw" id="6HRhZeXL6F5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HRhZeXHgJ1" resolve="ideaProject" />
+                </node>
+                <node concept="liA8E" id="6HRhZeXL6F6" role="2OqNvi">
+                  <ref role="37wK5l" to="1m72:~ComponentManager.getMessageBus()" resolve="getMessageBus" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6HRhZeXL6F7" role="2OqNvi">
+                <ref role="37wK5l" to="4b2m:~MessageBus.connect()" resolve="connect" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1LcZBjPGAsY" role="3cqZAp">
+          <node concept="2OqwBi" id="1LcZBjPGE6D" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXL6F8" role="2Oq$k0">
+              <ref role="3cqZAo" node="6HRhZeXL6F2" resolve="connection" />
+            </node>
+            <node concept="liA8E" id="1LcZBjPGFf2" role="2OqNvi">
+              <ref role="37wK5l" to="4b2m:~SimpleMessageBusConnection.subscribe(com.intellij.util.messages.Topic,java.lang.Object)" resolve="subscribe" />
+              <node concept="10M0yZ" id="1LcZBjPGISD" role="37wK5m">
+                <ref role="3cqZAo" to="fnpx:~Notifications.TOPIC" resolve="TOPIC" />
+                <ref role="1PxDUh" to="fnpx:~Notifications" resolve="Notifications" />
+              </node>
+              <node concept="37vLTw" id="1LcZBjPHP5Y" role="37wK5m">
+                <ref role="3cqZAo" node="1LcZBjPHP4S" resolve="notifications" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXMLtg" role="3cqZAp">
+          <node concept="2Sg_IR" id="6HRhZeXMLZo" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXMLZp" role="2SgG2M">
+              <ref role="3cqZAo" node="6HRhZeXMKx$" resolve="triggerNotification" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6HRhZeXMLdn" role="3cqZAp" />
+        <node concept="3cpWs8" id="4k0nQshbwg0" role="3cqZAp">
+          <node concept="3cpWsn" id="4k0nQshbwfZ" role="3cpWs9">
+            <property role="TrG5h" value="found" />
+            <node concept="10P_77" id="4k0nQshbwg1" role="1tU5fm" />
+            <node concept="2OqwBi" id="4k0nQshbJhc" role="33vP2m">
+              <node concept="2ShNRf" id="4k0nQshb$ld" role="2Oq$k0">
+                <node concept="YeOm9" id="4k0nQshbEvi" role="2ShVmc">
+                  <node concept="1Y3b0j" id="4k0nQshbEvl" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="9w4s:~WaitFor.&lt;init&gt;(int)" resolve="WaitFor" />
+                    <ref role="1Y3XeK" to="9w4s:~WaitFor" resolve="WaitFor" />
+                    <node concept="3Tm1VV" id="4k0nQshbEvm" role="1B3o_S" />
+                    <node concept="37vLTw" id="6HRhZeXLm3e" role="37wK5m">
+                      <ref role="3cqZAo" node="6HRhZeXLltM" resolve="timeout" />
+                    </node>
+                    <node concept="3clFb_" id="4k0nQshbEMt" role="jymVt">
+                      <property role="TrG5h" value="condition" />
+                      <node concept="3Tmbuc" id="4k0nQshbEMu" role="1B3o_S" />
+                      <node concept="10P_77" id="4k0nQshbEMw" role="3clF45" />
+                      <node concept="3clFbS" id="4k0nQshbEMy" role="3clF47">
+                        <node concept="3clFbF" id="4k0nQshbGYO" role="3cqZAp">
+                          <node concept="2OqwBi" id="4k0nQshbHQL" role="3clFbG">
+                            <node concept="37vLTw" id="4k0nQshbGYN" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6HRhZeXLmtc" resolve="notificationFound" />
+                            </node>
+                            <node concept="liA8E" id="4k0nQshbI$7" role="2OqNvi">
+                              <ref role="37wK5l" to="i5cy:~AtomicBoolean.get()" resolve="get" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="4k0nQshbEMz" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="4k0nQshbKQn" role="2OqNvi">
+                <ref role="37wK5l" node="4k0nQshbEMt" resolve="condition" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6HRhZeXL$Vx" role="3cqZAp">
+          <node concept="2OqwBi" id="6HRhZeXL_p4" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXL$Vv" role="2Oq$k0">
+              <ref role="3cqZAo" node="6HRhZeXL6F2" resolve="connection" />
+            </node>
+            <node concept="liA8E" id="6HRhZeXLA2m" role="2OqNvi">
+              <ref role="37wK5l" to="4b2m:~SimpleMessageBusConnection.disconnect()" resolve="disconnect" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6HRhZeXLEoB" role="3cqZAp" />
+        <node concept="1gVbGN" id="6HRhZeXLxKl" role="3cqZAp">
+          <node concept="37vLTw" id="6HRhZeXLyeh" role="1gVkn0">
+            <ref role="3cqZAo" node="4k0nQshbwfZ" resolve="found" />
+          </node>
+          <node concept="Xl_RD" id="6HRhZeXLzDA" role="1gVpfI">
+            <property role="Xl_RC" value="Notification not found" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXL2TF" role="1B3o_S" />
+      <node concept="3cqZAl" id="6HRhZeXL35K" role="3clF45" />
+      <node concept="37vLTG" id="6HRhZeXMKx$" role="3clF46">
+        <property role="TrG5h" value="triggerNotification" />
+        <node concept="1ajhzC" id="6HRhZeXMKT4" role="1tU5fm">
+          <node concept="3cqZAl" id="6HRhZeXMKX3" role="1ajl9A" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6HRhZeXL3Lz" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <property role="3TUv4t" value="true" />
+        <node concept="1ajhzC" id="6HRhZeXL3Lx" role="1tU5fm">
+          <node concept="3cqZAl" id="6HRhZeXL4qw" role="1ajl9A" />
+          <node concept="3uibUv" id="6HRhZeXL4os" role="1ajw0F">
+            <ref role="3uigEE" to="fnpx:~Notification" resolve="Notification" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6HRhZeXLltM" role="3clF46">
+        <property role="TrG5h" value="timeout" />
+        <node concept="10Oyi0" id="6HRhZeXLlSg" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ0fyC" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ0hqb" role="jymVt">
+      <property role="TrG5h" value="withPowerSaveModelEnabled" />
+      <node concept="3clFbS" id="5nwfWGQ0hqd" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ0hqe" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ0hqf" role="3cpWs9">
+            <property role="TrG5h" value="wasEnabled" />
+            <node concept="10P_77" id="5nwfWGQ0hqg" role="1tU5fm" />
+            <node concept="2YIFZM" id="5nwfWGQ0hqh" role="33vP2m">
+              <ref role="37wK5l" to="ddhc:~PowerSaveMode.isEnabled()" resolve="isEnabled" />
+              <ref role="1Pybhc" to="ddhc:~PowerSaveMode" resolve="PowerSaveMode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="5nwfWGQ0hqi" role="3cqZAp">
+          <node concept="3clFbS" id="5nwfWGQ0hqj" role="1zxBo7">
+            <node concept="3clFbF" id="5nwfWGQ0hqk" role="3cqZAp">
+              <node concept="2YIFZM" id="5nwfWGQ0hql" role="3clFbG">
+                <ref role="37wK5l" to="ddhc:~PowerSaveMode.setEnabled(boolean)" resolve="setEnabled" />
+                <ref role="1Pybhc" to="ddhc:~PowerSaveMode" resolve="PowerSaveMode" />
+                <node concept="3clFbT" id="5nwfWGQ0hqm" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5nwfWGQ0hqn" role="3cqZAp">
+              <node concept="2Sg_IR" id="5nwfWGQ0hqo" role="3clFbG">
+                <node concept="37vLTw" id="5nwfWGQ0hqp" role="2SgG2M">
+                  <ref role="3cqZAo" node="5nwfWGQ0hqx" resolve="code" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1wplmZ" id="5nwfWGQ0hqq" role="1zxBo6">
+            <node concept="3clFbS" id="5nwfWGQ0hqr" role="1wplMD">
+              <node concept="3clFbF" id="5nwfWGQ0hqs" role="3cqZAp">
+                <node concept="2YIFZM" id="5nwfWGQ0hqt" role="3clFbG">
+                  <ref role="37wK5l" to="ddhc:~PowerSaveMode.setEnabled(boolean)" resolve="setEnabled" />
+                  <ref role="1Pybhc" to="ddhc:~PowerSaveMode" resolve="PowerSaveMode" />
+                  <node concept="37vLTw" id="5nwfWGQ0hqu" role="37wK5m">
+                    <ref role="3cqZAo" node="5nwfWGQ0hqf" resolve="wasEnabled" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="5nwfWGQ0hqv" role="3clF45" />
+      <node concept="37vLTG" id="5nwfWGQ0hqx" role="3clF46">
+        <property role="TrG5h" value="code" />
+        <node concept="1ajhzC" id="5nwfWGQ0hqy" role="1tU5fm">
+          <node concept="3cqZAl" id="5nwfWGQ0hqz" role="1ajl9A" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ0hqw" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ0ZPi" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ10Ho" role="jymVt">
+      <property role="TrG5h" value="assertHasFatalError" />
+      <node concept="3clFbS" id="5nwfWGQ10Hq" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ10Hr" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ10Hs" role="3cpWs9">
+            <property role="TrG5h" value="fatalErrors" />
+            <node concept="2OqwBi" id="5nwfWGQ10Ht" role="33vP2m">
+              <node concept="2YIFZM" id="5nwfWGQ10Hu" role="2Oq$k0">
+                <ref role="37wK5l" to="al1t:~MessagePool.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="al1t:~MessagePool" resolve="MessagePool" />
+              </node>
+              <node concept="liA8E" id="5nwfWGQ10Hv" role="2OqNvi">
+                <ref role="37wK5l" to="al1t:~MessagePool.getFatalErrors(boolean,boolean)" resolve="getFatalErrors" />
+                <node concept="3clFbT" id="5nwfWGQ10Hw" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="3clFbT" id="5nwfWGQ10Hx" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="_YKpA" id="5nwfWGQ10Hy" role="1tU5fm">
+              <node concept="3uibUv" id="5nwfWGQ10Hz" role="_ZDj9">
+                <ref role="3uigEE" to="al1t:~AbstractMessage" resolve="AbstractMessage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5nwfWGQ10H$" role="3cqZAp">
+          <node concept="3clFbS" id="5nwfWGQ10H_" role="3clFbx">
+            <node concept="3vlDli" id="5nwfWGQ10HA" role="3cqZAp">
+              <node concept="37vLTw" id="5nwfWGQ10HB" role="3tpDZB">
+                <ref role="3cqZAo" node="5nwfWGQ10HS" resolve="errorText" />
+              </node>
+              <node concept="2OqwBi" id="5nwfWGQ10HC" role="3tpDZA">
+                <node concept="2OqwBi" id="5nwfWGQ10HD" role="2Oq$k0">
+                  <node concept="37vLTw" id="5nwfWGQ10HE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5nwfWGQ10Hs" resolve="fatalErrors" />
+                  </node>
+                  <node concept="1yVyf7" id="5nwfWGQ10HF" role="2OqNvi" />
+                </node>
+                <node concept="liA8E" id="5nwfWGQ10HG" role="2OqNvi">
+                  <ref role="37wK5l" to="al1t:~AbstractMessage.getMessage()" resolve="getMessage" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="5nwfWGQ10HH" role="3clFbw">
+            <node concept="10Nm6u" id="5nwfWGQ10HI" role="3uHU7w" />
+            <node concept="37vLTw" id="5nwfWGQ10HJ" role="3uHU7B">
+              <ref role="3cqZAo" node="5nwfWGQ10HS" resolve="errorText" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="5nwfWGQ10HK" role="9aQIa">
+            <node concept="3clFbS" id="5nwfWGQ10HL" role="9aQI4">
+              <node concept="3vwNmj" id="5nwfWGQ10HM" role="3cqZAp">
+                <node concept="2OqwBi" id="5nwfWGQ10HN" role="3vwVQn">
+                  <node concept="37vLTw" id="5nwfWGQ10HO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5nwfWGQ10Hs" resolve="fatalErrors" />
+                  </node>
+                  <node concept="3GX2aA" id="5nwfWGQ10HP" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="5nwfWGQ10HR" role="3clF45" />
+      <node concept="37vLTG" id="5nwfWGQ10HS" role="3clF46">
+        <property role="TrG5h" value="errorText" />
+        <node concept="17QB3L" id="5nwfWGQ10HT" role="1tU5fm" />
+        <node concept="2AHcQZ" id="5nwfWGQ10HU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ10HQ" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="6HRhZeXHgKe" role="1B3o_S" />
+    <node concept="3UR2Jj" id="6HRhZeXHgKf" role="lGtFl">
+      <node concept="TZ5HA" id="6HRhZeXHgKg" role="TZ5H$">
+        <node concept="1dT_AC" id="6HRhZeXHgKh" role="1dT_Ay">
+          <property role="1dT_AB" value="This class can be called from places where there is no write/read access to the model like editor node test cases." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6HRhZeXG281">
+    <property role="TrG5h" value="ProjectTestHelper" />
+    <node concept="312cEg" id="6HRhZeXG2xv" role="jymVt">
+      <property role="TrG5h" value="project" />
+      <node concept="3uibUv" id="6HRhZeXG2xj" role="1tU5fm">
+        <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+      </node>
+      <node concept="3Tm6S6" id="6HRhZeXG2xG" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXG2x9" role="jymVt" />
+    <node concept="3clFbW" id="6HRhZeXG2y3" role="jymVt">
+      <node concept="3cqZAl" id="6HRhZeXG2y4" role="3clF45" />
+      <node concept="3clFbS" id="6HRhZeXG2y6" role="3clF47">
+        <node concept="3clFbF" id="6HRhZeXG2$d" role="3cqZAp">
+          <node concept="37vLTI" id="6HRhZeXG3oc" role="3clFbG">
+            <node concept="37vLTw" id="6HRhZeXG3sM" role="37vLTx">
+              <ref role="3cqZAo" node="6HRhZeXG2yw" resolve="project" />
+            </node>
+            <node concept="2OqwBi" id="6HRhZeXG2Ef" role="37vLTJ">
+              <node concept="Xjq3P" id="6HRhZeXG2$c" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6HRhZeXG2Mg" role="2OqNvi">
+                <ref role="2Oxat5" node="6HRhZeXG2xv" resolve="project" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6HRhZeXG2y7" role="1B3o_S" />
+      <node concept="37vLTG" id="6HRhZeXG2yw" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="6HRhZeXG2yv" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6HRhZeXG2xT" role="jymVt" />
+    <node concept="3clFb_" id="3NYwjf355CN" role="jymVt">
+      <property role="TrG5h" value="reloadModule" />
+      <node concept="3clFbS" id="3NYwjf355CQ" role="3clF47">
+        <node concept="3clFbF" id="3NYwjf35c1f" role="3cqZAp">
+          <node concept="2YIFZM" id="3NYwjf35c1g" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="3NYwjf35c1h" role="37wK5m">
+              <node concept="3clFbS" id="3NYwjf35c1i" role="1bW5cS">
+                <node concept="1QHqEO" id="3NYwjf35c1j" role="3cqZAp">
+                  <node concept="1QHqEC" id="3NYwjf35c1k" role="1QHqEI">
+                    <node concept="3clFbS" id="3NYwjf35c1l" role="1bW5cS">
+                      <node concept="3cpWs8" id="3NYwjf35fkJ" role="3cqZAp">
+                        <node concept="3cpWsn" id="3NYwjf35fkK" role="3cpWs9">
+                          <property role="TrG5h" value="classLoaderManager" />
+                          <node concept="3uibUv" id="3NYwjf35eSZ" role="1tU5fm">
+                            <ref role="3uigEE" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                          </node>
+                          <node concept="2OqwBi" id="3NYwjf35fkL" role="33vP2m">
+                            <node concept="37vLTw" id="3NYwjf35fkM" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                            </node>
+                            <node concept="liA8E" id="3NYwjf35fkN" role="2OqNvi">
+                              <ref role="37wK5l" to="z1c3:~Project.getComponent(java.lang.Class)" resolve="getComponent" />
+                              <node concept="3VsKOn" id="3NYwjf35fkO" role="37wK5m">
+                                <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3NYwjf35lsz" role="3cqZAp">
+                        <node concept="2OqwBi" id="3NYwjf35mzS" role="3clFbG">
+                          <node concept="37vLTw" id="3NYwjf35lsx" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3NYwjf35fkK" resolve="classLoaderManager" />
+                          </node>
+                          <node concept="liA8E" id="3NYwjf35nRe" role="2OqNvi">
+                            <ref role="37wK5l" to="3qmy:~ClassLoaderManager.reloadModule(org.jetbrains.mps.openapi.module.SModule)" resolve="reloadModule" />
+                            <node concept="37vLTw" id="3NYwjf35oKh" role="37wK5m">
+                              <ref role="3cqZAo" node="3NYwjf358MV" resolve="module" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3NYwjf35c1t" role="ukAjM">
+                    <node concept="37vLTw" id="3NYwjf35c1u" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                    </node>
+                    <node concept="liA8E" id="3NYwjf35c1v" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3NYwjf354Bi" role="1B3o_S" />
+      <node concept="3cqZAl" id="3NYwjf355Aa" role="3clF45" />
+      <node concept="37vLTG" id="3NYwjf358MV" role="3clF46">
+        <property role="TrG5h" value="module" />
+        <node concept="3uibUv" id="3NYwjf358MU" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3NYwjf35u$5" role="jymVt" />
+    <node concept="3clFb_" id="3NYwjf35txY" role="jymVt">
+      <property role="TrG5h" value="reloadModules" />
+      <node concept="3clFbS" id="3NYwjf35txZ" role="3clF47">
+        <node concept="3clFbF" id="3NYwjf35ty0" role="3cqZAp">
+          <node concept="2YIFZM" id="3NYwjf35ty1" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="3NYwjf35ty2" role="37wK5m">
+              <node concept="3clFbS" id="3NYwjf35ty3" role="1bW5cS">
+                <node concept="1QHqEO" id="3NYwjf35ty4" role="3cqZAp">
+                  <node concept="1QHqEC" id="3NYwjf35ty5" role="1QHqEI">
+                    <node concept="3clFbS" id="3NYwjf35ty6" role="1bW5cS">
+                      <node concept="3cpWs8" id="3NYwjf35ty7" role="3cqZAp">
+                        <node concept="3cpWsn" id="3NYwjf35ty8" role="3cpWs9">
+                          <property role="TrG5h" value="classLoaderManager" />
+                          <node concept="3uibUv" id="3NYwjf35ty9" role="1tU5fm">
+                            <ref role="3uigEE" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                          </node>
+                          <node concept="2OqwBi" id="3NYwjf35tya" role="33vP2m">
+                            <node concept="37vLTw" id="3NYwjf35tyb" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                            </node>
+                            <node concept="liA8E" id="3NYwjf35tyc" role="2OqNvi">
+                              <ref role="37wK5l" to="z1c3:~Project.getComponent(java.lang.Class)" resolve="getComponent" />
+                              <node concept="3VsKOn" id="3NYwjf35tyd" role="37wK5m">
+                                <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3NYwjf35tye" role="3cqZAp">
+                        <node concept="2OqwBi" id="3NYwjf35tyf" role="3clFbG">
+                          <node concept="37vLTw" id="3NYwjf35tyg" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3NYwjf35ty8" resolve="classLoaderManager" />
+                          </node>
+                          <node concept="liA8E" id="3NYwjf35tyh" role="2OqNvi">
+                            <ref role="37wK5l" to="3qmy:~ClassLoaderManager.reloadModules(java.lang.Iterable)" resolve="reloadModules" />
+                            <node concept="37vLTw" id="3NYwjf35tyi" role="37wK5m">
+                              <ref role="3cqZAo" node="3NYwjf35tyo" resolve="modules" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3NYwjf35tyj" role="ukAjM">
+                    <node concept="37vLTw" id="3NYwjf35tyk" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                    </node>
+                    <node concept="liA8E" id="3NYwjf35tyl" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3NYwjf35tym" role="1B3o_S" />
+      <node concept="3cqZAl" id="3NYwjf35tyn" role="3clF45" />
+      <node concept="37vLTG" id="3NYwjf35tyo" role="3clF46">
+        <property role="TrG5h" value="modules" />
+        <node concept="3uibUv" id="3NYwjf35typ" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
+          <node concept="3qUE_q" id="3NYwjf35_lh" role="11_B2D">
+            <node concept="3uibUv" id="3NYwjf35ASp" role="3qUE_r">
+              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3NYwjf35D91" role="jymVt" />
+    <node concept="3clFb_" id="3NYwjf35BZK" role="jymVt">
+      <property role="TrG5h" value="reloadAll" />
+      <node concept="3clFbS" id="3NYwjf35BZL" role="3clF47">
+        <node concept="3clFbF" id="3NYwjf35BZM" role="3cqZAp">
+          <node concept="2YIFZM" id="3NYwjf35BZN" role="3clFbG">
+            <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+            <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+            <node concept="1bVj0M" id="3NYwjf35BZO" role="37wK5m">
+              <node concept="3clFbS" id="3NYwjf35BZP" role="1bW5cS">
+                <node concept="1QHqEO" id="3NYwjf35BZQ" role="3cqZAp">
+                  <node concept="1QHqEC" id="3NYwjf35BZR" role="1QHqEI">
+                    <node concept="3clFbS" id="3NYwjf35BZS" role="1bW5cS">
+                      <node concept="3cpWs8" id="3NYwjf35BZT" role="3cqZAp">
+                        <node concept="3cpWsn" id="3NYwjf35BZU" role="3cpWs9">
+                          <property role="TrG5h" value="classLoaderManager" />
+                          <node concept="3uibUv" id="3NYwjf35BZV" role="1tU5fm">
+                            <ref role="3uigEE" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                          </node>
+                          <node concept="2OqwBi" id="3NYwjf35BZW" role="33vP2m">
+                            <node concept="37vLTw" id="3NYwjf35BZX" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                            </node>
+                            <node concept="liA8E" id="3NYwjf35BZY" role="2OqNvi">
+                              <ref role="37wK5l" to="z1c3:~Project.getComponent(java.lang.Class)" resolve="getComponent" />
+                              <node concept="3VsKOn" id="3NYwjf35BZZ" role="37wK5m">
+                                <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="3NYwjf35C00" role="3cqZAp">
+                        <node concept="2OqwBi" id="3NYwjf35C01" role="3clFbG">
+                          <node concept="37vLTw" id="3NYwjf35C02" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3NYwjf35BZU" resolve="classLoaderManager" />
+                          </node>
+                          <node concept="liA8E" id="3NYwjf35C03" role="2OqNvi">
+                            <ref role="37wK5l" to="3qmy:~ClassLoaderManager.reloadAll(org.jetbrains.mps.openapi.util.ProgressMonitor)" resolve="reloadAll" />
+                            <node concept="2ShNRf" id="3NYwjf35Nwg" role="37wK5m">
+                              <node concept="1pGfFk" id="3NYwjf363MR" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="mk8z:~EmptyProgressMonitor.&lt;init&gt;()" resolve="EmptyProgressMonitor" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3NYwjf35C05" role="ukAjM">
+                    <node concept="37vLTw" id="3NYwjf35C06" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                    </node>
+                    <node concept="liA8E" id="3NYwjf35C07" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3NYwjf35C08" role="1B3o_S" />
+      <node concept="3cqZAl" id="3NYwjf35C09" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ1fex" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ2_bv" role="jymVt">
+      <property role="TrG5h" value="getOpenEditors" />
+      <node concept="3clFbS" id="5nwfWGQ2_b_" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ2_bA" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ2_bB" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="5nwfWGQ2_bC" role="1tU5fm">
+              <node concept="3uibUv" id="5nwfWGQ2_bD" role="_ZDj9">
+                <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ2_bE" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ2_bF" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ2_bG" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ2_bH" role="3cpWs9">
+            <property role="TrG5h" value="editors" />
+            <node concept="10Q1$e" id="5nwfWGQ2_bI" role="1tU5fm">
+              <node concept="3uibUv" id="5nwfWGQ2_bJ" role="10Q1$1">
+                <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5nwfWGQ2_bK" role="33vP2m">
+              <node concept="2YIFZM" id="5nwfWGQ2_bL" role="2Oq$k0">
+                <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <node concept="2YIFZM" id="5nwfWGQ2F7Q" role="37wK5m">
+                  <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                  <node concept="37vLTw" id="5nwfWGQ2FC4" role="37wK5m">
+                    <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5nwfWGQ2_bN" role="2OqNvi">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getAllEditors()" resolve="getAllEditors" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1DcWWT" id="5nwfWGQ2_bO" role="3cqZAp">
+          <node concept="37vLTw" id="5nwfWGQ2_bP" role="1DdaDG">
+            <ref role="3cqZAo" node="5nwfWGQ2_bH" resolve="editors" />
+          </node>
+          <node concept="3cpWsn" id="5nwfWGQ2_bQ" role="1Duv9x">
+            <property role="TrG5h" value="editor" />
+            <node concept="3uibUv" id="5nwfWGQ2_bR" role="1tU5fm">
+              <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="5nwfWGQ2_bS" role="2LFqv$">
+            <node concept="3clFbJ" id="5nwfWGQ2_bT" role="3cqZAp">
+              <node concept="2ZW3vV" id="5nwfWGQ2_bU" role="3clFbw">
+                <node concept="37vLTw" id="5nwfWGQ2_bV" role="2ZW6bz">
+                  <ref role="3cqZAo" node="5nwfWGQ2_bQ" resolve="editor" />
+                </node>
+                <node concept="3uibUv" id="5nwfWGQ2_bW" role="2ZW6by">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="5nwfWGQ2_bX" role="3clFbx">
+                <node concept="3cpWs8" id="5nwfWGQ2_bY" role="3cqZAp">
+                  <node concept="3cpWsn" id="5nwfWGQ2_bZ" role="3cpWs9">
+                    <property role="TrG5h" value="mpsEditor" />
+                    <node concept="3uibUv" id="5nwfWGQ2_c0" role="1tU5fm">
+                      <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                    </node>
+                    <node concept="10QFUN" id="5nwfWGQ2_c1" role="33vP2m">
+                      <node concept="37vLTw" id="5nwfWGQ2_c2" role="10QFUP">
+                        <ref role="3cqZAo" node="5nwfWGQ2_bQ" resolve="editor" />
+                      </node>
+                      <node concept="3uibUv" id="5nwfWGQ2_c3" role="10QFUM">
+                        <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="5nwfWGQ2_c4" role="3cqZAp">
+                  <node concept="3cpWsn" id="5nwfWGQ2_c5" role="3cpWs9">
+                    <property role="TrG5h" value="nodeEditor" />
+                    <node concept="3uibUv" id="5nwfWGQ2_c6" role="1tU5fm">
+                      <ref role="3uigEE" to="cj4x:~Editor" resolve="Editor" />
+                    </node>
+                    <node concept="2OqwBi" id="5nwfWGQ2_c7" role="33vP2m">
+                      <node concept="37vLTw" id="5nwfWGQ2_c8" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5nwfWGQ2_bZ" resolve="mpsEditor" />
+                      </node>
+                      <node concept="liA8E" id="5nwfWGQ2_c9" role="2OqNvi">
+                        <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getNodeEditor()" resolve="getNodeEditor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="5nwfWGQ2_ca" role="3cqZAp">
+                  <node concept="3y3z36" id="5nwfWGQ2_cb" role="3clFbw">
+                    <node concept="37vLTw" id="5nwfWGQ2_cc" role="3uHU7B">
+                      <ref role="3cqZAo" node="5nwfWGQ2_c5" resolve="nodeEditor" />
+                    </node>
+                    <node concept="10Nm6u" id="5nwfWGQ2_cd" role="3uHU7w" />
+                  </node>
+                  <node concept="3clFbS" id="5nwfWGQ2_ce" role="3clFbx">
+                    <node concept="3clFbF" id="5nwfWGQ2_cf" role="3cqZAp">
+                      <node concept="2OqwBi" id="5nwfWGQ2_cg" role="3clFbG">
+                        <node concept="37vLTw" id="5nwfWGQ2_ch" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5nwfWGQ2_bB" resolve="res" />
+                        </node>
+                        <node concept="TSZUe" id="5nwfWGQ2_ci" role="2OqNvi">
+                          <node concept="37vLTw" id="5nwfWGQ2_cj" role="25WWJ7">
+                            <ref role="3cqZAo" node="5nwfWGQ2_bZ" resolve="mpsEditor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5nwfWGQ2_ck" role="3cqZAp">
+          <node concept="37vLTw" id="5nwfWGQ2_cl" role="3cqZAk">
+            <ref role="3cqZAo" node="5nwfWGQ2_bB" resolve="res" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="5nwfWGQ2_cn" role="3clF45">
+        <node concept="3uibUv" id="5nwfWGQ2_co" role="_ZDj9">
+          <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5nwfWGQ2_bx" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ2_cm" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="2$zHkrOr12d" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ2H0Q" role="jymVt">
+      <property role="TrG5h" value="getActiveEditor" />
+      <node concept="3clFbS" id="5nwfWGQ2H0S" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ2H0T" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ2H0U" role="3cpWs9">
+            <property role="TrG5h" value="editor" />
+            <node concept="3uibUv" id="5nwfWGQ2H0V" role="1tU5fm">
+              <ref role="3uigEE" to="iwsx:~FileEditor" resolve="FileEditor" />
+            </node>
+            <node concept="2OqwBi" id="5nwfWGQ2H0W" role="33vP2m">
+              <node concept="2YIFZM" id="5nwfWGQ2H0X" role="2Oq$k0">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                <node concept="2YIFZM" id="5nwfWGQ2H0Y" role="37wK5m">
+                  <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                  <node concept="37vLTw" id="5nwfWGQ2HCH" role="37wK5m">
+                    <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5nwfWGQ2H0Z" role="2OqNvi">
+                <ref role="37wK5l" to="iwsx:~FileEditorManager.getSelectedEditor()" resolve="getSelectedEditor" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5nwfWGQ2H10" role="3cqZAp">
+          <node concept="3clFbS" id="5nwfWGQ2H11" role="3clFbx">
+            <node concept="3cpWs6" id="5nwfWGQ2H12" role="3cqZAp">
+              <node concept="0kSF2" id="5nwfWGQ2H13" role="3cqZAk">
+                <node concept="3uibUv" id="5nwfWGQ2H14" role="0kSFW">
+                  <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+                </node>
+                <node concept="37vLTw" id="5nwfWGQ2H15" role="0kSFX">
+                  <ref role="3cqZAo" node="5nwfWGQ2H0U" resolve="editor" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="5nwfWGQ2H16" role="3clFbw">
+            <node concept="3uibUv" id="5nwfWGQ2H17" role="2ZW6by">
+              <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            </node>
+            <node concept="37vLTw" id="5nwfWGQ2H18" role="2ZW6bz">
+              <ref role="3cqZAo" node="5nwfWGQ2H0U" resolve="editor" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5nwfWGQ2H19" role="3cqZAp" />
+        <node concept="3cpWs6" id="5nwfWGQ2H1a" role="3cqZAp">
+          <node concept="10Nm6u" id="5nwfWGQ2H1b" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="5nwfWGQ2H1d" role="3clF45">
+        <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ2H1c" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ3wHR" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ3xXM" role="jymVt">
+      <property role="TrG5h" value="closeOpenEditors" />
+      <node concept="3clFbS" id="5nwfWGQ3xXP" role="3clF47">
+        <node concept="3clFbF" id="2$zHkrOwwui" role="3cqZAp">
+          <node concept="2OqwBi" id="2$zHkrOwxIJ" role="3clFbG">
+            <node concept="2es0OD" id="2$zHkrOwzfa" role="2OqNvi">
+              <node concept="1bVj0M" id="2$zHkrOwzfc" role="23t8la">
+                <node concept="3clFbS" id="2$zHkrOwzfd" role="1bW5cS">
+                  <node concept="3clFbF" id="2$zHkrOwCQr" role="3cqZAp">
+                    <node concept="2OqwBi" id="2$zHkrOwBc5" role="3clFbG">
+                      <node concept="2YIFZM" id="2$zHkrOwArc" role="2Oq$k0">
+                        <ref role="1Pybhc" to="iwsx:~FileEditorManager" resolve="FileEditorManager" />
+                        <ref role="37wK5l" to="iwsx:~FileEditorManager.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+                        <node concept="2YIFZM" id="5nwfWGQ3A3O" role="37wK5m">
+                          <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                          <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                          <node concept="37vLTw" id="5nwfWGQ3AD_" role="37wK5m">
+                            <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="2$zHkrOwBnw" role="2OqNvi">
+                        <ref role="37wK5l" to="iwsx:~FileEditorManager.closeFile(com.intellij.openapi.vfs.VirtualFile)" resolve="closeFile" />
+                        <node concept="2OqwBi" id="2$zHkrOwDVt" role="37wK5m">
+                          <node concept="37vLTw" id="2$zHkrOwD4D" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2$zHkrOwzfe" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="2$zHkrOwF4s" role="2OqNvi">
+                            <ref role="37wK5l" to="k3nr:~MPSFileNodeEditor.getFile()" resolve="getFile" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="2$zHkrOwzfe" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="2$zHkrOwzff" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="5nwfWGQ3zZm" role="2Oq$k0">
+              <ref role="37wK5l" node="5nwfWGQ2_bv" resolve="getOpenEditors" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ3xl8" role="1B3o_S" />
+      <node concept="3cqZAl" id="5nwfWGQ3xSb" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ6VQP" role="jymVt" />
+    <node concept="3clFb_" id="5nwfWGQ13On" role="jymVt">
+      <property role="TrG5h" value="assertEditorNotBroken" />
+      <node concept="3clFbS" id="5nwfWGQ13Op" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ13Oq" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ13Or" role="3cpWs9">
+            <property role="TrG5h" value="latch" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="5nwfWGQ13Os" role="1tU5fm">
+              <ref role="3uigEE" to="5zyv:~CountDownLatch" resolve="CountDownLatch" />
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ13Ot" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ13Ou" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="5zyv:~CountDownLatch.&lt;init&gt;(int)" resolve="CountDownLatch" />
+                <node concept="3cmrfG" id="5nwfWGQ13Ov" role="37wK5m">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5nwfWGQ13Ow" role="3cqZAp" />
+        <node concept="3cpWs8" id="5nwfWGQ13Ox" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ13Oy" role="3cpWs9">
+            <property role="TrG5h" value="component" />
+            <node concept="3uibUv" id="5nwfWGQ13Oz" role="1tU5fm">
+              <ref role="3uigEE" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ13O$" role="33vP2m">
+              <node concept="YeOm9" id="5nwfWGQ13O_" role="2ShVmc">
+                <node concept="1Y3b0j" id="5nwfWGQ13OA" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="7a0s:2iNJDZP2RE6" resolve="HeadlessEditorComponent" />
+                  <ref role="1Y3XeK" to="7a0s:6qGpHl7IHpK" resolve="HeadlessEditorComponent" />
+                  <node concept="3Tm1VV" id="5nwfWGQ13OB" role="1B3o_S" />
+                  <node concept="3clFb_" id="5nwfWGQ13OC" role="jymVt">
+                    <property role="TrG5h" value="getMessageHandler" />
+                    <node concept="3Tm1VV" id="5nwfWGQ13OD" role="1B3o_S" />
+                    <node concept="2AHcQZ" id="5nwfWGQ13OE" role="2AJF6D">
+                      <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                    </node>
+                    <node concept="3uibUv" id="5nwfWGQ13OF" role="3clF45">
+                      <ref role="3uigEE" to="et5u:~IMessageHandler" resolve="IMessageHandler" />
+                    </node>
+                    <node concept="3clFbS" id="5nwfWGQ13OG" role="3clF47">
+                      <node concept="3clFbF" id="5nwfWGQ13OH" role="3cqZAp">
+                        <node concept="2ShNRf" id="5nwfWGQ13OI" role="3clFbG">
+                          <node concept="YeOm9" id="5nwfWGQ13OJ" role="2ShVmc">
+                            <node concept="1Y3b0j" id="5nwfWGQ13OK" role="YeSDq">
+                              <property role="2bfB8j" value="true" />
+                              <property role="373rjd" value="true" />
+                              <ref role="1Y3XeK" to="et5u:~IMessageHandler" resolve="IMessageHandler" />
+                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                              <node concept="3Tm1VV" id="5nwfWGQ13OL" role="1B3o_S" />
+                              <node concept="3clFb_" id="5nwfWGQ13OM" role="jymVt">
+                                <property role="TrG5h" value="handle" />
+                                <node concept="3Tm1VV" id="5nwfWGQ13ON" role="1B3o_S" />
+                                <node concept="3cqZAl" id="5nwfWGQ13OO" role="3clF45" />
+                                <node concept="37vLTG" id="5nwfWGQ13OP" role="3clF46">
+                                  <property role="TrG5h" value="message" />
+                                  <node concept="3uibUv" id="5nwfWGQ13OQ" role="1tU5fm">
+                                    <ref role="3uigEE" to="et5u:~IMessage" resolve="IMessage" />
+                                  </node>
+                                  <node concept="2AHcQZ" id="5nwfWGQ13OR" role="2AJF6D">
+                                    <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+                                  </node>
+                                </node>
+                                <node concept="3clFbS" id="5nwfWGQ13OS" role="3clF47">
+                                  <node concept="3clFbJ" id="5nwfWGQ13OT" role="3cqZAp">
+                                    <node concept="3clFbS" id="5nwfWGQ13OU" role="3clFbx">
+                                      <node concept="3clFbF" id="5nwfWGQ13OV" role="3cqZAp">
+                                        <node concept="2OqwBi" id="5nwfWGQ13OW" role="3clFbG">
+                                          <node concept="37vLTw" id="5nwfWGQ13OX" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="5nwfWGQ13Or" resolve="latch" />
+                                          </node>
+                                          <node concept="liA8E" id="5nwfWGQ13OY" role="2OqNvi">
+                                            <ref role="37wK5l" to="5zyv:~CountDownLatch.countDown()" resolve="countDown" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2OqwBi" id="5nwfWGQ13OZ" role="3clFbw">
+                                      <node concept="2OqwBi" id="5nwfWGQ13P0" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5nwfWGQ13P1" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5nwfWGQ13OP" resolve="message" />
+                                        </node>
+                                        <node concept="liA8E" id="5nwfWGQ13P2" role="2OqNvi">
+                                          <ref role="37wK5l" to="et5u:~IMessage.getText()" resolve="getText" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="5nwfWGQ13P3" role="2OqNvi">
+                                        <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                                        <node concept="Xl_RD" id="5nwfWGQ13P4" role="37wK5m">
+                                          <property role="Xl_RC" value="Error creating editor cell" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2AHcQZ" id="5nwfWGQ13P5" role="2AJF6D">
+                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2AHcQZ" id="5nwfWGQ13P6" role="2AJF6D">
+                      <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="5nwfWGQ7048" role="37wK5m">
+                    <node concept="37vLTw" id="5nwfWGQ6YB3" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6HRhZeXG2xv" resolve="project" />
+                    </node>
+                    <node concept="liA8E" id="5nwfWGQ71PT" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5nwfWGQ13P8" role="3cqZAp">
+          <node concept="2OqwBi" id="5nwfWGQ13P9" role="3clFbG">
+            <node concept="37vLTw" id="5nwfWGQ13Pa" role="2Oq$k0">
+              <ref role="3cqZAo" node="5nwfWGQ13Oy" resolve="component" />
+            </node>
+            <node concept="liA8E" id="5nwfWGQ13Pb" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.editNode(org.jetbrains.mps.openapi.model.SNode)" resolve="editNode" />
+              <node concept="37vLTw" id="5nwfWGQ13Pc" role="37wK5m">
+                <ref role="3cqZAo" node="5nwfWGQ13PE" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5nwfWGQ13Pd" role="3cqZAp" />
+        <node concept="3cpWs8" id="5nwfWGQ13Pe" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ13Pf" role="3cpWs9">
+            <property role="TrG5h" value="invoked" />
+            <node concept="10P_77" id="5nwfWGQ13Pg" role="1tU5fm" />
+            <node concept="3clFbT" id="5nwfWGQ13Ph" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3J1_TO" id="5nwfWGQ13Pi" role="3cqZAp">
+          <node concept="3clFbS" id="5nwfWGQ13Pj" role="1zxBo7">
+            <node concept="3clFbF" id="5nwfWGQ13Pk" role="3cqZAp">
+              <node concept="37vLTI" id="5nwfWGQ13Pl" role="3clFbG">
+                <node concept="2OqwBi" id="5nwfWGQ13Pm" role="37vLTx">
+                  <node concept="37vLTw" id="5nwfWGQ13Pn" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5nwfWGQ13Or" resolve="latch" />
+                  </node>
+                  <node concept="liA8E" id="5nwfWGQ13Po" role="2OqNvi">
+                    <ref role="37wK5l" to="5zyv:~CountDownLatch.await(long,java.util.concurrent.TimeUnit)" resolve="await" />
+                    <node concept="3cmrfG" id="5nwfWGQ13Pp" role="37wK5m">
+                      <property role="3cmrfH" value="100" />
+                    </node>
+                    <node concept="Rm8GO" id="5nwfWGQ13Pq" role="37wK5m">
+                      <ref role="Rm8GQ" to="5zyv:~TimeUnit.MILLISECONDS" resolve="MILLISECONDS" />
+                      <ref role="1Px2BO" to="5zyv:~TimeUnit" resolve="TimeUnit" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5nwfWGQ13Pr" role="37vLTJ">
+                  <ref role="3cqZAo" node="5nwfWGQ13Pf" resolve="invoked" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="5nwfWGQ13Ps" role="1zxBo5">
+            <node concept="3clFbS" id="5nwfWGQ13Pt" role="1zc67A">
+              <node concept="3xETmq" id="5nwfWGQ13Pu" role="3cqZAp">
+                <node concept="3_1$Yv" id="5nwfWGQ13Pv" role="3_9lra">
+                  <node concept="2OqwBi" id="5nwfWGQ13Pw" role="3_1BAH">
+                    <node concept="37vLTw" id="5nwfWGQ13Px" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nwfWGQ13Pz" resolve="e" />
+                    </node>
+                    <node concept="liA8E" id="5nwfWGQ13Py" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="XOnhg" id="5nwfWGQ13Pz" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="5nwfWGQ13P$" role="1tU5fm">
+                <node concept="3uibUv" id="5nwfWGQ13P_" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~InterruptedException" resolve="InterruptedException" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="5nwfWGQ13PA" role="3cqZAp">
+          <node concept="37vLTw" id="5nwfWGQ13PB" role="3vFALc">
+            <ref role="3cqZAo" node="5nwfWGQ13Pf" resolve="invoked" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="5nwfWGQ13PD" role="3clF45" />
+      <node concept="37vLTG" id="5nwfWGQ13PE" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="5nwfWGQ13PF" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ13PC" role="1B3o_S" />
+      <node concept="3uibUv" id="5nwfWGQa7MP" role="Sfmx6">
+        <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5nwfWGQ6VQQ" role="jymVt" />
+    <node concept="3Tm1VV" id="6HRhZeXG282" role="1B3o_S" />
+    <node concept="3UR2Jj" id="6HRhZeXG7KV" role="lGtFl">
+      <node concept="TZ5HA" id="6HRhZeXG7KW" role="TZ5H$">
+        <node concept="1dT_AC" id="6HRhZeXG7KX" role="1dT_Ay">
+          <property role="1dT_AB" value="This class can be called from places where there is no write/read access to the model like editor node test cases." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5nwfWGQ2Sfl">
+    <property role="3GE5qa" value="" />
+    <property role="TrG5h" value="TypesystemTestUtil" />
+    <node concept="2tJIrI" id="5nwfWGQ30hu" role="jymVt" />
+    <node concept="2YIFZL" id="5nwfWGQ31Bx" role="jymVt">
+      <property role="TrG5h" value="measureTypesystemPerformance" />
+      <node concept="3clFbS" id="5nwfWGQ31B$" role="3clF47">
+        <node concept="3cpWs8" id="5nwfWGQ31B_" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ31BA" role="3cpWs9">
+            <property role="TrG5h" value="structureChecker" />
+            <node concept="3uibUv" id="5nwfWGQ31BB" role="1tU5fm">
+              <ref role="3uigEE" to="wsw7:4r$i1_aEwSg" resolve="IChecker" />
+              <node concept="3uibUv" id="5nwfWGQ31BC" role="11_B2D">
+                <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+              </node>
+              <node concept="3uibUv" id="5nwfWGQ31BD" role="11_B2D">
+                <ref role="3uigEE" to="d6hs:~NodeReportItem" resolve="NodeReportItem" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="5nwfWGQ31BE" role="33vP2m">
+              <node concept="1pGfFk" id="5nwfWGQ31BF" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="6if8:~StructureChecker.&lt;init&gt;()" resolve="StructureChecker" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ31BG" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ31BH" role="3cpWs9">
+            <property role="TrG5h" value="startTime" />
+            <node concept="3cpWsb" id="5nwfWGQ31BI" role="1tU5fm" />
+            <node concept="2YIFZM" id="5nwfWGQ31BJ" role="33vP2m">
+              <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+              <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ31BK" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ31BL" role="3cpWs9">
+            <property role="TrG5h" value="checker" />
+            <node concept="3uibUv" id="5nwfWGQ31BM" role="1tU5fm">
+              <ref role="3uigEE" to="wsw7:3xfDcbRbJai" resolve="IAbstractChecker" />
+              <node concept="3uibUv" id="5nwfWGQ31BN" role="11_B2D">
+                <ref role="3uigEE" to="wsw7:4QJbmJH1Aa8" resolve="ModelCheckerBuilder.ItemsToCheck" />
+              </node>
+              <node concept="3uibUv" id="5nwfWGQ31BO" role="11_B2D">
+                <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5nwfWGQ31BP" role="33vP2m">
+              <node concept="2ShNRf" id="5nwfWGQ31BQ" role="2Oq$k0">
+                <node concept="1pGfFk" id="5nwfWGQ31BR" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wsw7:6nj_ILmBNrL" resolve="ModelCheckerBuilder" />
+                  <node concept="2OqwBi" id="5nwfWGQ31BS" role="37wK5m">
+                    <node concept="2ShNRf" id="5nwfWGQ31BT" role="2Oq$k0">
+                      <node concept="1pGfFk" id="5nwfWGQ31BU" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="wsw7:6pnunaLnyyn" resolve="ModelCheckerBuilder.ModelsExtractorImpl" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="5nwfWGQ31BV" role="2OqNvi">
+                      <ref role="37wK5l" to="wsw7:34euvBSCGJN" resolve="includeStubs" />
+                      <node concept="3clFbT" id="5nwfWGQ31BW" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="5nwfWGQ31BX" role="2OqNvi">
+                <ref role="37wK5l" to="wsw7:6bXa3O$aFCh" resolve="createChecker" />
+                <node concept="2ShNRf" id="5nwfWGQ31BY" role="37wK5m">
+                  <node concept="Tc6Ow" id="5nwfWGQ31BZ" role="2ShVmc">
+                    <node concept="3uibUv" id="5nwfWGQ31C0" role="HW$YZ">
+                      <ref role="3uigEE" to="wsw7:4r$i1_aEwSg" resolve="IChecker" />
+                      <node concept="3qTvmN" id="5nwfWGQ31C1" role="11_B2D" />
+                      <node concept="3qUE_q" id="5nwfWGQ31C2" role="11_B2D">
+                        <node concept="3uibUv" id="5nwfWGQ31C3" role="3qUE_r">
+                          <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5nwfWGQ31C4" role="HW$Y0">
+                      <ref role="3cqZAo" node="5nwfWGQ31BA" resolve="structureChecker" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5nwfWGQ31C5" role="3cqZAp">
+          <node concept="2OqwBi" id="5nwfWGQ31C6" role="3clFbG">
+            <node concept="37vLTw" id="5nwfWGQ31C7" role="2Oq$k0">
+              <ref role="3cqZAo" node="5nwfWGQ31BL" resolve="checker" />
+            </node>
+            <node concept="liA8E" id="5nwfWGQ31C8" role="2OqNvi">
+              <ref role="37wK5l" to="wsw7:4SGXHKgYYAZ" resolve="check" />
+              <node concept="2YIFZM" id="5nwfWGQ31C9" role="37wK5m">
+                <ref role="37wK5l" to="wsw7:fM_JX6ud1s" resolve="forSingleModel" />
+                <ref role="1Pybhc" to="wsw7:4QJbmJH1Aa8" resolve="ModelCheckerBuilder.ItemsToCheck" />
+                <node concept="37vLTw" id="5nwfWGQ31Ca" role="37wK5m">
+                  <ref role="3cqZAo" node="5nwfWGQ31Cu" resolve="model" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5nwfWGQ31Cb" role="37wK5m">
+                <node concept="2JrnkZ" id="5nwfWGQ31Cc" role="2Oq$k0">
+                  <node concept="37vLTw" id="5nwfWGQ31Cd" role="2JrQYb">
+                    <ref role="3cqZAo" node="5nwfWGQ31Cu" resolve="model" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5nwfWGQ31Ce" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5nwfWGQ31Cf" role="37wK5m">
+                <node concept="1pGfFk" id="5nwfWGQ31Cg" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="18ew:~CollectConsumer.&lt;init&gt;()" resolve="CollectConsumer" />
+                  <node concept="3uibUv" id="5nwfWGQ31Ch" role="1pMfVU">
+                    <ref role="3uigEE" to="d6hs:~IssueKindReportItem" resolve="IssueKindReportItem" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ShNRf" id="5nwfWGQ31Ci" role="37wK5m">
+                <node concept="1pGfFk" id="5nwfWGQ31Cj" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="mk8z:~EmptyProgressMonitor.&lt;init&gt;()" resolve="EmptyProgressMonitor" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5nwfWGQ31Ck" role="3cqZAp">
+          <node concept="3cpWsn" id="5nwfWGQ31Cl" role="3cpWs9">
+            <property role="TrG5h" value="stopTime" />
+            <node concept="3cpWsb" id="5nwfWGQ31Cm" role="1tU5fm" />
+            <node concept="2YIFZM" id="5nwfWGQ31Cn" role="33vP2m">
+              <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+              <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5nwfWGQ31Co" role="3cqZAp">
+          <node concept="2YIFZM" id="5nwfWGQ31Cp" role="3cqZAk">
+            <ref role="37wK5l" to="28m1:~Duration.ofNanos(long)" resolve="ofNanos" />
+            <ref role="1Pybhc" to="28m1:~Duration" resolve="Duration" />
+            <node concept="3cpWsd" id="5nwfWGQ31Cq" role="37wK5m">
+              <node concept="37vLTw" id="5nwfWGQ31Cr" role="3uHU7w">
+                <ref role="3cqZAo" node="5nwfWGQ31BH" resolve="startTime" />
+              </node>
+              <node concept="37vLTw" id="5nwfWGQ31Cs" role="3uHU7B">
+                <ref role="3cqZAo" node="5nwfWGQ31Cl" resolve="stopTime" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5nwfWGQ31Bz" role="3clF45">
+        <ref role="3uigEE" to="28m1:~Duration" resolve="Duration" />
+      </node>
+      <node concept="37vLTG" id="5nwfWGQ31Cu" role="3clF46">
+        <property role="TrG5h" value="model" />
+        <node concept="H_c77" id="5nwfWGQ31Cv" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="5nwfWGQ31Ct" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="5nwfWGQ2Sfm" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="6J17ghv7mbt">
+    <property role="TrG5h" value="ProcessRunnerForConfigurationTests" />
+    <property role="2bfB8j" value="true" />
+    <property role="3GE5qa" value="mpsPlatform" />
+    <node concept="3Tm1VV" id="6J17ghv7mbu" role="1B3o_S" />
+    <node concept="312cEg" id="6J17ghv7mhG" role="jymVt">
+      <property role="TrG5h" value="myProcess" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6J17ghv7mhI" role="1tU5fm">
+        <ref role="3uigEE" to="uu3z:~ProcessHandler" resolve="ProcessHandler" />
+      </node>
+      <node concept="3Tm6S6" id="6J17ghv7mhJ" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6J17ghv7mhK" role="jymVt">
+      <property role="TrG5h" value="myAllowedErrorPatterns" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6J17ghv7mhM" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+        <node concept="3uibUv" id="6J17ghv7mhN" role="11_B2D">
+          <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6J17ghv7mhO" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6J17ghv7mhP" role="jymVt">
+      <property role="TrG5h" value="myExpectedPatterns" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6J17ghv7mhR" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+        <node concept="3uibUv" id="6J17ghv7mhS" role="11_B2D">
+          <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6J17ghv7mhT" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6J17ghv7mhU" role="jymVt">
+      <property role="TrG5h" value="myExitPatterns" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="6J17ghv7mhW" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+        <node concept="3uibUv" id="6J17ghv7mhX" role="11_B2D">
+          <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6J17ghv7mhY" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6J17ghv7mhZ" role="jymVt">
+      <property role="TrG5h" value="myExitCodeMustBeZero" />
+      <property role="3TUv4t" value="true" />
+      <node concept="10P_77" id="6J17ghv7mi1" role="1tU5fm" />
+      <node concept="3Tm6S6" id="6J17ghv7mi2" role="1B3o_S" />
+    </node>
+    <node concept="312cEg" id="6J17ghv7mi3" role="jymVt">
+      <property role="TrG5h" value="myTimeOut" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3cpWsb" id="6J17ghv7mi5" role="1tU5fm" />
+      <node concept="3Tm6S6" id="6J17ghv7mi6" role="1B3o_S" />
+    </node>
+    <node concept="3clFbW" id="6J17ghv7mi7" role="jymVt">
+      <node concept="3cqZAl" id="6J17ghv7mi8" role="3clF45" />
+      <node concept="37vLTG" id="6J17ghv7mi9" role="3clF46">
+        <property role="TrG5h" value="process" />
+        <node concept="2AHcQZ" id="6J17ghv7mia" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="6J17ghv7mib" role="1tU5fm">
+          <ref role="3uigEE" to="uu3z:~ProcessHandler" resolve="ProcessHandler" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6J17ghv7mic" role="3clF46">
+        <property role="TrG5h" value="expectedPatterns" />
+        <node concept="2AHcQZ" id="6J17ghv7mid" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="6J17ghv7mie" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mif" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6J17ghv7mig" role="3clF46">
+        <property role="TrG5h" value="allowedErrorPatterns" />
+        <node concept="2AHcQZ" id="6J17ghv7mih" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="6J17ghv7mii" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mij" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6J17ghv7mik" role="3clF46">
+        <property role="TrG5h" value="exitPatterns" />
+        <node concept="2AHcQZ" id="6J17ghv7mil" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3uibUv" id="6J17ghv7mim" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7min" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6J17ghv7mio" role="3clF46">
+        <property role="TrG5h" value="exitCodeMustBeZero" />
+        <node concept="10P_77" id="6J17ghv7mip" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6J17ghv7miq" role="3clF46">
+        <property role="TrG5h" value="timeOut" />
+        <node concept="3cpWsb" id="6J17ghv7mir" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="6J17ghv7mis" role="3clF47">
+        <node concept="3clFbF" id="6J17ghv7mit" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miu" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miv" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mhG" resolve="myProcess" />
+            </node>
+            <node concept="37vLTw" id="6J17ghv7miw" role="37vLTx">
+              <ref role="3cqZAo" node="6J17ghv7mi9" resolve="process" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7mix" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miy" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miz" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mi3" resolve="myTimeOut" />
+            </node>
+            <node concept="37vLTw" id="6J17ghv7mi$" role="37vLTx">
+              <ref role="3cqZAo" node="6J17ghv7miq" resolve="timeOut" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7mi_" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miA" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miB" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mhZ" resolve="myExitCodeMustBeZero" />
+            </node>
+            <node concept="37vLTw" id="6J17ghv7miC" role="37vLTx">
+              <ref role="3cqZAo" node="6J17ghv7mio" resolve="exitCodeMustBeZero" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7miD" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miE" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miF" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mhK" resolve="myAllowedErrorPatterns" />
+            </node>
+            <node concept="2OqwBi" id="6J17ghva_mS" role="37vLTx">
+              <node concept="2OqwBi" id="6J17ghvaq7s" role="2Oq$k0">
+                <node concept="2YIFZM" id="6J17ghvafUZ" role="2Oq$k0">
+                  <ref role="37wK5l" to="1ctc:~Stream.concat(java.util.stream.Stream,java.util.stream.Stream)" resolve="concat" />
+                  <ref role="1Pybhc" to="1ctc:~Stream" resolve="Stream" />
+                  <node concept="2OqwBi" id="6J17ghvagIr" role="37wK5m">
+                    <node concept="37vLTw" id="6J17ghvagIs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mig" resolve="allowedErrorPatterns" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghvagIt" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6J17ghvalFl" role="37wK5m">
+                    <node concept="37vLTw" id="6J17ghvajgs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mic" resolve="expectedPatterns" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghvaoz5" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="6J17ghvas$_" role="2OqNvi">
+                  <ref role="37wK5l" to="1ctc:~Stream.distinct()" resolve="distinct" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6J17ghvaC25" role="2OqNvi">
+                <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                <node concept="2YIFZM" id="6J17ghvaDkt" role="37wK5m">
+                  <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                  <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
+                  <node concept="3uibUv" id="6J17ghvaDku" role="3PaCim">
+                    <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7miN" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miO" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miP" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mhP" resolve="myExpectedPatterns" />
+            </node>
+            <node concept="2OqwBi" id="6J17ghv8dTH" role="37vLTx">
+              <node concept="2OqwBi" id="6J17ghv89Mp" role="2Oq$k0">
+                <node concept="2OqwBi" id="6J17ghv7EG$" role="2Oq$k0">
+                  <node concept="37vLTw" id="6J17ghv7z10" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6J17ghv7mic" resolve="expectedPatterns" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv7EG_" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="6J17ghv89Mq" role="2OqNvi">
+                  <ref role="37wK5l" to="1ctc:~Stream.distinct()" resolve="distinct" />
+                </node>
+              </node>
+              <node concept="liA8E" id="6J17ghv8dTI" role="2OqNvi">
+                <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                <node concept="2YIFZM" id="6J17ghv8dTJ" role="37wK5m">
+                  <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                  <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
+                  <node concept="3uibUv" id="6J17ghv8dTK" role="3PaCim">
+                    <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7miV" role="3cqZAp">
+          <node concept="37vLTI" id="6J17ghv7miW" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7miX" role="37vLTJ">
+              <ref role="3cqZAo" node="6J17ghv7mhU" resolve="myExitPatterns" />
+            </node>
+            <node concept="37vLTw" id="6J17ghv7miY" role="37vLTx">
+              <ref role="3cqZAo" node="6J17ghv7mik" resolve="exitPatterns" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6J17ghv7miZ" role="1B3o_S" />
+    </node>
+    <node concept="312cEu" id="6J17ghv7mbv" role="jymVt">
+      <property role="TrG5h" value="Builder" />
+      <property role="1EXbeo" value="true" />
+      <node concept="3Tm1VV" id="6J17ghv7mbw" role="1B3o_S" />
+      <node concept="312cEg" id="6J17ghv7mbx" role="jymVt">
+        <property role="TrG5h" value="myProcess" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mbz" role="1tU5fm">
+          <ref role="3uigEE" to="uu3z:~ProcessHandler" resolve="ProcessHandler" />
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mb$" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mb_" role="jymVt">
+        <property role="TrG5h" value="myAllowedErrorPatterns" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mbB" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mbC" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z4$" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z4D" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+            <node concept="3uibUv" id="6J17ghv7z4E" role="1pMfVU">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mbF" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mbG" role="jymVt">
+        <property role="TrG5h" value="myExpectedPatterns" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mbI" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mbJ" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z5S" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z5X" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+            <node concept="3uibUv" id="6J17ghv7z5Y" role="1pMfVU">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mbM" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mbN" role="jymVt">
+        <property role="TrG5h" value="myExitPatterns" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mbP" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mbQ" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z6a" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z6f" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+            <node concept="3uibUv" id="6J17ghv7z6g" role="1pMfVU">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mbT" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mbU" role="jymVt">
+        <property role="TrG5h" value="myExitCodeMustBeZero" />
+        <node concept="10P_77" id="6J17ghv7mbW" role="1tU5fm" />
+        <node concept="3clFbT" id="6J17ghv7mbX" role="33vP2m">
+          <property role="3clFbU" value="true" />
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mbY" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mbZ" role="jymVt">
+        <property role="TrG5h" value="myTimeOut" />
+        <node concept="3cpWsb" id="6J17ghv7mc1" role="1tU5fm" />
+        <node concept="2OqwBi" id="6J17ghv7Dz$" role="33vP2m">
+          <node concept="Rm8GO" id="6J17ghv7z3D" role="2Oq$k0">
+            <ref role="1Px2BO" to="5zyv:~TimeUnit" resolve="TimeUnit" />
+            <ref role="Rm8GQ" to="5zyv:~TimeUnit.SECONDS" resolve="SECONDS" />
+          </node>
+          <node concept="liA8E" id="6J17ghv7Dz_" role="2OqNvi">
+            <ref role="37wK5l" to="5zyv:~TimeUnit.toMillis(long)" resolve="toMillis" />
+            <node concept="3cmrfG" id="6J17ghv7DzA" role="37wK5m">
+              <property role="3cmrfH" value="150" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mc4" role="1B3o_S" />
+      </node>
+      <node concept="3clFbW" id="6J17ghv7mc5" role="jymVt">
+        <node concept="3cqZAl" id="6J17ghv7mc6" role="3clF45" />
+        <node concept="37vLTG" id="6J17ghv7mc7" role="3clF46">
+          <property role="TrG5h" value="process" />
+          <node concept="2AHcQZ" id="6J17ghv7mc8" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="6J17ghv7mc9" role="1tU5fm">
+            <ref role="3uigEE" to="uu3z:~ProcessHandler" resolve="ProcessHandler" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mca" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7mcb" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7mcc" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7mcd" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7mbx" resolve="myProcess" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv7mce" role="37vLTx">
+                <ref role="3cqZAo" node="6J17ghv7mc7" resolve="process" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mcf" role="1B3o_S" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mcg" role="jymVt">
+        <property role="TrG5h" value="setTimeOut" />
+        <node concept="37vLTG" id="6J17ghv7mch" role="3clF46">
+          <property role="TrG5h" value="millis" />
+          <node concept="3cpWsb" id="6J17ghv7mci" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mcj" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7mck" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7mcl" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7mcm" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7mbZ" resolve="myTimeOut" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv7mcn" role="37vLTx">
+                <ref role="3cqZAo" node="6J17ghv7mch" resolve="millis" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mco" role="3cqZAp">
+            <node concept="Xjq3P" id="6J17ghv7mcp" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mcq" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mcr" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbv" resolve="ProcessRunnerForConfigurationTests.Builder" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mcs" role="jymVt">
+        <property role="TrG5h" value="addExpectedPaterns" />
+        <node concept="37vLTG" id="6J17ghv7mct" role="3clF46">
+          <property role="TrG5h" value="expectedPatterns" />
+          <node concept="2AHcQZ" id="6J17ghv7mcu" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="6J17ghv7mcv" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+            <node concept="3uibUv" id="6J17ghv7mcw" role="11_B2D">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mcx" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7mcy" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7Cte" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7z9c" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mbG" resolve="myExpectedPatterns" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Ctf" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                <node concept="37vLTw" id="6J17ghv7Ctg" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mct" resolve="expectedPatterns" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mc_" role="3cqZAp">
+            <node concept="Xjq3P" id="6J17ghv7mcA" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mcB" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mcC" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbv" resolve="ProcessRunnerForConfigurationTests.Builder" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mcD" role="jymVt">
+        <property role="TrG5h" value="addAllowedErrorPaterns" />
+        <node concept="37vLTG" id="6J17ghv7mcE" role="3clF46">
+          <property role="TrG5h" value="allowedErrorPatterns" />
+          <node concept="2AHcQZ" id="6J17ghv7mcF" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="6J17ghv7mcG" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+            <node concept="3uibUv" id="6J17ghv7mcH" role="11_B2D">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mcI" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7mcJ" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7YOL" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7z3K" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mb_" resolve="myAllowedErrorPatterns" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7YOM" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                <node concept="37vLTw" id="6J17ghv7YON" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mcE" resolve="allowedErrorPatterns" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mcM" role="3cqZAp">
+            <node concept="Xjq3P" id="6J17ghv7mcN" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mcO" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mcP" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbv" resolve="ProcessRunnerForConfigurationTests.Builder" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mcQ" role="jymVt">
+        <property role="TrG5h" value="addExitPaterns" />
+        <node concept="37vLTG" id="6J17ghv7mcR" role="3clF46">
+          <property role="TrG5h" value="exitPatterns" />
+          <node concept="2AHcQZ" id="6J17ghv7mcS" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+          <node concept="3uibUv" id="6J17ghv7mcT" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~List" resolve="List" />
+            <node concept="3uibUv" id="6J17ghv7mcU" role="11_B2D">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mcV" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7mcW" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7Wtj" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7z65" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mbN" resolve="myExitPatterns" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Wtk" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                <node concept="37vLTw" id="6J17ghv7Wtl" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mcR" resolve="exitPatterns" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mcZ" role="3cqZAp">
+            <node concept="Xjq3P" id="6J17ghv7md0" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7md1" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7md2" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbv" resolve="ProcessRunnerForConfigurationTests.Builder" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7md3" role="jymVt">
+        <property role="TrG5h" value="exitCodeMustBeZero" />
+        <node concept="37vLTG" id="6J17ghv7md4" role="3clF46">
+          <property role="TrG5h" value="value" />
+          <node concept="10P_77" id="6J17ghv7md5" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7md6" role="3clF47">
+          <node concept="3clFbF" id="6J17ghv7md7" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7md8" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7md9" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7mbU" resolve="myExitCodeMustBeZero" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv7mda" role="37vLTx">
+                <ref role="3cqZAo" node="6J17ghv7md4" resolve="value" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mdb" role="3cqZAp">
+            <node concept="Xjq3P" id="6J17ghv7mdc" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mdd" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mde" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbv" resolve="ProcessRunnerForConfigurationTests.Builder" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mdf" role="jymVt">
+        <property role="TrG5h" value="build" />
+        <node concept="2AHcQZ" id="6J17ghv7mdg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mdh" role="3clF47">
+          <node concept="3cpWs6" id="6J17ghv7mdi" role="3cqZAp">
+            <node concept="2ShNRf" id="6J17ghv7z7s" role="3cqZAk">
+              <node concept="1pGfFk" id="6J17ghv7z7F" role="2ShVmc">
+                <ref role="37wK5l" node="6J17ghv7mi7" resolve="ProcessRunnerForConfigurationTests" />
+                <node concept="37vLTw" id="6J17ghv7z7G" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mbx" resolve="myProcess" />
+                </node>
+                <node concept="37vLTw" id="6J17ghv7z7H" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mbG" resolve="myExpectedPatterns" />
+                </node>
+                <node concept="37vLTw" id="6J17ghv7z7I" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mb_" resolve="myAllowedErrorPatterns" />
+                </node>
+                <node concept="37vLTw" id="6J17ghv7z7J" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mbN" resolve="myExitPatterns" />
+                </node>
+                <node concept="37vLTw" id="6J17ghv7z7K" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mbU" resolve="myExitCodeMustBeZero" />
+                </node>
+                <node concept="37vLTw" id="6J17ghv7z7L" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mbZ" resolve="myTimeOut" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7mdq" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mdr" role="3clF45">
+          <ref role="3uigEE" node="6J17ghv7mbt" resolve="ProcessRunnerForConfigurationTests" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="6J17ghv7mj0" role="jymVt">
+      <property role="TrG5h" value="startAndCheckProcess" />
+      <node concept="3clFbS" id="6J17ghv7mj1" role="3clF47">
+        <node concept="3cpWs8" id="6J17ghv7mj3" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv7mj2" role="3cpWs9">
+            <property role="TrG5h" value="listenerParsingOutput" />
+            <node concept="3uibUv" id="6J17ghv7mj4" role="1tU5fm">
+              <ref role="3uigEE" node="6J17ghv7mds" resolve="ProcessRunnerForConfigurationTests.ProcessListenerWhichParsesOutput" />
+            </node>
+            <node concept="2ShNRf" id="6J17ghv7z2H" role="33vP2m">
+              <node concept="HV5vD" id="6J17ghv7z2J" role="2ShVmc">
+                <ref role="HV5vE" node="6J17ghv7mds" resolve="ProcessRunnerForConfigurationTests.ProcessListenerWhichParsesOutput" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6J17ghv7mj6" role="3cqZAp">
+          <node concept="2OqwBi" id="6J17ghv7TrS" role="3clFbG">
+            <node concept="37vLTw" id="6J17ghv7z6L" role="2Oq$k0">
+              <ref role="3cqZAo" node="6J17ghv7mhG" resolve="myProcess" />
+            </node>
+            <node concept="liA8E" id="6J17ghv7TrT" role="2OqNvi">
+              <ref role="37wK5l" to="uu3z:~ProcessHandler.addProcessListener(com.intellij.execution.process.ProcessListener)" resolve="addProcessListener" />
+              <node concept="37vLTw" id="6J17ghv7TrU" role="37wK5m">
+                <ref role="3cqZAo" node="6J17ghv7mj2" resolve="listenerParsingOutput" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6J17ghv7mja" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv7mj9" role="3cpWs9">
+            <property role="TrG5h" value="exitCode" />
+            <node concept="10Oyi0" id="6J17ghv7mjb" role="1tU5fm" />
+            <node concept="2YIFZM" id="6J17ghv8uoQ" role="33vP2m">
+              <ref role="1Pybhc" to="lk2n:3oW7HLfqDlu" resolve="ProcessHandlerBuilder" />
+              <ref role="37wK5l" to="lk2n:pdcevhyp45" resolve="startAndWait" />
+              <node concept="37vLTw" id="6J17ghv8uoR" role="37wK5m">
+                <ref role="3cqZAo" node="6J17ghv7mhG" resolve="myProcess" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv8uoS" role="37wK5m">
+                <ref role="3cqZAo" node="6J17ghv7mi3" resolve="myTimeOut" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6J17ghv7mjg" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv7mjf" role="3cpWs9">
+            <property role="TrG5h" value="eventInCaseOfFailure" />
+            <node concept="3uibUv" id="6J17ghv7mjh" role="1tU5fm">
+              <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+            </node>
+            <node concept="2OqwBi" id="6J17ghv7NLn" role="33vP2m">
+              <node concept="37vLTw" id="6J17ghv7z4y" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mj2" resolve="listenerParsingOutput" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7NLo" role="2OqNvi">
+                <ref role="37wK5l" node="6J17ghv7me4" resolve="getFailedEvent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6J17ghv7mjj" role="3cqZAp">
+          <node concept="3y3z36" id="6J17ghv7mjk" role="3clFbw">
+            <node concept="37vLTw" id="6J17ghv7mjl" role="3uHU7B">
+              <ref role="3cqZAo" node="6J17ghv7mjf" resolve="eventInCaseOfFailure" />
+            </node>
+            <node concept="10Nm6u" id="6J17ghv7mjm" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="6J17ghv7mjo" role="3clFbx">
+            <node concept="3clFbF" id="6J17ghv7mjp" role="3cqZAp">
+              <node concept="2YIFZM" id="6J17ghv7z5k" role="3clFbG">
+                <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                <ref role="37wK5l" to="rjhg:~Assert.fail(java.lang.String)" resolve="fail" />
+                <node concept="3cpWs3" id="6J17ghv7z5l" role="37wK5m">
+                  <node concept="Xl_RD" id="6J17ghv7z5m" role="3uHU7B">
+                    <property role="Xl_RC" value="Failed with the process event " />
+                  </node>
+                  <node concept="2OqwBi" id="6J17ghv7XeI" role="3uHU7w">
+                    <node concept="37vLTw" id="6J17ghv7z5o" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mjf" resolve="eventInCaseOfFailure" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghv7XeJ" role="2OqNvi">
+                      <ref role="37wK5l" to="uu3z:~ProcessEvent.getText()" resolve="getText" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6J17ghv7mjv" role="3cqZAp">
+          <node concept="3cpWsn" id="6J17ghv7mju" role="3cpWs9">
+            <property role="TrG5h" value="printedPatterns" />
+            <node concept="3uibUv" id="6J17ghv7mjw" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+              <node concept="3uibUv" id="6J17ghv7mjx" role="11_B2D">
+                <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6J17ghv7SIv" role="33vP2m">
+              <node concept="37vLTw" id="6J17ghv7z2b" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mj2" resolve="listenerParsingOutput" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7SIw" role="2OqNvi">
+                <ref role="37wK5l" node="6J17ghv7mdV" resolve="getPrintedPatterns" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6J17ghv7mjz" role="3cqZAp">
+          <node concept="3eOSWO" id="6J17ghv7mj$" role="3clFbw">
+            <node concept="2OqwBi" id="6J17ghv7Udr" role="3uHU7B">
+              <node concept="37vLTw" id="6J17ghv7z9j" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mhP" resolve="myExpectedPatterns" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Uds" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6J17ghv7N7U" role="3uHU7w">
+              <node concept="37vLTw" id="6J17ghv7z8U" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mju" resolve="printedPatterns" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7N7V" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Set.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="6J17ghv7mjC" role="3clFbx">
+            <node concept="3cpWs8" id="6J17ghv7mjE" role="3cqZAp">
+              <node concept="3cpWsn" id="6J17ghv7mjD" role="3cpWs9">
+                <property role="TrG5h" value="failMsg" />
+                <node concept="3uibUv" id="6J17ghv7mjF" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                </node>
+                <node concept="Xl_RD" id="6J17ghv7mjG" role="33vP2m">
+                  <property role="Xl_RC" value="The test has not printed all of the required messages: \n" />
+                </node>
+              </node>
+            </node>
+            <node concept="1DcWWT" id="6J17ghv7mjH" role="3cqZAp">
+              <node concept="3cpWsn" id="6J17ghv7mjX" role="1Duv9x">
+                <property role="TrG5h" value="expectedPattern" />
+                <node concept="3uibUv" id="6J17ghv7mjZ" role="1tU5fm">
+                  <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="6J17ghv7mjJ" role="2LFqv$">
+                <node concept="3clFbJ" id="6J17ghv7mjK" role="3cqZAp">
+                  <node concept="3fqX7Q" id="6J17ghv7mjL" role="3clFbw">
+                    <node concept="1eOMI4" id="6J17ghv7mjO" role="3fr31v">
+                      <node concept="2OqwBi" id="6J17ghv7UWk" role="1eOMHV">
+                        <node concept="37vLTw" id="6J17ghv7z59" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6J17ghv7mju" resolve="printedPatterns" />
+                        </node>
+                        <node concept="liA8E" id="6J17ghv7UWl" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+                          <node concept="37vLTw" id="6J17ghv7UWm" role="37wK5m">
+                            <ref role="3cqZAo" node="6J17ghv7mjX" resolve="expectedPattern" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="6J17ghv7mjQ" role="3clFbx">
+                    <node concept="3clFbF" id="6J17ghv7mjR" role="3cqZAp">
+                      <node concept="d57v9" id="6J17ghv7mjS" role="3clFbG">
+                        <node concept="37vLTw" id="6J17ghv7mjT" role="37vLTJ">
+                          <ref role="3cqZAo" node="6J17ghv7mjD" resolve="failMsg" />
+                        </node>
+                        <node concept="3cpWs3" id="6J17ghv7mjU" role="37vLTx">
+                          <node concept="Xl_RD" id="6J17ghv7mjV" role="3uHU7B">
+                            <property role="Xl_RC" value="Expected message is not found : '" />
+                          </node>
+                          <node concept="37vLTw" id="6J17ghv7mjW" role="3uHU7w">
+                            <ref role="3cqZAo" node="6J17ghv7mjX" resolve="expectedPattern" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="6J17ghv7mk1" role="1DdaDG">
+                <ref role="3cqZAo" node="6J17ghv7mhP" resolve="myExpectedPatterns" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="6J17ghv7mk2" role="3cqZAp">
+              <node concept="2YIFZM" id="6J17ghv7z2v" role="3clFbG">
+                <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                <ref role="37wK5l" to="rjhg:~Assert.fail(java.lang.String)" resolve="fail" />
+                <node concept="37vLTw" id="6J17ghv7z2w" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mjD" resolve="failMsg" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6J17ghv7mk5" role="3cqZAp">
+          <node concept="1Wc70l" id="6J17ghv7mk6" role="3clFbw">
+            <node concept="37vLTw" id="6J17ghv7mk7" role="3uHU7B">
+              <ref role="3cqZAo" node="6J17ghv7mhZ" resolve="myExitCodeMustBeZero" />
+            </node>
+            <node concept="3y3z36" id="6J17ghv7mk8" role="3uHU7w">
+              <node concept="37vLTw" id="6J17ghv7mk9" role="3uHU7B">
+                <ref role="3cqZAo" node="6J17ghv7mj9" resolve="exitCode" />
+              </node>
+              <node concept="3cmrfG" id="6J17ghv7mka" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="6J17ghv7mkc" role="3clFbx">
+            <node concept="3clFbF" id="6J17ghv7mkd" role="3cqZAp">
+              <node concept="2YIFZM" id="6J17ghv7z6n" role="3clFbG">
+                <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                <ref role="37wK5l" to="rjhg:~Assert.fail(java.lang.String)" resolve="fail" />
+                <node concept="3cpWs3" id="6J17ghv7z6o" role="37wK5m">
+                  <node concept="Xl_RD" id="6J17ghv7z6p" role="3uHU7B">
+                    <property role="Xl_RC" value="Exit with non-zero code " />
+                  </node>
+                  <node concept="37vLTw" id="6J17ghv7z6q" role="3uHU7w">
+                    <ref role="3cqZAo" node="6J17ghv7mj9" resolve="exitCode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6J17ghv7mki" role="1B3o_S" />
+      <node concept="3cqZAl" id="6J17ghv7mkj" role="3clF45" />
+    </node>
+    <node concept="312cEu" id="6J17ghv7mds" role="jymVt">
+      <property role="TrG5h" value="ProcessListenerWhichParsesOutput" />
+      <property role="2bfB8j" value="true" />
+      <property role="1EXbeo" value="true" />
+      <node concept="3Tm6S6" id="6J17ghv7mdt" role="1B3o_S" />
+      <node concept="3uibUv" id="6J17ghv7mdu" role="1zkMxy">
+        <ref role="3uigEE" to="uu3z:~ProcessAdapter" resolve="ProcessAdapter" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mdv" role="jymVt">
+        <property role="TrG5h" value="myFailedEvent" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mdx" role="1tU5fm">
+          <ref role="3uigEE" to="18ew:~Reference" resolve="Reference" />
+          <node concept="3uibUv" id="6J17ghv7mdy" role="11_B2D">
+            <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+          </node>
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z6B" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z6C" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="18ew:~Reference.&lt;init&gt;()" resolve="Reference" />
+            <node concept="3uibUv" id="6J17ghv7z6D" role="1pMfVU">
+              <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7md_" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mdA" role="jymVt">
+        <property role="TrG5h" value="myPrintedExpectedPatterns" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mdC" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+          <node concept="3uibUv" id="6J17ghv7mdD" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z7W" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z80" role="2ShVmc">
+            <property role="373rjd" value="true" />
+            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;()" resolve="HashSet" />
+            <node concept="3uibUv" id="6J17ghv7z81" role="1pMfVU">
+              <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mdG" role="1B3o_S" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mdV" role="jymVt">
+        <property role="TrG5h" value="getPrintedPatterns" />
+        <node concept="2AHcQZ" id="6J17ghv7mdW" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mdX" role="3clF47">
+          <node concept="3cpWs6" id="6J17ghv7mdY" role="3cqZAp">
+            <node concept="2YIFZM" id="6J17ghv7z2N" role="3cqZAk">
+              <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+              <ref role="37wK5l" to="33ny:~Collections.unmodifiableSet(java.util.Set)" resolve="unmodifiableSet" />
+              <node concept="37vLTw" id="6J17ghv7z2O" role="37wK5m">
+                <ref role="3cqZAo" node="6J17ghv7mdA" resolve="myPrintedExpectedPatterns" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7me1" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7me2" role="3clF45">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+          <node concept="3uibUv" id="6J17ghv7me3" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFb_" id="6J17ghv7me4" role="jymVt">
+        <property role="TrG5h" value="getFailedEvent" />
+        <node concept="2AHcQZ" id="6J17ghv7me5" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7me6" role="3clF47">
+          <node concept="3cpWs6" id="6J17ghv7me7" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7Gi2" role="3cqZAk">
+              <node concept="37vLTw" id="6J17ghv7z1n" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mdv" resolve="myFailedEvent" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Gi3" role="2OqNvi">
+                <ref role="37wK5l" to="18ew:~Reference.get()" resolve="get" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7me9" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mea" role="3clF45">
+          <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+        </node>
+      </node>
+      <node concept="312cEg" id="6J17ghv7mdH" role="jymVt">
+        <property role="TrG5h" value="myCurText" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="6J17ghv7mdJ" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+        </node>
+        <node concept="2ShNRf" id="6J17ghv7z1q" role="33vP2m">
+          <node concept="1pGfFk" id="6J17ghv7z1v" role="2ShVmc">
+            <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mdL" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mdM" role="jymVt">
+        <property role="TrG5h" value="myLastEvent" />
+        <node concept="3uibUv" id="6J17ghv7mdO" role="1tU5fm">
+          <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+        </node>
+        <node concept="10Nm6u" id="6J17ghv7mdP" role="33vP2m" />
+        <node concept="3Tm6S6" id="6J17ghv7mdQ" role="1B3o_S" />
+      </node>
+      <node concept="312cEg" id="6J17ghv7mdR" role="jymVt">
+        <property role="TrG5h" value="myLastKey" />
+        <node concept="3uibUv" id="6J17ghv7mdT" role="1tU5fm">
+          <ref role="3uigEE" to="zn9m:~Key" resolve="Key" />
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mdU" role="1B3o_S" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7meb" role="jymVt">
+        <property role="TrG5h" value="onTextAvailable" />
+        <property role="od$2w" value="true" />
+        <node concept="2AHcQZ" id="6J17ghv7mec" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="37vLTG" id="6J17ghv7med" role="3clF46">
+          <property role="TrG5h" value="event" />
+          <node concept="3uibUv" id="6J17ghv7mee" role="1tU5fm">
+            <ref role="3uigEE" to="uu3z:~ProcessEvent" resolve="ProcessEvent" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="6J17ghv7mef" role="3clF46">
+          <property role="TrG5h" value="key" />
+          <node concept="3uibUv" id="6J17ghv7meg" role="1tU5fm">
+            <ref role="3uigEE" to="zn9m:~Key" resolve="Key" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7meh" role="3clF47">
+          <node concept="3SKdUt" id="6J17ghv7mkG" role="3cqZAp">
+            <node concept="1PaTwC" id="6J17ghv7mkH" role="1aUNEU">
+              <node concept="3oM_SD" id="6J17ghv7mkI" role="1PaTwD">
+                <property role="3oM_SC" value="assuming" />
+              </node>
+              <node concept="3oM_SD" id="6J17ghv7mkJ" role="1PaTwD">
+                <property role="3oM_SC" value="everything" />
+              </node>
+              <node concept="3oM_SD" id="6J17ghv7mkK" role="1PaTwD">
+                <property role="3oM_SC" value="comes" />
+              </node>
+              <node concept="3oM_SD" id="6J17ghv7mkL" role="1PaTwD">
+                <property role="3oM_SC" value="in" />
+              </node>
+              <node concept="3oM_SD" id="6J17ghv7mkM" role="1PaTwD">
+                <property role="3oM_SC" value="lines" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6J17ghv7mej" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mei" role="3cpWs9">
+              <property role="TrG5h" value="text" />
+              <node concept="3uibUv" id="6J17ghv7mek" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+              <node concept="2OqwBi" id="6J17ghv7I0r" role="33vP2m">
+                <node concept="37vLTw" id="6J17ghv7z3S" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6J17ghv7med" resolve="event" />
+                </node>
+                <node concept="liA8E" id="6J17ghv7I0s" role="2OqNvi">
+                  <ref role="37wK5l" to="uu3z:~ProcessEvent.getText()" resolve="getText" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="6J17ghv7mem" role="3cqZAp">
+            <node concept="1eOMI4" id="6J17ghv7meu" role="3clFbw">
+              <node concept="22lmx$" id="6J17ghv7men" role="1eOMHV">
+                <node concept="3clFbC" id="6J17ghv7meo" role="3uHU7B">
+                  <node concept="37vLTw" id="6J17ghv7mep" role="3uHU7B">
+                    <ref role="3cqZAo" node="6J17ghv7mei" resolve="text" />
+                  </node>
+                  <node concept="10Nm6u" id="6J17ghv7meq" role="3uHU7w" />
+                </node>
+                <node concept="3clFbC" id="6J17ghv7mer" role="3uHU7w">
+                  <node concept="2OqwBi" id="6J17ghv7OrA" role="3uHU7B">
+                    <node concept="37vLTw" id="6J17ghv7z5C" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mei" resolve="text" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghv7OrB" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                    </node>
+                  </node>
+                  <node concept="3cmrfG" id="6J17ghv7met" role="3uHU7w">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7mew" role="3clFbx">
+              <node concept="3cpWs6" id="6J17ghv7mex" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="6J17ghv7mey" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7mez" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7me$" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7mdR" resolve="myLastKey" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv7me_" role="37vLTx">
+                <ref role="3cqZAo" node="6J17ghv7mef" resolve="key" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6J17ghv7meA" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7meB" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7meC" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7mdM" resolve="myLastEvent" />
+              </node>
+              <node concept="37vLTw" id="6J17ghv7meD" role="37vLTx">
+                <ref role="3cqZAo" node="6J17ghv7med" resolve="event" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6J17ghv7meE" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7Y0g" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7z5H" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mdH" resolve="myCurText" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Y0h" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                <node concept="37vLTw" id="6J17ghv7Y0i" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7mei" resolve="text" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="6J17ghv7meH" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7S2r" role="3clFbw">
+              <node concept="37vLTw" id="6J17ghv7z2q" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mei" resolve="text" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7S2s" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                <node concept="Xl_RD" id="6J17ghv7S2t" role="37wK5m">
+                  <property role="Xl_RC" value="\n" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7meL" role="3clFbx">
+              <node concept="3clFbF" id="6J17ghv7meM" role="3cqZAp">
+                <node concept="1rXfSq" id="6J17ghv7meN" role="3clFbG">
+                  <ref role="37wK5l" node="6J17ghv7meQ" resolve="flush" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="6J17ghv7meO" role="1B3o_S" />
+        <node concept="3cqZAl" id="6J17ghv7meP" role="3clF45" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7meQ" role="jymVt">
+        <property role="TrG5h" value="flush" />
+        <node concept="3clFbS" id="6J17ghv7meR" role="3clF47">
+          <node concept="3cpWs8" id="6J17ghv7meT" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7meS" role="3cpWs9">
+              <property role="TrG5h" value="text" />
+              <node concept="3uibUv" id="6J17ghv7meU" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+              <node concept="2OqwBi" id="6J17ghv7LMF" role="33vP2m">
+                <node concept="37vLTw" id="6J17ghv7z44" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6J17ghv7mdH" resolve="myCurText" />
+                </node>
+                <node concept="liA8E" id="6J17ghv7LMG" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6J17ghv7meX" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7meW" role="3cpWs9">
+              <property role="TrG5h" value="lastIndexOfBr" />
+              <node concept="10Oyi0" id="6J17ghv7meY" role="1tU5fm" />
+              <node concept="2OqwBi" id="6J17ghv7P5J" role="33vP2m">
+                <node concept="37vLTw" id="6J17ghv7z1g" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6J17ghv7meS" resolve="text" />
+                </node>
+                <node concept="liA8E" id="6J17ghv7P5K" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.lastIndexOf(java.lang.String)" resolve="lastIndexOf" />
+                  <node concept="Xl_RD" id="6J17ghv7P5L" role="37wK5m">
+                    <property role="Xl_RC" value="\n" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1gVbGN" id="6J17ghv7mf4" role="3cqZAp">
+            <node concept="2d3UOw" id="6J17ghv7mf1" role="1gVkn0">
+              <node concept="37vLTw" id="6J17ghv7mf2" role="3uHU7B">
+                <ref role="3cqZAo" node="6J17ghv7meW" resolve="lastIndexOfBr" />
+              </node>
+              <node concept="3cmrfG" id="6J17ghv7mf3" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6J17ghv7mf5" role="3cqZAp">
+            <node concept="37vLTI" id="6J17ghv7mf6" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7mf7" role="37vLTJ">
+                <ref role="3cqZAo" node="6J17ghv7meS" resolve="text" />
+              </node>
+              <node concept="2OqwBi" id="6J17ghv7KFt" role="37vLTx">
+                <node concept="37vLTw" id="6J17ghv7z7m" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6J17ghv7meS" resolve="text" />
+                </node>
+                <node concept="liA8E" id="6J17ghv7KFu" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                  <node concept="3cmrfG" id="6J17ghv7KFv" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                  <node concept="3cpWs3" id="6J17ghv7KFw" role="37wK5m">
+                    <node concept="37vLTw" id="6J17ghv7KFx" role="3uHU7B">
+                      <ref role="3cqZAo" node="6J17ghv7meW" resolve="lastIndexOfBr" />
+                    </node>
+                    <node concept="3cmrfG" id="6J17ghv7KFy" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6J17ghv7mfd" role="3cqZAp">
+            <node concept="2OqwBi" id="6J17ghv7Ht4" role="3clFbG">
+              <node concept="37vLTw" id="6J17ghv7z8Z" role="2Oq$k0">
+                <ref role="3cqZAo" node="6J17ghv7mdH" resolve="myCurText" />
+              </node>
+              <node concept="liA8E" id="6J17ghv7Ht5" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~StringBuilder.delete(int,int)" resolve="delete" />
+                <node concept="3cmrfG" id="6J17ghv7Ht6" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="6J17ghv8bum" role="37wK5m">
+                  <node concept="37vLTw" id="6J17ghv7Ht8" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6J17ghv7meS" resolve="text" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv8bun" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6J17ghv7mfi" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mfh" role="3cpWs9">
+              <property role="TrG5h" value="splitByLines" />
+              <node concept="10Q1$e" id="6J17ghv7mfk" role="1tU5fm">
+                <node concept="3uibUv" id="6J17ghv7mfj" role="10Q1$1">
+                  <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="6J17ghv7z1_" role="33vP2m">
+                <ref role="1Pybhc" to="zdap:~StringUtil" resolve="StringUtil" />
+                <ref role="37wK5l" to="zdap:~StringUtil.splitByLinesKeepSeparators(java.lang.String)" resolve="splitByLinesKeepSeparators" />
+                <node concept="37vLTw" id="6J17ghv7z1A" role="37wK5m">
+                  <ref role="3cqZAo" node="6J17ghv7meS" resolve="text" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1DcWWT" id="6J17ghv7mfn" role="3cqZAp">
+            <node concept="37vLTw" id="6J17ghv7mg9" role="1DdaDG">
+              <ref role="3cqZAo" node="6J17ghv7mfh" resolve="splitByLines" />
+            </node>
+            <node concept="3cpWsn" id="6J17ghv7mg6" role="1Duv9x">
+              <property role="TrG5h" value="line" />
+              <node concept="3uibUv" id="6J17ghv7mg8" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7mfp" role="2LFqv$">
+              <node concept="3cpWs8" id="6J17ghv7mfr" role="3cqZAp">
+                <node concept="3cpWsn" id="6J17ghv7mfq" role="3cpWs9">
+                  <property role="TrG5h" value="patternsWeEncountered" />
+                  <node concept="3uibUv" id="6J17ghv7mfs" role="1tU5fm">
+                    <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                    <node concept="3uibUv" id="6J17ghv7mft" role="11_B2D">
+                      <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                    </node>
+                  </node>
+                  <node concept="1rXfSq" id="6J17ghv7mfu" role="33vP2m">
+                    <ref role="37wK5l" node="6J17ghv7mh6" resolve="getPatternsForWhichMsgExpected" />
+                    <node concept="37vLTw" id="6J17ghv7mfv" role="37wK5m">
+                      <ref role="3cqZAo" node="6J17ghv7mg6" resolve="line" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="6J17ghv7mfw" role="3cqZAp">
+                <node concept="2OqwBi" id="6J17ghv7Mqw" role="3clFbG">
+                  <node concept="37vLTw" id="6J17ghv7z6X" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6J17ghv7mdA" resolve="myPrintedExpectedPatterns" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv7Mqx" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Set.addAll(java.util.Collection)" resolve="addAll" />
+                    <node concept="37vLTw" id="6J17ghv7Mqy" role="37wK5m">
+                      <ref role="3cqZAo" node="6J17ghv7mfq" resolve="patternsWeEncountered" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6J17ghv7mfz" role="3cqZAp">
+                <node concept="2OqwBi" id="6J17ghv7Jx8" role="3clFbw">
+                  <node concept="10M0yZ" id="6J17ghv7z9q" role="2Oq$k0">
+                    <ref role="1PxDUh" to="uu3z:~ProcessOutputTypes" resolve="ProcessOutputTypes" />
+                    <ref role="3cqZAo" to="uu3z:~ProcessOutputTypes.STDERR" resolve="STDERR" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv7Jx9" role="2OqNvi">
+                    <ref role="37wK5l" to="zn9m:~Key.equals(java.lang.Object)" resolve="equals" />
+                    <node concept="37vLTw" id="6J17ghv7Jxa" role="37wK5m">
+                      <ref role="3cqZAo" node="6J17ghv7mdR" resolve="myLastKey" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="6J17ghv7mfR" role="9aQIa">
+                  <node concept="3clFbS" id="6J17ghv7mfS" role="9aQI4">
+                    <node concept="3clFbF" id="6J17ghv7mfT" role="3cqZAp">
+                      <node concept="2OqwBi" id="6J17ghv7ZDm" role="3clFbG">
+                        <node concept="10M0yZ" id="6J17ghv7z23" role="2Oq$k0">
+                          <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                          <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                        </node>
+                        <node concept="liA8E" id="6J17ghv7ZDn" role="2OqNvi">
+                          <ref role="37wK5l" to="guwi:~PrintStream.print(java.lang.String)" resolve="print" />
+                          <node concept="3cpWs3" id="6J17ghv7ZDo" role="37wK5m">
+                            <node concept="Xl_RD" id="6J17ghv7ZDp" role="3uHU7B">
+                              <property role="Xl_RC" value="TEST OUTPUT::: " />
+                            </node>
+                            <node concept="37vLTw" id="6J17ghv7ZDq" role="3uHU7w">
+                              <ref role="3cqZAo" node="6J17ghv7mg6" resolve="line" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6J17ghv7mfB" role="3clFbx">
+                  <node concept="3clFbJ" id="6J17ghv7mfC" role="3cqZAp">
+                    <node concept="3fqX7Q" id="6J17ghv7mfD" role="3clFbw">
+                      <node concept="1eOMI4" id="6J17ghv7mfG" role="3fr31v">
+                        <node concept="1rXfSq" id="6J17ghv7mfE" role="1eOMHV">
+                          <ref role="37wK5l" node="6J17ghv7mg$" resolve="isErrMsgAllowed" />
+                          <node concept="37vLTw" id="6J17ghv7mfF" role="37wK5m">
+                            <ref role="3cqZAo" node="6J17ghv7mg6" resolve="line" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="6J17ghv7mfI" role="3clFbx">
+                      <node concept="3clFbF" id="6J17ghv7mfJ" role="3cqZAp">
+                        <node concept="2OqwBi" id="6J17ghv7IWz" role="3clFbG">
+                          <node concept="37vLTw" id="6J17ghv7z5O" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6J17ghv7mdv" resolve="myFailedEvent" />
+                          </node>
+                          <node concept="liA8E" id="6J17ghv7IW$" role="2OqNvi">
+                            <ref role="37wK5l" to="18ew:~Reference.set(java.lang.Object)" resolve="set" />
+                            <node concept="37vLTw" id="6J17ghv7IW_" role="37wK5m">
+                              <ref role="3cqZAo" node="6J17ghv7mdM" resolve="myLastEvent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="6J17ghv7mfM" role="3cqZAp">
+                    <node concept="2OqwBi" id="6J17ghv7AWa" role="3clFbG">
+                      <node concept="10M0yZ" id="6J17ghv7z9_" role="2Oq$k0">
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                        <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                      </node>
+                      <node concept="liA8E" id="6J17ghv7AWb" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.print(java.lang.String)" resolve="print" />
+                        <node concept="3cpWs3" id="6J17ghv7AWc" role="37wK5m">
+                          <node concept="Xl_RD" id="6J17ghv7AWd" role="3uHU7B">
+                            <property role="Xl_RC" value="TEST ERR OUTPUT::: " />
+                          </node>
+                          <node concept="37vLTw" id="6J17ghv7AWe" role="3uHU7w">
+                            <ref role="3cqZAo" node="6J17ghv7mg6" resolve="line" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6J17ghv7mfY" role="3cqZAp">
+                <node concept="1rXfSq" id="6J17ghv7mfZ" role="3clFbw">
+                  <ref role="37wK5l" node="6J17ghv7mgc" resolve="needToExit" />
+                  <node concept="37vLTw" id="6J17ghv7mg0" role="37wK5m">
+                    <ref role="3cqZAo" node="6J17ghv7mg6" resolve="line" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6J17ghv7mg2" role="3clFbx">
+                  <node concept="3clFbF" id="6J17ghv7mg3" role="3cqZAp">
+                    <node concept="2OqwBi" id="6J17ghv88UG" role="3clFbG">
+                      <node concept="2OqwBi" id="6J17ghv7RmG" role="2Oq$k0">
+                        <node concept="37vLTw" id="6J17ghv7z15" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6J17ghv7mdM" resolve="myLastEvent" />
+                        </node>
+                        <node concept="liA8E" id="6J17ghv7RmH" role="2OqNvi">
+                          <ref role="37wK5l" to="uu3z:~ProcessEvent.getProcessHandler()" resolve="getProcessHandler" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="6J17ghv88UH" role="2OqNvi">
+                        <ref role="37wK5l" to="uu3z:~ProcessHandler.detachProcess()" resolve="detachProcess" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mga" role="1B3o_S" />
+        <node concept="3cqZAl" id="6J17ghv7mgb" role="3clF45" />
+      </node>
+      <node concept="2tJIrI" id="5nwfWGQ1XUN" role="jymVt" />
+      <node concept="3clFb_" id="6J17ghv7mgc" role="jymVt">
+        <property role="TrG5h" value="needToExit" />
+        <node concept="37vLTG" id="6J17ghv7mgd" role="3clF46">
+          <property role="TrG5h" value="text" />
+          <node concept="17QB3L" id="5nwfWGQ1QpZ" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mgf" role="3clF47">
+          <node concept="1DcWWT" id="6J17ghv7mgg" role="3cqZAp">
+            <node concept="37vLTw" id="6J17ghv8COd" role="1DdaDG">
+              <ref role="3cqZAo" node="6J17ghv7mhU" resolve="myExitPatterns" />
+            </node>
+            <node concept="3cpWsn" id="6J17ghv7mgr" role="1Duv9x">
+              <property role="TrG5h" value="exitPattern" />
+              <node concept="3uibUv" id="6J17ghv7mgt" role="1tU5fm">
+                <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7mgi" role="2LFqv$">
+              <node concept="3clFbJ" id="6J17ghv7mgj" role="3cqZAp">
+                <node concept="2OqwBi" id="6J17ghv8aCm" role="3clFbw">
+                  <node concept="2OqwBi" id="6J17ghv7GTU" role="2Oq$k0">
+                    <node concept="37vLTw" id="6J17ghv7z7T" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mgr" resolve="exitPattern" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghv7GTV" role="2OqNvi">
+                      <ref role="37wK5l" to="ni5j:~Pattern.matcher(java.lang.CharSequence)" resolve="matcher" />
+                      <node concept="37vLTw" id="6J17ghv7GTW" role="37wK5m">
+                        <ref role="3cqZAo" node="6J17ghv7mgd" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="6J17ghv8aCn" role="2OqNvi">
+                    <ref role="37wK5l" to="ni5j:~Matcher.matches()" resolve="matches" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6J17ghv7mgo" role="3clFbx">
+                  <node concept="3cpWs6" id="6J17ghv7mgp" role="3cqZAp">
+                    <node concept="3clFbT" id="6J17ghv7mgq" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mgw" role="3cqZAp">
+            <node concept="3clFbT" id="6J17ghv7mgx" role="3cqZAk" />
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mgy" role="1B3o_S" />
+        <node concept="10P_77" id="6J17ghv7mgz" role="3clF45" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mg$" role="jymVt">
+        <property role="TrG5h" value="isErrMsgAllowed" />
+        <node concept="37vLTG" id="6J17ghv7mg_" role="3clF46">
+          <property role="TrG5h" value="text" />
+          <node concept="17QB3L" id="5nwfWGQ23KQ" role="1tU5fm" />
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mgB" role="3clF47">
+          <node concept="3cpWs8" id="6J17ghv7mgD" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mgC" role="3cpWs9">
+              <property role="TrG5h" value="allowed" />
+              <node concept="10P_77" id="6J17ghv7mgE" role="1tU5fm" />
+              <node concept="3clFbT" id="6J17ghv7mgF" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="1DcWWT" id="6J17ghv7mgG" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mgX" role="1Duv9x">
+              <property role="TrG5h" value="allowedPattern" />
+              <node concept="3uibUv" id="6J17ghv7mgZ" role="1tU5fm">
+                <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7mgI" role="2LFqv$">
+              <node concept="3cpWs8" id="6J17ghv7mgK" role="3cqZAp">
+                <node concept="3cpWsn" id="6J17ghv7mgJ" role="3cpWs9">
+                  <property role="TrG5h" value="matcher" />
+                  <node concept="3uibUv" id="6J17ghv7mgL" role="1tU5fm">
+                    <ref role="3uigEE" to="ni5j:~Matcher" resolve="Matcher" />
+                  </node>
+                  <node concept="2OqwBi" id="6J17ghv7E5W" role="33vP2m">
+                    <node concept="37vLTw" id="6J17ghv7z2k" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mgX" resolve="allowedPattern" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghv7E5X" role="2OqNvi">
+                      <ref role="37wK5l" to="ni5j:~Pattern.matcher(java.lang.CharSequence)" resolve="matcher" />
+                      <node concept="37vLTw" id="6J17ghv7E5Y" role="37wK5m">
+                        <ref role="3cqZAo" node="6J17ghv7mg_" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6J17ghv7mgO" role="3cqZAp">
+                <node concept="2OqwBi" id="6J17ghv7QFi" role="3clFbw">
+                  <node concept="37vLTw" id="6J17ghv7z55" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6J17ghv7mgJ" resolve="matcher" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv7QFj" role="2OqNvi">
+                    <ref role="37wK5l" to="ni5j:~Matcher.matches()" resolve="matches" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6J17ghv7mgR" role="3clFbx">
+                  <node concept="3clFbF" id="6J17ghv7mgS" role="3cqZAp">
+                    <node concept="37vLTI" id="6J17ghv7mgT" role="3clFbG">
+                      <node concept="37vLTw" id="6J17ghv7mgU" role="37vLTJ">
+                        <ref role="3cqZAo" node="6J17ghv7mgC" resolve="allowed" />
+                      </node>
+                      <node concept="3clFbT" id="6J17ghv7mgV" role="37vLTx">
+                        <property role="3clFbU" value="true" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zACq4" id="6J17ghv7mgW" role="3cqZAp" />
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6J17ghv7mh1" role="1DdaDG">
+              <ref role="3cqZAo" node="6J17ghv7mhK" resolve="myAllowedErrorPatterns" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mh2" role="3cqZAp">
+            <node concept="37vLTw" id="6J17ghv7mh3" role="3cqZAk">
+              <ref role="3cqZAo" node="6J17ghv7mgC" resolve="allowed" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mh4" role="1B3o_S" />
+        <node concept="10P_77" id="6J17ghv7mh5" role="3clF45" />
+      </node>
+      <node concept="3clFb_" id="6J17ghv7mh6" role="jymVt">
+        <property role="TrG5h" value="getPatternsForWhichMsgExpected" />
+        <node concept="37vLTG" id="6J17ghv7mh7" role="3clF46">
+          <property role="TrG5h" value="text" />
+          <node concept="3uibUv" id="6J17ghv7mh8" role="1tU5fm">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="6J17ghv7mh9" role="3clF47">
+          <node concept="3cpWs8" id="6J17ghv7mhb" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mha" role="3cpWs9">
+              <property role="TrG5h" value="met" />
+              <node concept="3uibUv" id="6J17ghv7mhc" role="1tU5fm">
+                <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                <node concept="3uibUv" id="6J17ghv7mhd" role="11_B2D">
+                  <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="6J17ghv7z3U" role="33vP2m">
+                <node concept="1pGfFk" id="6J17ghv7z3Z" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+                  <node concept="3uibUv" id="6J17ghv7z40" role="1pMfVU">
+                    <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1DcWWT" id="6J17ghv7mhh" role="3cqZAp">
+            <node concept="3cpWsn" id="6J17ghv7mhy" role="1Duv9x">
+              <property role="TrG5h" value="expectedPattern" />
+              <node concept="3uibUv" id="6J17ghv7mh$" role="1tU5fm">
+                <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="6J17ghv7mhj" role="2LFqv$">
+              <node concept="3cpWs8" id="6J17ghv7mhl" role="3cqZAp">
+                <node concept="3cpWsn" id="6J17ghv7mhk" role="3cpWs9">
+                  <property role="TrG5h" value="matcher" />
+                  <node concept="3uibUv" id="6J17ghv7mhm" role="1tU5fm">
+                    <ref role="3uigEE" to="ni5j:~Matcher" resolve="Matcher" />
+                  </node>
+                  <node concept="2OqwBi" id="6J17ghv7Q08" role="33vP2m">
+                    <node concept="37vLTw" id="6J17ghv7z5f" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6J17ghv7mhy" resolve="expectedPattern" />
+                    </node>
+                    <node concept="liA8E" id="6J17ghv7Q09" role="2OqNvi">
+                      <ref role="37wK5l" to="ni5j:~Pattern.matcher(java.lang.CharSequence)" resolve="matcher" />
+                      <node concept="37vLTw" id="6J17ghv7Q0a" role="37wK5m">
+                        <ref role="3cqZAo" node="6J17ghv7mh7" resolve="text" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6J17ghv7mhp" role="3cqZAp">
+                <node concept="2OqwBi" id="6J17ghv7K6j" role="3clFbw">
+                  <node concept="37vLTw" id="6J17ghv7z1b" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6J17ghv7mhk" resolve="matcher" />
+                  </node>
+                  <node concept="liA8E" id="6J17ghv7K6k" role="2OqNvi">
+                    <ref role="37wK5l" to="ni5j:~Matcher.matches()" resolve="matches" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="6J17ghv7mhs" role="3clFbx">
+                  <node concept="3clFbF" id="6J17ghv9267" role="3cqZAp">
+                    <node concept="2OqwBi" id="6J17ghv9ar4" role="3clFbG">
+                      <node concept="37vLTw" id="6J17ghv9265" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6J17ghv7mha" resolve="met" />
+                      </node>
+                      <node concept="liA8E" id="6J17ghv9g2K" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                        <node concept="37vLTw" id="6J17ghv9jMN" role="37wK5m">
+                          <ref role="3cqZAo" node="6J17ghv7mhy" resolve="expectedPattern" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6J17ghv7mhA" role="1DdaDG">
+              <ref role="3cqZAo" node="6J17ghv7mhP" resolve="myExpectedPatterns" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6J17ghv7mhB" role="3cqZAp">
+            <node concept="37vLTw" id="6J17ghv7mhC" role="3cqZAk">
+              <ref role="3cqZAo" node="6J17ghv7mha" resolve="met" />
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm6S6" id="6J17ghv7mhD" role="1B3o_S" />
+        <node concept="3uibUv" id="6J17ghv7mhE" role="3clF45">
+          <ref role="3uigEE" to="33ny:~List" resolve="List" />
+          <node concept="3uibUv" id="6J17ghv7mhF" role="11_B2D">
+            <ref role="3uigEE" to="ni5j:~Pattern" resolve="Pattern" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="5nwfWGQ282k" role="lGtFl">
+      <node concept="TZ5HA" id="5nwfWGQ282l" role="TZ5H$">
+        <node concept="1dT_AC" id="5nwfWGQ282m" role="1dT_Ay">
+          <property role="1dT_AB" value="Copied from https://github.com/JetBrains/MPS/blob/master/testbench/testsolutions/execution-test/tests/test_gen/jetbrains/mps/execution/impl/configurations/util/ProcessRunnerForConfigurationTests.java" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/solutions/nl.f1re.testing.runtime/nl.f1re.testing.runtime.msd
+++ b/code/testing/solutions/nl.f1re.testing.runtime/nl.f1re.testing.runtime.msd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="nl.f1re.testing.runtime" uuid="f4eaf5cb-c1e6-4968-831c-c28a93349488" moduleVersion="0">
+  <models>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet compile="mps" classes="mps" ext="no" type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">af52e9df-2136-4ef8-81b2-bec0babe5e4c(jetbrains.mps.lang.editor.tooltips.runtime)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
+    <dependency reexport="false">36c11d2d-1875-4a95-8bdb-70ea1ac63222(jetbrains.mps.execution.api)</dependency>
+    <dependency reexport="false">49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
+    <module reference="36c11d2d-1875-4a95-8bdb-70ea1ac63222(jetbrains.mps.execution.api)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="af52e9df-2136-4ef8-81b2-bec0babe5e4c(jetbrains.mps.lang.editor.tooltips.runtime)" version="0" />
+    <module reference="f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/docs/extensions/full_extensions_list.md
+++ b/docs/extensions/full_extensions_list.md
@@ -37,6 +37,11 @@ This is a full list of all the extensions that are contained in MPS-extensions.
 | *de.itemis.mps.linenumbers.plugin*            | line numbers for the editor                                                                                                                                                                                                                                                                                                                   |
 | *de.itemis.mps.editor.htmlcell*               | HTML-based editor cells                                                                                                                                                                                                                                                                                                                       |
 
+**Testing**
+
+| Name              | Description                 |
+|-------------------|-----------------------------|
+| *nl.f1re.testing* | utility classes for testing |
 
 **Generator**
 

--- a/docs/extensions/testing.md
+++ b/docs/extensions/testing.md
@@ -1,0 +1,152 @@
+# Testing
+
+**Language Namespace :** `nl.f1re.testing`
+
+This language contains utility classes to help with writing tests and
+a concept `fileNodeEditor` to get access to the (IntelliJ) editor of the testcase ([MPSFileNodeEditor](http://127.0.0.1:63320/node?ref=1ed103c3-3aa6-49b7-9c21-6765ee11f224%2Fjava%3Ajetbrains.mps.ide.editor%28MPS.Editor%2F%29%2F~MPSFileNodeEditor)).
+All helper classes assume no read/write access to the model.
+When a class needs an editor cell, you can pass it, for example, through
+
+- `editor component.findNodeCell(node)`
+- `editor component.getSelectedCell()`
+
+If you are in a nodes test case and not an editor test case, you need an editor component first:
+```java
+HeadlessEditorComponent component = new HeadlessEditorComponent();
+component.editNode(node);
+```
+
+## Asserts
+
+*void assertFails(ThrowableRunnable<Throwable>)* - checks that a code block fails or makes the test fail otherwise.
+
+```java title="Successful assert"
+Asserts.assertFails(new ThrowableRunnable<Throwable>() { 
+  @Override 
+  public void run() throws Throwable { 
+    throw new  RuntimeException(); 
+  } 
+})
+```
+
+```java title="Failing assert"
+Asserts.assertFails(new ThrowableRunnable<Throwable>() { 
+  @Override 
+  public void run() throws Throwable { 
+    System.out.println("No exception"); 
+  } 
+})
+```
+
+## EditorCellTestHelper
+
+This class contains methods that help with editor cells. An `EditorCell` must be passed as an argument.
+
+- *node<> getLinkedNode()* - returns the referenced node of a hyperlink.
+- *void focus()* - change the selection to the cell and also set the focus.
+- *EditorCell_Collection getToolTipCell()* - returns the root cell of the tooltip if the cell has a tooltip.
+
+## EditorComponentTestHelper
+
+This class contains methods that help with manipulating the editor.  An `EditorComponent` must be passed as an argument.
+
+- *void increaseUIScale()* - increase the editor scale by 20% and rebuild the editor afterwards
+ ``` java title="Example: Increase the editor scaling (needs the reflection language)"
+ new  EditorComponentTestHelper(editor component).increaseUIScale();
+ ```
+
+ - *void decreaseUIScale()* - decrease the editor scale by 20% and rebuild the editor afterwards
+ ``` java title="Example: Increase the editor scaling (needs the reflection language)"
+ new  EditorComponentTestHelper(editor component).increaseUIScale();
+ ```
+
+  - *void resetUIScale()* - reset the editor scale and rebuild the editor afterwards
+ ``` java title="Example: Increase the editor scaling (needs the reflection language)"
+ new  EditorComponentTestHelper(editor component).increaseUIScale();
+ ```
+
+- *ContextAssistantManager openContextAssistant()* - Opens the [context assistant](https://www.jetbrains.com/help/mps/context-assistant.html) in the editor.
+
+## IntentionTester
+
+This class contains methods to work with intentions.  An `EditorContext` must be passed as an argument as well as the information if surround intentions should be found.
+
+- *Pair<IntentionExecutable, SNode> getSingleMatchingIntention(node, intentionCondition)* - returns a single intention that can be applied for the node that matches a condition
+
+``` java title="Example: Read the description of a specific intention"
+node<> intention = node-ptr/ClassConceptNewName/.resolve(repository); 
+Pair<IntentionExecutable, SNode> matchingIntention = new  IntentionTester(editorContext).getSingleMatchingIntention(node, new  MatchIntentionById(intention.getFqName() + "_Intention"));
+string description = matchingIntention.o1.getDescription(node, editorContext);
+```
+
+## PlatformTestHelper
+
+This classes contains utility methods for testing the IntelliJ platform.  An `jetbrains.mps.project.Project` must be passed as an argument.
+
+- *void withClipboardData(action, data)* - temporarily set the clipboard data to a certain string and execute an action
+
+```java title="Example: Paste the text 'test' into the MPS editor."
+new  PlatformTestHelper(project).withClipboardData({ => 
+  try { 
+    invoke action by id: $Paste 
+  } catch (Exception e) { 
+    fail : e.getMessage(); 
+  } 
+}, "test")
+```
+
+- *void findNotification(triggerNotification,action,timeout)* - create a new notification and wait a certain time for it to appear
+
+```java title="Example: Create a notification and assert its title and content."
+new  PlatformTestHelper(project).findNotification({ => 
+  NotificationGroup group = new  NotificationGroup("TestGroup", NotificationDisplayType.BALLOON, true); 
+  Notification notification = group.createNotification("Title", "Content", NotificationType.INFORMATION); 
+  Notifications.Bus.notify(notification, ProjectHelper.toIdeaProject(project)); 
+}, {notification => 
+  assert "Title" equals notification.getTitle() ; 
+  assert "Content" equals notification.getContent() ; 
+  assert NotificationType.INFORMATION equals notification.getType() ; 
+}, 1000)
+```
+
+- *void withPowerSaveModelEnabled(code)* - execute code while the [power save mode](https://www.jetbrains.com/help/mps/status-bar.html#status-bar-icons) enabled.#
+
+- *void assertHasFatalError(errorText)* - assert that the IDE threw an exception in the lower right corner.
+
+```java title="Example: Assert a fatal error"
+MessagePool.getInstance().addIdeFatalMessage(new  IdeaLoggingEvent("my error", new  Throwable())); 
+PlatformTestHelper platformTestHelper = new  PlatformTestHelper(project); 
+platformTestHelper.assertHasFatalError(null); 
+platformTestHelper.assertHasFatalError("my error");
+```
+
+## ProjectTestHelper
+
+This class contains helper methods that needs a project as an argument. An `jetbrains.mps.project.Project` must be passed as an argument to this class.
+
+- *void reloadModule(module)* - reload a module
+- *void reloadModules(modules)* - reload a list of modules
+- *void reloadAll()* - reload all modules
+
+```java title="Example: Reload a module"
+new  ProjectTestHelper(project).withClassLoading({manager => manager.reloadModule(model/.getModule()); });
+```
+
+- *list<MPSFileNodeEditor> getOpenEditors()* - returns a list of opened editors or an empty list instead.
+
+- *MPSFileNodeEditor getActiveEditor()* - returns the currently selected opened editor.
+
+- *void closeOpenEditors()* - close all open editors
+
+- *void assertEditorNotBroken(node)* - assert that the editor for the node can be created. It catches exception where an editor cell can't be created.
+
+# TypesystemTestUtil
+
+This class contains helper methods for testing the typesystem.
+
+- *Duration measureTypesystemPerformance(model)* - tests how long it takes to execute all typesystem checks for a model.
+
+```java title="Example: Check that the typesystem checks take less than 1000ms"
+Duration duration = TypesystemTestUtil.measureTypesystemPerformance(modelToCheck); 
+assert true duration.compareTo(Duration.ofMillis(10000)) < 0 : "check executed in more than 1000ms";
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - Project View: extensions/other/project-view.md
       - Shadow Models: extensions/other/shadow-models.md
   - Stubs: extensions/stubs.md
+  - Testing: extensions/testing.md
   - Utilities:
       - Intentions Menu: extensions/utils/intentions-menu.md
       - Model Listener: extensions/utils/model-listener.md


### PR DESCRIPTION
I added a new plugin that contains a model `io.f1re.testing.runtime` that contains helper classes for testing various aspects in MPS and also the IntelliJ platform. They execute the code in the right thread automatically, as they can be also called from editor tests which don't have command access to the model enabled. Test helper classes:

- Asserts (assert fails)
- EditorCellTestHelper
- EditorComponentTestHelper
- IntentionTester
- PlatformTestHelper
- ProjectTestHelper
- TypesystemTestUtil

In addition, this PR contains 60 tests (`io.f1re.testing.examples`) for testing nearly everything that you can test in MPS.
Please let me know if we need any other types of tests.