### PR TITLE
fix(polyfunc): reduce dependencies of the generated code

### DIFF
--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -11829,11 +11829,6 @@
               <ref role="3bR37D" node="4iIKqJTZ5H4" resolve="de.q60.mps.polymorphicfunctions.runtime" />
             </node>
           </node>
-          <node concept="1SiIV0" id="66nVdZVOLyj" role="3bR37C">
-            <node concept="3bR9La" id="66nVdZVOLyk" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-            </node>
-          </node>
           <node concept="1BupzO" id="2eucapX088i" role="3bR31x">
             <property role="3ZfqAx" value="generator/template" />
             <property role="1Hdu6h" value="true" />
@@ -11860,16 +11855,6 @@
               <node concept="3qWCbU" id="2eucapX088k" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
-            </node>
-          </node>
-          <node concept="1SiIV0" id="66nVdZW6cQc" role="3bR37C">
-            <node concept="3bR9La" id="66nVdZW6cQd" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:7Kfy9QB6KZM" resolve="closures.runtime" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="6RNzJhk84Od" role="3bR37C">
-            <node concept="3bR9La" id="6RNzJhk84Oe" role="1SiIV1">
-              <ref role="3bR37D" node="6fQhGuklQWU" resolve="de.q60.mps.collections.libs" />
             </node>
           </node>
         </node>

--- a/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions/de.q60.mps.polymorphicfunctions.mpl
+++ b/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions/de.q60.mps.polymorphicfunctions.mpl
@@ -27,9 +27,6 @@
       <dependencies>
         <dependency reexport="false">18463265-6d45-4514-82f1-cf7eb1222492(de.q60.mps.polymorphicfunctions.runtime)</dependency>
         <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
-        <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
-        <dependency reexport="false">4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)</dependency>
-        <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -55,10 +52,7 @@
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
-        <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
         <module reference="bc963c22-d419-49b6-8543-ea411eb9d3a1(de.q60.mps.polymorphicfunctions)" version="0" />
         <module reference="9403afb2-a8b8-418b-add1-1ddb008187f1(de.q60.mps.polymorphicfunctions#01)" version="0" />
         <module reference="18463265-6d45-4514-82f1-cf7eb1222492(de.q60.mps.polymorphicfunctions.runtime)" version="0" />

--- a/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions/generator/template/main@generator.mps
+++ b/code/shadowmodels/languages/de.q60.mps.polymorphicfunctions/generator/template/main@generator.mps
@@ -14,9 +14,7 @@
     <import index="bx8c" ref="r:d41a8c26-da48-469e-96f2-9d09a339f84d(de.q60.mps.polymorphicfunctions.structure)" />
     <import index="od2j" ref="r:19d224b8-fac8-4b19-ae42-e7b119858f3b(de.q60.mps.polymorphicfunctions.runtime)" />
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
-    <import index="nva4" ref="r:6a4f00d3-a72e-48b0-96be-a5139db9536c(jetbrains.mps.baseLanguage.closures)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" implicit="true" />
     <import index="e9uj" ref="r:a0737da3-c8e0-437c-a9b2-5b254393a0a1(de.q60.mps.polymorphicfunctions.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -398,364 +396,359 @@
             <node concept="3cqZAl" id="3jJoUQ70pbw" role="3clF45" />
             <node concept="3Tm1VV" id="3jJoUQ70pbx" role="1B3o_S" />
             <node concept="3clFbS" id="3jJoUQ70pby" role="3clF47">
-              <node concept="3clFbF" id="3jJoUQ70pcu" role="3cqZAp">
-                <node concept="2OqwBi" id="3jJoUQ70q3y" role="3clFbG">
-                  <node concept="37vLTw" id="3jJoUQ70ZSy" role="2Oq$k0">
-                    <ref role="3cqZAo" to="od2j:3jJoUQ6YEnK" resolve="myImplementations" />
-                  </node>
-                  <node concept="liA8E" id="3jJoUQ70qM5" role="2OqNvi">
-                    <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
-                    <node concept="Xl_RD" id="3jJoUQ70rsH" role="37wK5m">
-                      <property role="Xl_RC" value="declId" />
-                      <node concept="17Uvod" id="3jJoUQ710he" role="lGtFl">
-                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                        <property role="2qtEX9" value="value" />
-                        <node concept="3zFVjK" id="3jJoUQ710hf" role="3zH0cK">
-                          <node concept="3clFbS" id="3jJoUQ710hg" role="2VODD2">
-                            <node concept="3clFbF" id="3jJoUQ71cO2" role="3cqZAp">
-                              <node concept="2OqwBi" id="3jJoUQ71dOZ" role="3clFbG">
-                                <node concept="2OqwBi" id="3jJoUQ71d1T" role="2Oq$k0">
-                                  <node concept="30H73N" id="3jJoUQ71cO1" role="2Oq$k0" />
-                                  <node concept="3TrEf2" id="3jJoUQ71dsh" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="bx8c:1upvoB3Sm7d" resolve="decl" />
-                                  </node>
+              <node concept="3clFbF" id="5oKUazDnmTR" role="3cqZAp">
+                <node concept="1rXfSq" id="5oKUazDnmTP" role="3clFbG">
+                  <ref role="37wK5l" to="od2j:5oKUazDl7HJ" resolve="addImplementation" />
+                  <node concept="Xl_RD" id="3jJoUQ70rsH" role="37wK5m">
+                    <property role="Xl_RC" value="declId" />
+                    <node concept="17Uvod" id="3jJoUQ710he" role="lGtFl">
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                      <property role="2qtEX9" value="value" />
+                      <node concept="3zFVjK" id="3jJoUQ710hf" role="3zH0cK">
+                        <node concept="3clFbS" id="3jJoUQ710hg" role="2VODD2">
+                          <node concept="3clFbF" id="3jJoUQ71cO2" role="3cqZAp">
+                            <node concept="2OqwBi" id="3jJoUQ71dOZ" role="3clFbG">
+                              <node concept="2OqwBi" id="3jJoUQ71d1T" role="2Oq$k0">
+                                <node concept="30H73N" id="3jJoUQ71cO1" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="3jJoUQ71dsh" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="bx8c:1upvoB3Sm7d" resolve="decl" />
                                 </node>
