### PR TITLE
[MPS 2025.3] Fix javac compilation error: re-export dependency

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -10546,6 +10546,7 @@
         </node>
         <node concept="1SiIV0" id="1kvClgLzQmh" role="3bR37C">
           <node concept="3bR9La" id="1kvClgLzQmi" role="1SiIV1">
+            <property role="3bR36h" value="true" />
             <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
           </node>
         </node>
@@ -18146,17 +18147,80 @@
               <property role="3MwjfP" value="lib" />
             </node>
           </node>
-          <node concept="2HvfSZ" id="4_SQzDOofhp" role="39821P">
-            <node concept="398BVA" id="4_SQzDOofnN" role="2HvfZ0">
+          <node concept="28jJK3" id="6sGAGM5GK5i" role="39821P">
+            <node concept="398BVA" id="6sGAGM5GKme" role="28jJRO">
               <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
-              <node concept="2Ry0Ak" id="4_SQzDOofuf" role="iGT6I">
+              <node concept="2Ry0Ak" id="6sGAGM5GKJB" role="iGT6I">
                 <property role="2Ry0Am" value="shadowmodels" />
-                <node concept="2Ry0Ak" id="4_SQzDOofuk" role="2Ry0An">
+                <node concept="2Ry0Ak" id="6sGAGM5GKS6" role="2Ry0An">
                   <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="4_SQzDOofup" role="2Ry0An">
+                  <node concept="2Ry0Ak" id="6sGAGM5GKS9" role="2Ry0An">
                     <property role="2Ry0Am" value="de.q60.mps.collections.libs" />
-                    <node concept="2Ry0Ak" id="4_SQzDOofuu" role="2Ry0An">
+                    <node concept="2Ry0Ak" id="6sGAGM5GL0B" role="2Ry0An">
                       <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="6sGAGM5GL0E" role="2Ry0An">
+                        <property role="2Ry0Am" value="commons-collections4.jar" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="28jJK3" id="6sGAGM5GL0F" role="39821P">
+            <node concept="398BVA" id="6sGAGM5GL0G" role="28jJRO">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="6sGAGM5GL0H" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="6sGAGM5GL0I" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="6sGAGM5GL0J" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.q60.mps.collections.libs" />
+                    <node concept="2Ry0Ak" id="6sGAGM5GL0K" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="6sGAGM5GL9e" role="2Ry0An">
+                        <property role="2Ry0Am" value="guava.jar" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="28jJK3" id="6sGAGM5GLhF" role="39821P">
+            <node concept="398BVA" id="6sGAGM5GLhG" role="28jJRO">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="6sGAGM5GLhH" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="6sGAGM5GLhI" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="6sGAGM5GLhJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.q60.mps.collections.libs" />
+                    <node concept="2Ry0Ak" id="6sGAGM5GLhK" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="6sGAGM5GLqe" role="2Ry0An">
+                        <property role="2Ry0Am" value="trove4j.jar" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="28jJK3" id="6sGAGM5GLyF" role="39821P">
+            <node concept="398BVA" id="6sGAGM5GLyG" role="28jJRO">
+              <ref role="398BVh" node="2fo8bJE$D4t" resolve="extensions.code" />
+              <node concept="2Ry0Ak" id="6sGAGM5GLyH" role="iGT6I">
+                <property role="2Ry0Am" value="shadowmodels" />
+                <node concept="2Ry0Ak" id="6sGAGM5GLyI" role="2Ry0An">
+                  <property role="2Ry0Am" value="solutions" />
+                  <node concept="2Ry0Ak" id="6sGAGM5GLyJ" role="2Ry0An">
+                    <property role="2Ry0Am" value="de.q60.mps.collections.libs" />
+                    <node concept="2Ry0Ak" id="6sGAGM5GLyK" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="6sGAGM5GLFe" role="2Ry0An">
+                        <property role="2Ry0Am" value="vavr.jar" />
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/shadowmodels/solutions/de.q60.mps.polymorphicfunctions.runtime/de.q60.mps.polymorphicfunctions.runtime.msd
+++ b/code/shadowmodels/solutions/de.q60.mps.polymorphicfunctions.runtime/de.q60.mps.polymorphicfunctions.runtime.msd
@@ -18,7 +18,7 @@
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">e4fb5bb5-0ad9-4e08-9867-6c5a4b9d9246(de.q60.mps.util)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="true">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />


### PR DESCRIPTION
A dependency on de.q60.mps.collections.libs solution is re-exported by de.q60.mps.polymorphicfunctions.runtime.
Also, explicitly list library jars in build layout.