-                                <node concept="2qgKlT" id="3jJoUQ71exw" role="2OqNvi">
-                                  <ref role="37wK5l" to="e9uj:3jJoUQ7114V" resolve="getId" />
-                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="3jJoUQ71exw" role="2OqNvi">
+                                <ref role="37wK5l" to="e9uj:3jJoUQ7114V" resolve="getId" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="2ShNRf" id="3jJoUQ70sTR" role="37wK5m">
-                      <node concept="YeOm9" id="3jJoUQ70ulq" role="2ShVmc">
-                        <node concept="1Y3b0j" id="3jJoUQ70ult" role="YeSDq">
-                          <property role="2bfB8j" value="true" />
-                          <ref role="1Y3XeK" to="od2j:3jJoUQ6YpTW" resolve="IFunctionImplementation" />
-                          <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                          <node concept="312cEg" id="1sd2boLzXMs" role="jymVt">
-                            <property role="TrG5h" value="myParameterTypes" />
-                            <node concept="3Tm6S6" id="1sd2boLzXMt" role="1B3o_S" />
-                            <node concept="_YKpA" id="1sd2boLzYKC" role="1tU5fm">
-                              <node concept="3uibUv" id="1sd2boLzYPg" role="_ZDj9">
+                  </node>
+                  <node concept="2ShNRf" id="3jJoUQ70sTR" role="37wK5m">
+                    <node concept="YeOm9" id="3jJoUQ70ulq" role="2ShVmc">
+                      <node concept="1Y3b0j" id="3jJoUQ70ult" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="od2j:3jJoUQ6YpTW" resolve="IFunctionImplementation" />
+                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                        <node concept="312cEg" id="1sd2boLzXMs" role="jymVt">
+                          <property role="TrG5h" value="myParameterTypes" />
+                          <node concept="3Tm6S6" id="1sd2boLzXMt" role="1B3o_S" />
+                          <node concept="_YKpA" id="1sd2boLzYKC" role="1tU5fm">
+                            <node concept="3uibUv" id="1sd2boLzYPg" role="_ZDj9">
+                              <ref role="3uigEE" to="od2j:1sd2boLzKrA" resolve="IParameterType" />
+                            </node>
+                          </node>
+                          <node concept="2ShNRf" id="1sd2boLzZhR" role="33vP2m">
+                            <node concept="Tc6Ow" id="1sd2boLzZcO" role="2ShVmc">
+                              <node concept="3uibUv" id="1sd2boLzZcP" role="HW$YZ">
                                 <ref role="3uigEE" to="od2j:1sd2boLzKrA" resolve="IParameterType" />
                               </node>
-                            </node>
-                            <node concept="2ShNRf" id="1sd2boLzZhR" role="33vP2m">
-                              <node concept="Tc6Ow" id="1sd2boLzZcO" role="2ShVmc">
-                                <node concept="3uibUv" id="1sd2boLzZcP" role="HW$YZ">
-                                  <ref role="3uigEE" to="od2j:1sd2boLzKrA" resolve="IParameterType" />
+                              <node concept="10Nm6u" id="1sd2boLzZEs" role="HW$Y0">
+                                <node concept="1WS0z7" id="1sd2boL$0bL" role="lGtFl">
+                                  <node concept="3JmXsc" id="1sd2boL$0bM" role="3Jn$fo">
+                                    <node concept="3clFbS" id="1sd2boL$0bN" role="2VODD2">
+                                      <node concept="3clFbF" id="1sd2boL$0sQ" role="3cqZAp">
+                                        <node concept="2OqwBi" id="1sd2boL$3Rx" role="3clFbG">
+                                          <node concept="2OqwBi" id="1sd2boL$0D0" role="2Oq$k0">
+                                            <node concept="30H73N" id="1sd2boL$0sP" role="2Oq$k0" />
+                                            <node concept="3Tsc0h" id="1sd2boL$253" role="2OqNvi">
+                                              <ref role="3TtcxE" to="bx8c:1upvoB3SJLC" resolve="parameters" />
+                                            </node>
+                                          </node>
+                                          <node concept="13MTOL" id="1sd2boL$5m7" role="2OqNvi">
+                                            <ref role="13MTZf" to="bx8c:1upvoB3RW5$" resolve="type" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
-                                <node concept="10Nm6u" id="1sd2boLzZEs" role="HW$Y0">
-                                  <node concept="1WS0z7" id="1sd2boL$0bL" role="lGtFl">
-                                    <node concept="3JmXsc" id="1sd2boL$0bM" role="3Jn$fo">
-                                      <node concept="3clFbS" id="1sd2boL$0bN" role="2VODD2">
-                                        <node concept="3clFbF" id="1sd2boL$0sQ" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1sd2boL$3Rx" role="3clFbG">
-                                            <node concept="2OqwBi" id="1sd2boL$0D0" role="2Oq$k0">
-                                              <node concept="30H73N" id="1sd2boL$0sP" role="2Oq$k0" />
-                                              <node concept="3Tsc0h" id="1sd2boL$253" role="2OqNvi">
-                                                <ref role="3TtcxE" to="bx8c:1upvoB3SJLC" resolve="parameters" />
+                                <node concept="1sPUBX" id="1sd2boL$ejS" role="lGtFl">
+                                  <ref role="v9R2y" node="1sd2boL$7dy" resolve="switch_parameterType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="312cEg" id="2Vy1$4N3GJb" role="jymVt">
+                          <property role="TrG5h" value="contextIds" />
+                          <node concept="3Tm6S6" id="2Vy1$4N3GJc" role="1B3o_S" />
+                          <node concept="_YKpA" id="2Vy1$4N3GYZ" role="1tU5fm">
+                            <node concept="17QB3L" id="2Vy1$4N3H3k" role="_ZDj9" />
+                          </node>
+                          <node concept="2ShNRf" id="2Vy1$4N3HtW" role="33vP2m">
+                            <node concept="Tc6Ow" id="2Vy1$4N3Htx" role="2ShVmc">
+                              <node concept="17QB3L" id="2Vy1$4N3Hty" role="HW$YZ" />
+                              <node concept="Xl_RD" id="2Vy1$4N3HFE" role="HW$Y0">
+                                <property role="Xl_RC" value="id" />
+                                <node concept="1WS0z7" id="2Vy1$4N3I0p" role="lGtFl">
+                                  <node concept="3JmXsc" id="2Vy1$4N3I0q" role="3Jn$fo">
+                                    <node concept="3clFbS" id="2Vy1$4N3I0r" role="2VODD2">
+                                      <node concept="3clFbF" id="2Vy1$4N3I7T" role="3cqZAp">
+                                        <node concept="2OqwBi" id="2Vy1$4N3In8" role="3clFbG">
+                                          <node concept="30H73N" id="2Vy1$4N3I7S" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="2Vy1$4N3IE3" role="2OqNvi">
+                                            <ref role="37wK5l" to="e9uj:2Vy1$4MUwYY" resolve="getContexts" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="17Uvod" id="2Vy1$4N3IRn" role="lGtFl">
+                                  <property role="2qtEX9" value="value" />
+                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                  <node concept="3zFVjK" id="2Vy1$4N3IRo" role="3zH0cK">
+                                    <node concept="3clFbS" id="2Vy1$4N3IRp" role="2VODD2">
+                                      <node concept="3clFbF" id="2Vy1$4N3J2h" role="3cqZAp">
+                                        <node concept="2OqwBi" id="2Vy1$4N3JgG" role="3clFbG">
+                                          <node concept="30H73N" id="2Vy1$4N3J2g" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="2Vy1$4N3JCM" role="2OqNvi">
+                                            <ref role="37wK5l" to="e9uj:2Vy1$4N2l38" resolve="getContextId" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="312cEg" id="6EfR$DZO_yC" role="jymVt">
+                          <property role="TrG5h" value="groupIds" />
+                          <node concept="3Tm6S6" id="6EfR$DZO_yD" role="1B3o_S" />
+                          <node concept="_YKpA" id="6EfR$DZO_yE" role="1tU5fm">
+                            <node concept="17QB3L" id="6EfR$DZO_yF" role="_ZDj9" />
+                          </node>
+                          <node concept="2ShNRf" id="6EfR$DZO_yG" role="33vP2m">
+                            <node concept="Tc6Ow" id="6EfR$DZO_yH" role="2ShVmc">
+                              <node concept="17QB3L" id="6EfR$DZO_yI" role="HW$YZ" />
+                              <node concept="Xl_RD" id="6EfR$DZO_yJ" role="HW$Y0">
+                                <property role="Xl_RC" value="id" />
+                                <node concept="1WS0z7" id="6EfR$DZO_yK" role="lGtFl">
+                                  <node concept="3JmXsc" id="6EfR$DZO_yL" role="3Jn$fo">
+                                    <node concept="3clFbS" id="6EfR$DZO_yM" role="2VODD2">
+                                      <node concept="3clFbF" id="6EfR$DZO_yN" role="3cqZAp">
+                                        <node concept="2OqwBi" id="6EfR$DZO_yO" role="3clFbG">
+                                          <node concept="30H73N" id="6EfR$DZO_yP" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="6EfR$DZOLzI" role="2OqNvi">
+                                            <ref role="37wK5l" to="e9uj:6EfR$DZOCR5" resolve="getPriorityGroups" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="17Uvod" id="6EfR$DZO_yR" role="lGtFl">
+                                  <property role="2qtEX9" value="value" />
+                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                  <node concept="3zFVjK" id="6EfR$DZO_yS" role="3zH0cK">
+                                    <node concept="3clFbS" id="6EfR$DZO_yT" role="2VODD2">
+                                      <node concept="3clFbF" id="6EfR$DZO_yU" role="3cqZAp">
+                                        <node concept="2OqwBi" id="6EfR$DZO_yV" role="3clFbG">
+                                          <node concept="30H73N" id="6EfR$DZO_yW" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="6EfR$DZOOcC" role="2OqNvi">
+                                            <ref role="37wK5l" to="e9uj:6EfR$DZON7b" resolve="getGroupId" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3Tm1VV" id="3jJoUQ70ulu" role="1B3o_S" />
+                        <node concept="3clFb_" id="1sd2boLvzfg" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="getId" />
+                          <node concept="17QB3L" id="1sd2boLvzfh" role="3clF45" />
+                          <node concept="3Tm1VV" id="1sd2boLvzfi" role="1B3o_S" />
+                          <node concept="3clFbS" id="1sd2boLvzfl" role="3clF47">
+                            <node concept="3clFbF" id="1sd2boLv_4Q" role="3cqZAp">
+                              <node concept="Xl_RD" id="1sd2boLv_4P" role="3clFbG">
+                                <property role="Xl_RC" value="implId" />
+                                <node concept="17Uvod" id="1sd2boLv_dk" role="lGtFl">
+                                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                                  <property role="2qtEX9" value="value" />
+                                  <node concept="3zFVjK" id="1sd2boLv_dl" role="3zH0cK">
+                                    <node concept="3clFbS" id="1sd2boLv_dm" role="2VODD2">
+                                      <node concept="3clFbF" id="1sd2boLvOi4" role="3cqZAp">
+                                        <node concept="2OqwBi" id="1sd2boLvOvX" role="3clFbG">
+                                          <node concept="30H73N" id="1sd2boLvOi3" role="2Oq$k0" />
+                                          <node concept="2qgKlT" id="1sd2boLvP2h" role="2OqNvi">
+                                            <ref role="37wK5l" to="e9uj:1sd2boLvAH4" resolve="getId" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2AHcQZ" id="1sd2boLvzfm" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                        <node concept="3clFb_" id="3jJoUQ70ulv" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="isApplicable" />
+                          <node concept="37vLTG" id="3jJoUQ71MlC" role="3clF46">
+                            <property role="TrG5h" value="_PFcontext" />
+                            <property role="3TUv4t" value="true" />
+                            <node concept="3uibUv" id="3jJoUQ71MlD" role="1tU5fm">
+                              <ref role="3uigEE" to="od2j:3jJoUQ71IRE" resolve="IPFContext" />
+                            </node>
+                          </node>
+                          <node concept="37vLTG" id="3jJoUQ70ulw" role="3clF46">
+                            <property role="TrG5h" value="_PFparameters" />
+                            <property role="3TUv4t" value="true" />
+                            <node concept="3uibUv" id="3jJoUQ70ulx" role="1tU5fm">
+                              <ref role="3uigEE" to="od2j:3jJoUQ6Yq4x" resolve="ParameterList" />
+                            </node>
+                          </node>
+                          <node concept="10P_77" id="3jJoUQ70uly" role="3clF45" />
+                          <node concept="3Tm1VV" id="3jJoUQ70ulz" role="1B3o_S" />
+                          <node concept="3clFbS" id="3jJoUQ70ul_" role="3clF47">
+                            <node concept="3clFbH" id="3jJoUQ70xzl" role="3cqZAp">
+                              <node concept="1WS0z7" id="3jJoUQ70xY7" role="lGtFl">
+                                <node concept="3JmXsc" id="3jJoUQ70xY8" role="3Jn$fo">
+                                  <node concept="3clFbS" id="3jJoUQ70xY9" role="2VODD2">
+                                    <node concept="3clFbF" id="3jJoUQ70y3v" role="3cqZAp">
+                                      <node concept="2OqwBi" id="3jJoUQ70yfF" role="3clFbG">
+                                        <node concept="30H73N" id="3jJoUQ70y3u" role="2Oq$k0" />
+                                        <node concept="3Tsc0h" id="3jJoUQ70yJp" role="2OqNvi">
+                                          <ref role="3TtcxE" to="bx8c:1upvoB3SJLC" resolve="parameters" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="1sPUBX" id="3jJoUQ70zgy" role="lGtFl">
+                                <ref role="v9R2y" node="3jJoUQ70xzR" resolve="switch_isApplicable" />
+                              </node>
+                            </node>
+                            <node concept="3clFbJ" id="1sd2boLrssc" role="3cqZAp">
+                              <node concept="3clFbS" id="1sd2boLrsse" role="3clFbx">
+                                <node concept="3cpWs6" id="1sd2boLrsAg" role="3cqZAp">
+                                  <node concept="3clFbT" id="1sd2boLrtmE" role="3cqZAk">
+                                    <property role="3clFbU" value="false" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3fqX7Q" id="1sd2boLrs_d" role="3clFbw">
+                                <node concept="1eOMI4" id="1sd2boLrs_f" role="3fr31v">
+                                  <node concept="3clFbT" id="1sd2boLru6J" role="1eOMHV">
+                                    <property role="3clFbU" value="true" />
+                                    <node concept="29HgVG" id="1sd2boLruaY" role="lGtFl">
+                                      <node concept="3NFfHV" id="1sd2boLruaZ" role="3NFExx">
+                                        <node concept="3clFbS" id="1sd2boLrub0" role="2VODD2">
+                                          <node concept="3clFbF" id="1sd2boLrub6" role="3cqZAp">
+                                            <node concept="2OqwBi" id="1sd2boLrub1" role="3clFbG">
+                                              <node concept="3TrEf2" id="1sd2boLrub4" role="2OqNvi">
+                                                <ref role="3Tt5mk" to="bx8c:1sd2boLp1HD" resolve="condition" />
                                               </node>
-                                            </node>
-                                            <node concept="13MTOL" id="1sd2boL$5m7" role="2OqNvi">
-                                              <ref role="13MTZf" to="bx8c:1upvoB3RW5$" resolve="type" />
+                                              <node concept="30H73N" id="1sd2boLrub5" role="2Oq$k0" />
                                             </node>
                                           </node>
                                         </node>
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="1sPUBX" id="1sd2boL$ejS" role="lGtFl">
-                                    <ref role="v9R2y" node="1sd2boL$7dy" resolve="switch_parameterType" />
+                                </node>
+                              </node>
+                              <node concept="1W57fq" id="1sd2boLrv9X" role="lGtFl">
+                                <node concept="3IZrLx" id="1sd2boLrv9Y" role="3IZSJc">
+                                  <node concept="3clFbS" id="1sd2boLrv9Z" role="2VODD2">
+                                    <node concept="3clFbF" id="1sd2boLrvYF" role="3cqZAp">
+                                      <node concept="2OqwBi" id="1sd2boLryfB" role="3clFbG">
+                                        <node concept="2OqwBi" id="1sd2boLrwbX" role="2Oq$k0">
+                                          <node concept="30H73N" id="1sd2boLrvYE" role="2Oq$k0" />
+                                          <node concept="3TrEf2" id="1sd2boLrxCf" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="bx8c:1sd2boLp1HD" resolve="condition" />
+                                          </node>
+                                        </node>
+                                        <node concept="3x8VRR" id="1sd2boLryBQ" role="2OqNvi" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="3jJoUQ70uJd" role="3cqZAp">
+                              <node concept="3clFbT" id="3jJoUQ70uJc" role="3clFbG">
+                                <property role="3clFbU" value="true" />
                               </node>
                             </node>
                           </node>
-                          <node concept="312cEg" id="2Vy1$4N3GJb" role="jymVt">
-                            <property role="TrG5h" value="contextIds" />
-                            <node concept="3Tm6S6" id="2Vy1$4N3GJc" role="1B3o_S" />
-                            <node concept="_YKpA" id="2Vy1$4N3GYZ" role="1tU5fm">
-                              <node concept="17QB3L" id="2Vy1$4N3H3k" role="_ZDj9" />
-                            </node>
-                            <node concept="2ShNRf" id="2Vy1$4N3HtW" role="33vP2m">
-                              <node concept="Tc6Ow" id="2Vy1$4N3Htx" role="2ShVmc">
-                                <node concept="17QB3L" id="2Vy1$4N3Hty" role="HW$YZ" />
-                                <node concept="Xl_RD" id="2Vy1$4N3HFE" role="HW$Y0">
-                                  <property role="Xl_RC" value="id" />
-                                  <node concept="1WS0z7" id="2Vy1$4N3I0p" role="lGtFl">
-                                    <node concept="3JmXsc" id="2Vy1$4N3I0q" role="3Jn$fo">
-                                      <node concept="3clFbS" id="2Vy1$4N3I0r" role="2VODD2">
-                                        <node concept="3clFbF" id="2Vy1$4N3I7T" role="3cqZAp">
-                                          <node concept="2OqwBi" id="2Vy1$4N3In8" role="3clFbG">
-                                            <node concept="30H73N" id="2Vy1$4N3I7S" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="2Vy1$4N3IE3" role="2OqNvi">
-                                              <ref role="37wK5l" to="e9uj:2Vy1$4MUwYY" resolve="getContexts" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="17Uvod" id="2Vy1$4N3IRn" role="lGtFl">
-                                    <property role="2qtEX9" value="value" />
-                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                    <node concept="3zFVjK" id="2Vy1$4N3IRo" role="3zH0cK">
-                                      <node concept="3clFbS" id="2Vy1$4N3IRp" role="2VODD2">
-                                        <node concept="3clFbF" id="2Vy1$4N3J2h" role="3cqZAp">
-                                          <node concept="2OqwBi" id="2Vy1$4N3JgG" role="3clFbG">
-                                            <node concept="30H73N" id="2Vy1$4N3J2g" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="2Vy1$4N3JCM" role="2OqNvi">
-                                              <ref role="37wK5l" to="e9uj:2Vy1$4N2l38" resolve="getContextId" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                        </node>
+                        <node concept="3clFb_" id="3jJoUQ70ulB" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="execute" />
+                          <node concept="37vLTG" id="3jJoUQ71MSJ" role="3clF46">
+                            <property role="TrG5h" value="_PFcontext" />
+                            <property role="3TUv4t" value="true" />
+                            <node concept="3uibUv" id="3jJoUQ71MSK" role="1tU5fm">
+                              <ref role="3uigEE" to="od2j:3jJoUQ71IRE" resolve="IPFContext" />
                             </node>
                           </node>
-                          <node concept="312cEg" id="6EfR$DZO_yC" role="jymVt">
-                            <property role="TrG5h" value="groupIds" />
-                            <node concept="3Tm6S6" id="6EfR$DZO_yD" role="1B3o_S" />
-                            <node concept="_YKpA" id="6EfR$DZO_yE" role="1tU5fm">
-                              <node concept="17QB3L" id="6EfR$DZO_yF" role="_ZDj9" />
-                            </node>
-                            <node concept="2ShNRf" id="6EfR$DZO_yG" role="33vP2m">
-                              <node concept="Tc6Ow" id="6EfR$DZO_yH" role="2ShVmc">
-                                <node concept="17QB3L" id="6EfR$DZO_yI" role="HW$YZ" />
-                                <node concept="Xl_RD" id="6EfR$DZO_yJ" role="HW$Y0">
-                                  <property role="Xl_RC" value="id" />
-                                  <node concept="1WS0z7" id="6EfR$DZO_yK" role="lGtFl">
-                                    <node concept="3JmXsc" id="6EfR$DZO_yL" role="3Jn$fo">
-                                      <node concept="3clFbS" id="6EfR$DZO_yM" role="2VODD2">
-                                        <node concept="3clFbF" id="6EfR$DZO_yN" role="3cqZAp">
-                                          <node concept="2OqwBi" id="6EfR$DZO_yO" role="3clFbG">
-                                            <node concept="30H73N" id="6EfR$DZO_yP" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="6EfR$DZOLzI" role="2OqNvi">
-                                              <ref role="37wK5l" to="e9uj:6EfR$DZOCR5" resolve="getPriorityGroups" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="17Uvod" id="6EfR$DZO_yR" role="lGtFl">
-                                    <property role="2qtEX9" value="value" />
-                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                    <node concept="3zFVjK" id="6EfR$DZO_yS" role="3zH0cK">
-                                      <node concept="3clFbS" id="6EfR$DZO_yT" role="2VODD2">
-                                        <node concept="3clFbF" id="6EfR$DZO_yU" role="3cqZAp">
-                                          <node concept="2OqwBi" id="6EfR$DZO_yV" role="3clFbG">
-                                            <node concept="30H73N" id="6EfR$DZO_yW" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="6EfR$DZOOcC" role="2OqNvi">
-                                              <ref role="37wK5l" to="e9uj:6EfR$DZON7b" resolve="getGroupId" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                          <node concept="37vLTG" id="3jJoUQ70ulC" role="3clF46">
+                            <property role="TrG5h" value="_PFparameters" />
+                            <property role="3TUv4t" value="true" />
+                            <node concept="3uibUv" id="3jJoUQ70ulD" role="1tU5fm">
+                              <ref role="3uigEE" to="od2j:3jJoUQ6Yq4x" resolve="ParameterList" />
                             </node>
                           </node>
-                          <node concept="3Tm1VV" id="3jJoUQ70ulu" role="1B3o_S" />
-                          <node concept="3clFb_" id="1sd2boLvzfg" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="getId" />
-                            <node concept="17QB3L" id="1sd2boLvzfh" role="3clF45" />
-                            <node concept="3Tm1VV" id="1sd2boLvzfi" role="1B3o_S" />
-                            <node concept="3clFbS" id="1sd2boLvzfl" role="3clF47">
-                              <node concept="3clFbF" id="1sd2boLv_4Q" role="3cqZAp">
-                                <node concept="Xl_RD" id="1sd2boLv_4P" role="3clFbG">
-                                  <property role="Xl_RC" value="implId" />
-                                  <node concept="17Uvod" id="1sd2boLv_dk" role="lGtFl">
-                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                                    <property role="2qtEX9" value="value" />
-                                    <node concept="3zFVjK" id="1sd2boLv_dl" role="3zH0cK">
-                                      <node concept="3clFbS" id="1sd2boLv_dm" role="2VODD2">
-                                        <node concept="3clFbF" id="1sd2boLvOi4" role="3cqZAp">
-                                          <node concept="2OqwBi" id="1sd2boLvOvX" role="3clFbG">
-                                            <node concept="30H73N" id="1sd2boLvOi3" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="1sd2boLvP2h" role="2OqNvi">
-                                              <ref role="37wK5l" to="e9uj:1sd2boLvAH4" resolve="getId" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2AHcQZ" id="1sd2boLvzfm" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                            </node>
+                          <node concept="3uibUv" id="3jJoUQ70ulE" role="3clF45">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                           </node>
-                          <node concept="3clFb_" id="3jJoUQ70ulv" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="isApplicable" />
-                            <node concept="37vLTG" id="3jJoUQ71MlC" role="3clF46">
-                              <property role="TrG5h" value="_PFcontext" />
-                              <property role="3TUv4t" value="true" />
-                              <node concept="3uibUv" id="3jJoUQ71MlD" role="1tU5fm">
-                                <ref role="3uigEE" to="od2j:3jJoUQ71IRE" resolve="IPFContext" />
-                              </node>
-                            </node>
-                            <node concept="37vLTG" id="3jJoUQ70ulw" role="3clF46">
-                              <property role="TrG5h" value="_PFparameters" />
-                              <property role="3TUv4t" value="true" />
-                              <node concept="3uibUv" id="3jJoUQ70ulx" role="1tU5fm">
-                                <ref role="3uigEE" to="od2j:3jJoUQ6Yq4x" resolve="ParameterList" />
-                              </node>
-                            </node>
-                            <node concept="10P_77" id="3jJoUQ70uly" role="3clF45" />
-                            <node concept="3Tm1VV" id="3jJoUQ70ulz" role="1B3o_S" />
-                            <node concept="3clFbS" id="3jJoUQ70ul_" role="3clF47">
-                              <node concept="3clFbH" id="3jJoUQ70xzl" role="3cqZAp">
-                                <node concept="1WS0z7" id="3jJoUQ70xY7" role="lGtFl">
-                                  <node concept="3JmXsc" id="3jJoUQ70xY8" role="3Jn$fo">
-                                    <node concept="3clFbS" id="3jJoUQ70xY9" role="2VODD2">
-                                      <node concept="3clFbF" id="3jJoUQ70y3v" role="3cqZAp">
-                                        <node concept="2OqwBi" id="3jJoUQ70yfF" role="3clFbG">
-                                          <node concept="30H73N" id="3jJoUQ70y3u" role="2Oq$k0" />
-                                          <node concept="3Tsc0h" id="3jJoUQ70yJp" role="2OqNvi">
-                                            <ref role="3TtcxE" to="bx8c:1upvoB3SJLC" resolve="parameters" />
+                          <node concept="3Tm1VV" id="3jJoUQ70ulF" role="1B3o_S" />
+                          <node concept="3clFbS" id="3jJoUQ70ulH" role="3clF47">
+                            <node concept="3clFbH" id="3jJoUQ732e$" role="3cqZAp">
+                              <node concept="2b32R4" id="3jJoUQ732Ki" role="lGtFl">
+                                <node concept="3JmXsc" id="3jJoUQ732Kj" role="2P8S$">
+                                  <node concept="3clFbS" id="3jJoUQ732Kk" role="2VODD2">
+                                    <node concept="3clFbF" id="3jJoUQ71hX4" role="3cqZAp">
+                                      <node concept="2OqwBi" id="3jJoUQ71iW4" role="3clFbG">
+                                        <node concept="2OqwBi" id="3jJoUQ71i9e" role="2Oq$k0">
+                                          <node concept="30H73N" id="3jJoUQ71hX3" role="2Oq$k0" />
+                                          <node concept="3TrEf2" id="3jJoUQ71iyU" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="bx8c:1upvoB3Sm77" resolve="body" />
                                           </node>
                                         </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="1sPUBX" id="3jJoUQ70zgy" role="lGtFl">
-                                  <ref role="v9R2y" node="3jJoUQ70xzR" resolve="switch_isApplicable" />
-                                </node>
-                              </node>
-                              <node concept="3clFbJ" id="1sd2boLrssc" role="3cqZAp">
-                                <node concept="3clFbS" id="1sd2boLrsse" role="3clFbx">
-                                  <node concept="3cpWs6" id="1sd2boLrsAg" role="3cqZAp">
-                                    <node concept="3clFbT" id="1sd2boLrtmE" role="3cqZAk">
-                                      <property role="3clFbU" value="false" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3fqX7Q" id="1sd2boLrs_d" role="3clFbw">
-                                  <node concept="1eOMI4" id="1sd2boLrs_f" role="3fr31v">
-                                    <node concept="3clFbT" id="1sd2boLru6J" role="1eOMHV">
-                                      <property role="3clFbU" value="true" />
-                                      <node concept="29HgVG" id="1sd2boLruaY" role="lGtFl">
-                                        <node concept="3NFfHV" id="1sd2boLruaZ" role="3NFExx">
-                                          <node concept="3clFbS" id="1sd2boLrub0" role="2VODD2">
-                                            <node concept="3clFbF" id="1sd2boLrub6" role="3cqZAp">
-                                              <node concept="2OqwBi" id="1sd2boLrub1" role="3clFbG">
-                                                <node concept="3TrEf2" id="1sd2boLrub4" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="bx8c:1sd2boLp1HD" resolve="condition" />
-                                                </node>
-                                                <node concept="30H73N" id="1sd2boLrub5" role="2Oq$k0" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="1W57fq" id="1sd2boLrv9X" role="lGtFl">
-                                  <node concept="3IZrLx" id="1sd2boLrv9Y" role="3IZSJc">
-                                    <node concept="3clFbS" id="1sd2boLrv9Z" role="2VODD2">
-                                      <node concept="3clFbF" id="1sd2boLrvYF" role="3cqZAp">
-                                        <node concept="2OqwBi" id="1sd2boLryfB" role="3clFbG">
-                                          <node concept="2OqwBi" id="1sd2boLrwbX" role="2Oq$k0">
-                                            <node concept="30H73N" id="1sd2boLrvYE" role="2Oq$k0" />
-                                            <node concept="3TrEf2" id="1sd2boLrxCf" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="bx8c:1sd2boLp1HD" resolve="condition" />
-                                            </node>
-                                          </node>
-                                          <node concept="3x8VRR" id="1sd2boLryBQ" role="2OqNvi" />
+                                        <node concept="3Tsc0h" id="3jJoUQ71jGQ" role="2OqNvi">
+                                          <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
                                         </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="3clFbF" id="3jJoUQ70uJd" role="3cqZAp">
-                                <node concept="3clFbT" id="3jJoUQ70uJc" role="3clFbG">
-                                  <property role="3clFbU" value="true" />
-                                </node>
-                              </node>
                             </node>
-                          </node>
-                          <node concept="3clFb_" id="3jJoUQ70ulB" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="execute" />
-                            <node concept="37vLTG" id="3jJoUQ71MSJ" role="3clF46">
-                              <property role="TrG5h" value="_PFcontext" />
-                              <property role="3TUv4t" value="true" />
-                              <node concept="3uibUv" id="3jJoUQ71MSK" role="1tU5fm">
-                                <ref role="3uigEE" to="od2j:3jJoUQ71IRE" resolve="IPFContext" />
-                              </node>
-                            </node>
-                            <node concept="37vLTG" id="3jJoUQ70ulC" role="3clF46">
-                              <property role="TrG5h" value="_PFparameters" />
-                              <property role="3TUv4t" value="true" />
-                              <node concept="3uibUv" id="3jJoUQ70ulD" role="1tU5fm">
-                                <ref role="3uigEE" to="od2j:3jJoUQ6Yq4x" resolve="ParameterList" />
-                              </node>
-                            </node>
-                            <node concept="3uibUv" id="3jJoUQ70ulE" role="3clF45">
-                              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                            </node>
-                            <node concept="3Tm1VV" id="3jJoUQ70ulF" role="1B3o_S" />
-                            <node concept="3clFbS" id="3jJoUQ70ulH" role="3clF47">
-                              <node concept="3clFbH" id="3jJoUQ732e$" role="3cqZAp">
-                                <node concept="2b32R4" id="3jJoUQ732Ki" role="lGtFl">
-                                  <node concept="3JmXsc" id="3jJoUQ732Kj" role="2P8S$">
-                                    <node concept="3clFbS" id="3jJoUQ732Kk" role="2VODD2">
-                                      <node concept="3clFbF" id="3jJoUQ71hX4" role="3cqZAp">
-                                        <node concept="2OqwBi" id="3jJoUQ71iW4" role="3clFbG">
-                                          <node concept="2OqwBi" id="3jJoUQ71i9e" role="2Oq$k0">
-                                            <node concept="30H73N" id="3jJoUQ71hX3" role="2Oq$k0" />
-                                            <node concept="3TrEf2" id="3jJoUQ71iyU" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="bx8c:1upvoB3Sm77" resolve="body" />
+                            <node concept="3cpWs6" id="3jJoUQ72YJR" role="3cqZAp">
+                              <node concept="10Nm6u" id="3jJoUQ72ZPC" role="3cqZAk" />
+                              <node concept="1W57fq" id="3jJoUQ733WQ" role="lGtFl">
+                                <node concept="3IZrLx" id="3jJoUQ733WR" role="3IZSJc">
+                                  <node concept="3clFbS" id="3jJoUQ733WS" role="2VODD2">
+                                    <node concept="3clFbF" id="3jJoUQ734AA" role="3cqZAp">
+                                      <node concept="2OqwBi" id="3jJoUQ736$2" role="3clFbG">
+                                        <node concept="2OqwBi" id="3jJoUQ735J$" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="3jJoUQ734NO" role="2Oq$k0">
+                                            <node concept="30H73N" id="3jJoUQ734A_" role="2Oq$k0" />
+                                            <node concept="3TrEf2" id="3jJoUQ735pn" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="bx8c:1upvoB3Sm7d" resolve="decl" />
                                             </node>
                                           </node>
-                                          <node concept="3Tsc0h" id="3jJoUQ71jGQ" role="2OqNvi">
-                                            <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                                          <node concept="3TrEf2" id="3jJoUQ7368R" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="bx8c:1upvoB3TuSm" resolve="returnBaseType" />
                                           </node>
                                         </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3cpWs6" id="3jJoUQ72YJR" role="3cqZAp">
-                                <node concept="10Nm6u" id="3jJoUQ72ZPC" role="3cqZAk" />
-                                <node concept="1W57fq" id="3jJoUQ733WQ" role="lGtFl">
-                                  <node concept="3IZrLx" id="3jJoUQ733WR" role="3IZSJc">
-                                    <node concept="3clFbS" id="3jJoUQ733WS" role="2VODD2">
-                                      <node concept="3clFbF" id="3jJoUQ734AA" role="3cqZAp">
-                                        <node concept="2OqwBi" id="3jJoUQ736$2" role="3clFbG">
-                                          <node concept="2OqwBi" id="3jJoUQ735J$" role="2Oq$k0">
-                                            <node concept="2OqwBi" id="3jJoUQ734NO" role="2Oq$k0">
-                                              <node concept="30H73N" id="3jJoUQ734A_" role="2Oq$k0" />
-                                              <node concept="3TrEf2" id="3jJoUQ735pn" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="bx8c:1upvoB3Sm7d" resolve="decl" />
-                                              </node>
-                                            </node>
-                                            <node concept="3TrEf2" id="3jJoUQ7368R" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="bx8c:1upvoB3TuSm" resolve="returnBaseType" />
-                                            </node>
-                                          </node>
-                                          <node concept="1mIQ4w" id="3jJoUQ737iN" role="2OqNvi">
-                                            <node concept="chp4Y" id="3jJoUQ737wO" role="cj9EA">
-                                              <ref role="cht4Q" to="tpee:fzcqZ_H" resolve="VoidType" />
-                                            </node>
+                                        <node concept="1mIQ4w" id="3jJoUQ737iN" role="2OqNvi">
+                                          <node concept="chp4Y" id="3jJoUQ737wO" role="cj9EA">
+                                            <ref role="cht4Q" to="tpee:fzcqZ_H" resolve="VoidType" />
                                           </node>
                                         </node>
                                       </node>
@@ -765,66 +758,66 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFb_" id="1sd2boLzUMs" role="jymVt">
-                            <property role="1EzhhJ" value="false" />
-                            <property role="TrG5h" value="getParameterTypes" />
-                            <node concept="A3Dl8" id="1sd2boLzUMt" role="3clF45">
-                              <node concept="3uibUv" id="1sd2boLzUMu" role="A3Ik2">
-                                <ref role="3uigEE" to="od2j:1sd2boLzKrA" resolve="IParameterType" />
-                              </node>
-                            </node>
-                            <node concept="3Tm1VV" id="1sd2boLzUMv" role="1B3o_S" />
-                            <node concept="3clFbS" id="1sd2boLzUMy" role="3clF47">
-                              <node concept="3clFbF" id="1sd2boLzZK_" role="3cqZAp">
-                                <node concept="37vLTw" id="1sd2boLzZK$" role="3clFbG">
-                                  <ref role="3cqZAo" node="1sd2boLzXMs" resolve="myParameterTypes" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2AHcQZ" id="1sd2boLzUMz" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                        </node>
+                        <node concept="3clFb_" id="1sd2boLzUMs" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="getParameterTypes" />
+                          <node concept="A3Dl8" id="1sd2boLzUMt" role="3clF45">
+                            <node concept="3uibUv" id="1sd2boLzUMu" role="A3Ik2">
+                              <ref role="3uigEE" to="od2j:1sd2boLzKrA" resolve="IParameterType" />
                             </node>
                           </node>
-                          <node concept="3clFb_" id="2Vy1$4N3JM8" role="jymVt">
-                            <property role="TrG5h" value="getContextIds" />
-                            <node concept="A3Dl8" id="2Vy1$4N3JM9" role="3clF45">
-                              <node concept="17QB3L" id="2Vy1$4N3JMa" role="A3Ik2" />
-                            </node>
-                            <node concept="3Tm1VV" id="2Vy1$4N3JMb" role="1B3o_S" />
-                            <node concept="3clFbS" id="2Vy1$4N3JMe" role="3clF47">
-                              <node concept="3clFbF" id="2Vy1$4N3KRI" role="3cqZAp">
-                                <node concept="37vLTw" id="2Vy1$4N3KRH" role="3clFbG">
-                                  <ref role="3cqZAo" node="2Vy1$4N3GJb" resolve="contextIds" />
-                                </node>
+                          <node concept="3Tm1VV" id="1sd2boLzUMv" role="1B3o_S" />
+                          <node concept="3clFbS" id="1sd2boLzUMy" role="3clF47">
+                            <node concept="3clFbF" id="1sd2boLzZK_" role="3cqZAp">
+                              <node concept="37vLTw" id="1sd2boLzZK$" role="3clFbG">
+                                <ref role="3cqZAo" node="1sd2boLzXMs" resolve="myParameterTypes" />
                               </node>
-                            </node>
-                            <node concept="2AHcQZ" id="2Vy1$4N3JMf" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                             </node>
                           </node>
-                          <node concept="3clFb_" id="6EfR$DZOJLI" role="jymVt">
-                            <property role="TrG5h" value="getPriorityGroupIds" />
-                            <node concept="A3Dl8" id="6EfR$DZOJLJ" role="3clF45">
-                              <node concept="17QB3L" id="6EfR$DZOJLK" role="A3Ik2" />
-                            </node>
-                            <node concept="3Tm1VV" id="6EfR$DZOJLL" role="1B3o_S" />
-                            <node concept="3clFbS" id="6EfR$DZOJLO" role="3clF47">
-                              <node concept="3clFbF" id="6EfR$DZOLaA" role="3cqZAp">
-                                <node concept="37vLTw" id="6EfR$DZOLa_" role="3clFbG">
-                                  <ref role="3cqZAo" node="6EfR$DZO_yC" resolve="groupIds" />
-                                </node>
+                          <node concept="2AHcQZ" id="1sd2boLzUMz" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                        <node concept="3clFb_" id="2Vy1$4N3JM8" role="jymVt">
+                          <property role="TrG5h" value="getContextIds" />
+                          <node concept="A3Dl8" id="2Vy1$4N3JM9" role="3clF45">
+                            <node concept="17QB3L" id="2Vy1$4N3JMa" role="A3Ik2" />
+                          </node>
+                          <node concept="3Tm1VV" id="2Vy1$4N3JMb" role="1B3o_S" />
+                          <node concept="3clFbS" id="2Vy1$4N3JMe" role="3clF47">
+                            <node concept="3clFbF" id="2Vy1$4N3KRI" role="3cqZAp">
+                              <node concept="37vLTw" id="2Vy1$4N3KRH" role="3clFbG">
+                                <ref role="3cqZAo" node="2Vy1$4N3GJb" resolve="contextIds" />
                               </node>
                             </node>
-                            <node concept="2AHcQZ" id="6EfR$DZOJLP" role="2AJF6D">
-                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                          <node concept="2AHcQZ" id="2Vy1$4N3JMf" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                          </node>
+                        </node>
+                        <node concept="3clFb_" id="6EfR$DZOJLI" role="jymVt">
+                          <property role="TrG5h" value="getPriorityGroupIds" />
+                          <node concept="A3Dl8" id="6EfR$DZOJLJ" role="3clF45">
+                            <node concept="17QB3L" id="6EfR$DZOJLK" role="A3Ik2" />
+                          </node>
+                          <node concept="3Tm1VV" id="6EfR$DZOJLL" role="1B3o_S" />
+                          <node concept="3clFbS" id="6EfR$DZOJLO" role="3clF47">
+                            <node concept="3clFbF" id="6EfR$DZOLaA" role="3cqZAp">
+                              <node concept="37vLTw" id="6EfR$DZOLa_" role="3clFbG">
+                                <ref role="3cqZAo" node="6EfR$DZO_yC" resolve="groupIds" />
+                              </node>
                             </node>
+                          </node>
+                          <node concept="2AHcQZ" id="6EfR$DZOJLP" role="2AJF6D">
+                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="raruj" id="3jJoUQ70uWP" role="lGtFl" />
+                <node concept="raruj" id="5oKUazDozzO" role="lGtFl" />
               </node>
             </node>
           </node>

--- a/code/shadowmodels/solutions/de.q60.mps.polymorphicfunctions.runtime/models/de.q60.mps.polymorphicfunctions.runtime.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.polymorphicfunctions.runtime/models/de.q60.mps.polymorphicfunctions.runtime.mps
@@ -1377,6 +1377,40 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="2tJIrI" id="5oKUazDkYLl" role="jymVt" />
+    <node concept="3clFb_" id="5oKUazDl7HJ" role="jymVt">
+      <property role="TrG5h" value="addImplementation" />
+      <node concept="3clFbS" id="5oKUazDl7HM" role="3clF47">
+        <node concept="3clFbF" id="5oKUazDl9Sj" role="3cqZAp">
+          <node concept="2OqwBi" id="5oKUazDlaGx" role="3clFbG">
+            <node concept="37vLTw" id="5oKUazDl9Si" role="2Oq$k0">
+              <ref role="3cqZAo" node="3jJoUQ6YEnK" resolve="myImplementations" />
+            </node>
+            <node concept="liA8E" id="5oKUazDlegU" role="2OqNvi">
+              <ref role="37wK5l" to="3o3z:~Multimap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="37vLTw" id="5oKUazDlgzT" role="37wK5m">
+                <ref role="3cqZAo" node="5oKUazDl8pW" resolve="declarationId" />
+              </node>
+              <node concept="37vLTw" id="5oKUazDlhBR" role="37wK5m">
+                <ref role="3cqZAo" node="5oKUazDl8O2" resolve="implementation" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="5oKUazDl7gS" role="1B3o_S" />
+      <node concept="3cqZAl" id="5oKUazDl7Fd" role="3clF45" />
+      <node concept="37vLTG" id="5oKUazDl8pW" role="3clF46">
+        <property role="TrG5h" value="declarationId" />
+        <node concept="17QB3L" id="5oKUazDl8pV" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5oKUazDl8O2" role="3clF46">
+        <property role="TrG5h" value="implementation" />
+        <node concept="3uibUv" id="5oKUazDl9bP" role="1tU5fm">
+          <ref role="3uigEE" node="3jJoUQ6YpTW" resolve="IFunctionImplementation" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="1sd2boLthKV" role="jymVt" />
     <node concept="3clFb_" id="1sd2boLve7S" role="jymVt">
       <property role="1EzhhJ" value="false" />


### PR DESCRIPTION
Add protected method PFModule#addImplementation to encapsulate usage of Google Collections. Now the generated code no longer needs Google Collections on the compilation classpath (runtime dependency of course remains).