### PR TITLE
SelectionIntentionManager: use ModuleRuntime to manage instances

### DIFF
--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/de.itemis.mps.selection.runtime.msd
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/de.itemis.mps.selection.runtime.msd
@@ -29,6 +29,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:acfc188d-d5d6-4598-b370-6f4a983f05b2:jetbrains.mps.baseLanguage.methodReferences" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/intentions.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/intentions.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -23,7 +24,12 @@
     <import index="yyf4" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.util(MPS.OpenAPI/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
-    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
+    <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
+    <import index="t6h5" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang.reflect(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -61,6 +67,9 @@
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P">
+        <reference id="1182955020723" name="classConcept" index="1HBi2w" />
+      </concept>
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
@@ -73,9 +82,8 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
-        <child id="1081256993305" name="classType" index="2ZW6by" />
-        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -93,6 +101,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
         <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
@@ -106,7 +117,6 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -126,6 +136,7 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <property id="4467513934994662257" name="forceMultiLine" index="TyiWK" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -153,6 +164,7 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -166,6 +178,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -174,12 +187,11 @@
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
-      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
-        <reference id="1116615189566" name="classifier" index="3VsUkX" />
-      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
@@ -200,10 +212,14 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
-    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
-      <concept id="361130699826193249" name="jetbrains.mps.lang.modelapi.structure.ModulePointer" flags="ng" index="1dCxOk">
-        <property id="1863527487546097500" name="moduleId" index="1XweGW" />
-        <property id="1863527487545993577" name="moduleName" index="1XxBO9" />
+    <language id="acfc188d-d5d6-4598-b370-6f4a983f05b2" name="jetbrains.mps.baseLanguage.methodReferences">
+      <concept id="7915009415671748557" name="jetbrains.mps.baseLanguage.methodReferences.structure.MethodReferenceTypeTargetExpression" flags="ng" index="2FaPjH">
+        <child id="7915009415671751864" name="type" index="2FaQuo" />
+      </concept>
+      <concept id="237887375562511215" name="jetbrains.mps.baseLanguage.methodReferences.structure.MethodReference" flags="ng" index="37Ijox" />
+      <concept id="3507059745126391419" name="jetbrains.mps.baseLanguage.methodReferences.structure.IMethodReference" flags="ngI" index="3UZKCU">
+        <reference id="237887375562511297" name="method" index="37Ijqf" />
+        <child id="962278442658307079" name="target" index="wWaWy" />
       </concept>
     </language>
     <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
@@ -213,14 +229,17 @@
         <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
-    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
-        <child id="1678062499342629861" name="moduleId" index="37shsm" />
-      </concept>
-    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -255,10 +274,7 @@
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
-      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
-        <child id="1197687026896" name="keyType" index="3rHrn6" />
-        <child id="1197687035757" name="valueType" index="3rHtpV" />
-      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1208542034276" name="jetbrains.mps.baseLanguage.collections.structure.MapClearOperation" flags="nn" index="1yHZxX" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
@@ -335,10 +351,11 @@
     <node concept="2tJIrI" id="630t2b8aWoR" role="jymVt" />
     <node concept="312cEg" id="630t2b8bgH2" role="jymVt">
       <property role="TrG5h" value="myFactories" />
+      <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="630t2b8bgH3" role="1B3o_S" />
       <node concept="3rvAFt" id="630t2b8bgI2" role="1tU5fm">
         <node concept="3uibUv" id="630t2b8bw9E" role="3rvQeY">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
         </node>
         <node concept="_YKpA" id="630t2b8bwhF" role="3rvSg0">
           <node concept="3uibUv" id="630t2b8bwic" role="_ZDj9">
@@ -347,202 +364,111 @@
         </node>
       </node>
       <node concept="2ShNRf" id="630t2b8bx0U" role="33vP2m">
-        <node concept="3rGOSV" id="630t2b8bx0w" role="2ShVmc">
-          <node concept="3uibUv" id="630t2b8bx0x" role="3rHrn6">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="_YKpA" id="630t2b8bx0y" role="3rHtpV">
-            <node concept="3uibUv" id="630t2b8bx0z" role="_ZDj9">
-              <ref role="3uigEE" node="630t2b86oTu" resolve="ISelectionIntentionFactory" />
-            </node>
-          </node>
-        </node>
+        <node concept="3rGOSV" id="630t2b8bx0w" role="2ShVmc" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4e238oUMAHK" role="jymVt" />
+    <node concept="312cEg" id="3bOfznyvMm0" role="jymVt">
+      <property role="TrG5h" value="myLanguageRegistry" />
+      <node concept="3Tm6S6" id="3bOfznyvLb8" role="1B3o_S" />
+      <node concept="3uibUv" id="3bOfznyvMjZ" role="1tU5fm">
+        <ref role="3uigEE" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
       </node>
     </node>
     <node concept="312cEg" id="630t2b8bnYg" role="jymVt">
       <property role="TrG5h" value="myClasseslistener" />
-      <property role="3TUv4t" value="false" />
+      <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="630t2b8bnYh" role="1B3o_S" />
       <node concept="3uibUv" id="7JEoLgTzoof" role="1tU5fm">
-        <ref role="3uigEE" to="3qmy:~DeployListener" resolve="DeployListener" />
+        <ref role="3uigEE" to="ze1i:~ModuleDeploymentListener" resolve="ModuleDeploymentListener" />
       </node>
       <node concept="2ShNRf" id="630t2b8boeH" role="33vP2m">
         <node concept="YeOm9" id="630t2b8boeI" role="2ShVmc">
           <node concept="1Y3b0j" id="630t2b8boeJ" role="YeSDq">
             <property role="2bfB8j" value="true" />
             <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-            <ref role="1Y3XeK" to="3qmy:~DeployListener" resolve="DeployListener" />
+            <ref role="1Y3XeK" to="ze1i:~ModuleDeploymentListener" resolve="ModuleDeploymentListener" />
             <node concept="3Tm1VV" id="630t2b8boeK" role="1B3o_S" />
-            <node concept="3clFb_" id="7JEoLgTzpng" role="jymVt">
-              <property role="TrG5h" value="onLoaded" />
-              <node concept="3Tm1VV" id="7JEoLgTzpni" role="1B3o_S" />
-              <node concept="3cqZAl" id="7JEoLgTzpnk" role="3clF45" />
-              <node concept="37vLTG" id="7JEoLgTzpnl" role="3clF46">
-                <property role="TrG5h" value="modules" />
-                <node concept="3uibUv" id="7JEoLgTzpnm" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-                  <node concept="3uibUv" id="7JEoLgTzpnn" role="11_B2D">
-                    <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
-                  </node>
+            <node concept="3clFb_" id="4e238oUODTc" role="jymVt">
+              <property role="TrG5h" value="deploymentStateChanged" />
+              <node concept="3Tm1VV" id="4e238oUODTd" role="1B3o_S" />
+              <node concept="3cqZAl" id="4e238oUODTf" role="3clF45" />
+              <node concept="37vLTG" id="4e238oUODTg" role="3clF46">
+                <property role="TrG5h" value="change" />
+                <node concept="3uibUv" id="4e238oUODTh" role="1tU5fm">
+                  <ref role="3uigEE" to="ze1i:~ModuleDeploymentChange" resolve="ModuleDeploymentChange" />
                 </node>
-                <node concept="2AHcQZ" id="7JEoLgTzpno" role="2AJF6D">
+                <node concept="2AHcQZ" id="4e238oUODTi" role="2AJF6D">
                   <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
                 </node>
               </node>
-              <node concept="37vLTG" id="7JEoLgTzpnp" role="3clF46">
-                <property role="TrG5h" value="monitor" />
-                <node concept="3uibUv" id="7JEoLgTzpnq" role="1tU5fm">
-                  <ref role="3uigEE" to="yyf4:~ProgressMonitor" resolve="ProgressMonitor" />
-                </node>
-                <node concept="2AHcQZ" id="7JEoLgTzpnr" role="2AJF6D">
-                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="7JEoLgTzpnt" role="3clF47">
-                <node concept="3J1_TO" id="630t2b8btDZ" role="3cqZAp">
-                  <node concept="3clFbS" id="630t2b8btE4" role="1zxBo7">
-                    <node concept="2Gpval" id="630t2b8bvOP" role="3cqZAp">
-                      <node concept="2GrKxI" id="630t2b8bvOQ" role="2Gsz3X">
-                        <property role="TrG5h" value="module" />
-                      </node>
-                      <node concept="3clFbS" id="630t2b8bvOR" role="2LFqv$">
-                        <node concept="3clFbF" id="630t2b8bvU6" role="3cqZAp">
-                          <node concept="1rXfSq" id="630t2b8bvU5" role="3clFbG">
-                            <ref role="37wK5l" node="630t2b8bpLU" resolve="loadModule" />
-                            <node concept="2GrUjf" id="630t2b8bvWf" role="37wK5m">
-                              <ref role="2Gs0qQ" node="630t2b8bvOQ" resolve="module" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="630t2b8bvPR" role="2GsD0m">
-                        <ref role="3cqZAo" node="7JEoLgTzpnl" resolve="modules" />
-                      </node>
+              <node concept="3clFbS" id="4e238oUODTk" role="3clF47">
+                <node concept="3clFbF" id="4e238oUOQI1" role="3cqZAp">
+                  <node concept="2OqwBi" id="4e238oUOUDg" role="3clFbG">
+                    <node concept="37vLTw" id="4e238oUOQHZ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4e238oUODTg" resolve="change" />
                     </node>
-                  </node>
-                  <node concept="3uVAMA" id="630t2b8btE0" role="1zxBo5">
-                    <node concept="XOnhg" id="630t2b8btE2" role="1zc67B">
-                      <property role="3TUv4t" value="false" />
-                      <property role="TrG5h" value="ex" />
-                      <node concept="nSUau" id="o$qQITJfd2" role="1tU5fm">
-                        <node concept="3uibUv" id="630t2b8bu_a" role="nSUat">
-                          <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="630t2b8btE1" role="1zc67A">
-                      <node concept="RRSsy" id="1J9MAk9NAm9" role="3cqZAp">
-                        <property role="RRSoG" value="gZ5fh_4/error" />
-                        <node concept="Xl_RD" id="1J9MAk9NAmb" role="RRSoy" />
-                        <node concept="37vLTw" id="1J9MAk9NBSg" role="RRSow">
-                          <ref role="3cqZAo" node="630t2b8btE2" resolve="ex" />
+                    <node concept="liA8E" id="4e238oUOVG8" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleDeploymentChange.forEachRemoved(java.util.function.Consumer)" resolve="forEachRemoved" />
+                      <node concept="37Ijox" id="4e238oUOWDs" role="37wK5m">
+                        <ref role="37Ijqf" node="630t2b8bxhz" resolve="unloadModule" />
+                        <node concept="Xjq3P" id="4e238oUOWDt" role="wWaWy">
+                          <ref role="1HBi2w" node="630t2b86nFa" resolve="SelectionIntentionsManager" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="2AHcQZ" id="7JEoLgTzpnu" role="2AJF6D">
-                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-              </node>
-            </node>
-            <node concept="2tJIrI" id="7JEoLgTzvPo" role="jymVt" />
-            <node concept="3clFb_" id="7JEoLgTzpn_" role="jymVt">
-              <property role="TrG5h" value="onUnloaded" />
-              <node concept="3Tm1VV" id="7JEoLgTzpnB" role="1B3o_S" />
-              <node concept="3cqZAl" id="7JEoLgTzpnD" role="3clF45" />
-              <node concept="37vLTG" id="7JEoLgTzpnE" role="3clF46">
-                <property role="TrG5h" value="modules" />
-                <node concept="3uibUv" id="7JEoLgTzpnF" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-                  <node concept="3uibUv" id="7JEoLgTzpnG" role="11_B2D">
-                    <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
-                  </node>
-                </node>
-                <node concept="2AHcQZ" id="7JEoLgTzpnH" role="2AJF6D">
-                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                </node>
-              </node>
-              <node concept="37vLTG" id="7JEoLgTzpnI" role="3clF46">
-                <property role="TrG5h" value="monitor" />
-                <node concept="3uibUv" id="7JEoLgTzpnJ" role="1tU5fm">
-                  <ref role="3uigEE" to="yyf4:~ProgressMonitor" resolve="ProgressMonitor" />
-                </node>
-                <node concept="2AHcQZ" id="7JEoLgTzpnK" role="2AJF6D">
-                  <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="7JEoLgTzpnM" role="3clF47">
-                <node concept="3J1_TO" id="630t2b8b$lL" role="3cqZAp">
-                  <node concept="3clFbS" id="630t2b8b$lV" role="1zxBo7">
-                    <node concept="2Gpval" id="630t2b8b$lW" role="3cqZAp">
-                      <node concept="2GrKxI" id="630t2b8b$lX" role="2Gsz3X">
-                        <property role="TrG5h" value="module" />
-                      </node>
-                      <node concept="3clFbS" id="630t2b8b$lY" role="2LFqv$">
-                        <node concept="3clFbJ" id="4jHuzb0ERaF" role="3cqZAp">
-                          <node concept="3clFbS" id="4jHuzb0ERaH" role="3clFbx">
-                            <node concept="3clFbF" id="4jHuzb0ESjE" role="3cqZAp">
-                              <node concept="1rXfSq" id="4jHuzb0ESjC" role="3clFbG">
-                                <ref role="37wK5l" node="630t2b8aWnq" resolve="dispose" />
-                              </node>
-                            </node>
-                            <node concept="3cpWs6" id="4jHuzb0ESt6" role="3cqZAp" />
-                          </node>
-                          <node concept="17R0WA" id="4jHuzb0ERPP" role="3clFbw">
-                            <node concept="37shsh" id="4jHuzb0ES2T" role="3uHU7w">
-                              <node concept="1dCxOk" id="7WTFIQIcYxH" role="37shsm">
-                                <property role="1XxBO9" value="de.itemis.mps.selection.runtime" />
-                                <property role="1XweGW" value="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3" />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="4jHuzb0ERuj" role="3uHU7B">
-                              <node concept="2GrUjf" id="4jHuzb0ERne" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="630t2b8b$lX" resolve="module" />
-                              </node>
-                              <node concept="liA8E" id="4jHuzb0ERO5" role="2OqNvi">
-                                <ref role="37wK5l" to="j8aq:~ReloadableModule.getModuleReference()" resolve="getModuleReference" />
-                              </node>
-                            </node>
-                          </node>
+                <node concept="3clFbF" id="4e238oUP3Xg" role="3cqZAp">
+                  <node concept="2OqwBi" id="4e238oUP3Xh" role="3clFbG">
+                    <node concept="37vLTw" id="4e238oUP3Xi" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4e238oUODTg" resolve="change" />
+                    </node>
+                    <node concept="liA8E" id="4e238oUP3Xj" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleDeploymentChange.forEachReloaded(java.util.function.Consumer)" resolve="forEachReloaded" />
+                      <node concept="37Ijox" id="4e238oUP3Xk" role="37wK5m">
+                        <ref role="37Ijqf" node="630t2b8bxhz" resolve="unloadModule" />
+                        <node concept="Xjq3P" id="4e238oUP3Xl" role="wWaWy">
+                          <ref role="1HBi2w" node="630t2b86nFa" resolve="SelectionIntentionsManager" />
                         </node>
-                        <node concept="3clFbF" id="630t2b8b$lZ" role="3cqZAp">
-                          <node concept="1rXfSq" id="630t2b8b$m0" role="3clFbG">
-                            <ref role="37wK5l" node="630t2b8bxhz" resolve="unloadModule" />
-                            <node concept="2GrUjf" id="630t2b8b$m1" role="37wK5m">
-                              <ref role="2Gs0qQ" node="630t2b8b$lX" resolve="module" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="630t2b8b$m2" role="2GsD0m">
-                        <ref role="3cqZAo" node="7JEoLgTzpnE" resolve="modules" />
                       </node>
                     </node>
                   </node>
-                  <node concept="3uVAMA" id="630t2b8b$lM" role="1zxBo5">
-                    <node concept="XOnhg" id="630t2b8b$lT" role="1zc67B">
-                      <property role="3TUv4t" value="false" />
-                      <property role="TrG5h" value="ex" />
-                      <node concept="nSUau" id="o$qQITIWMO" role="1tU5fm">
-                        <node concept="3uibUv" id="630t2b8b$lU" role="nSUat">
-                          <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                </node>
+                <node concept="3clFbF" id="4e238oUP0CW" role="3cqZAp">
+                  <node concept="2OqwBi" id="4e238oUP0CX" role="3clFbG">
+                    <node concept="37vLTw" id="4e238oUP0CY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4e238oUODTg" resolve="change" />
+                    </node>
+                    <node concept="liA8E" id="4e238oUP0CZ" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleDeploymentChange.forEachReloaded(java.util.function.Consumer)" resolve="forEachReloaded" />
+                      <node concept="37Ijox" id="4e238oUP0D0" role="37wK5m">
+                        <ref role="37Ijqf" node="630t2b8bpLU" resolve="loadModule" />
+                        <node concept="Xjq3P" id="4e238oUP0D1" role="wWaWy">
+                          <ref role="1HBi2w" node="630t2b86nFa" resolve="SelectionIntentionsManager" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbS" id="630t2b8b$lN" role="1zc67A">
-                      <node concept="RRSsy" id="1J9MAk9NF3N" role="3cqZAp">
-                        <property role="RRSoG" value="gZ5fh_4/error" />
-                        <node concept="Xl_RD" id="1J9MAk9NF3P" role="RRSoy" />
-                        <node concept="37vLTw" id="1J9MAk9NG4i" role="RRSow">
-                          <ref role="3cqZAo" node="630t2b8b$lT" resolve="ex" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="4e238oUOHKI" role="3cqZAp">
+                  <node concept="2OqwBi" id="4e238oUOJ2x" role="3clFbG">
+                    <node concept="37vLTw" id="4e238oUOHKH" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4e238oUODTg" resolve="change" />
+                    </node>
+                    <node concept="liA8E" id="4e238oUOKFY" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleDeploymentChange.forEachAdded(java.util.function.Consumer)" resolve="forEachAdded" />
+                      <node concept="37Ijox" id="4e238oUONcG" role="37wK5m">
+                        <ref role="37Ijqf" node="630t2b8bpLU" resolve="loadModule" />
+                        <node concept="Xjq3P" id="4e238oUOM7Q" role="wWaWy">
+                          <ref role="1HBi2w" node="630t2b86nFa" resolve="SelectionIntentionsManager" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="2AHcQZ" id="7JEoLgTzpnN" role="2AJF6D">
+              <node concept="2AHcQZ" id="4e238oUODTl" role="2AJF6D">
                 <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
               </node>
             </node>
@@ -553,99 +479,102 @@
     <node concept="2tJIrI" id="630t2b8bgGa" role="jymVt" />
     <node concept="3clFb_" id="630t2b8aWl8" role="jymVt">
       <property role="TrG5h" value="init" />
+      <node concept="37vLTG" id="3bOfznyvrqk" role="3clF46">
+        <property role="TrG5h" value="languageRegistry" />
+        <node concept="3uibUv" id="3bOfznyv$m_" role="1tU5fm">
+          <ref role="3uigEE" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+        </node>
+        <node concept="2AHcQZ" id="3bOfznyvCDV" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
       <node concept="3cqZAl" id="630t2b8aWla" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b8aWlb" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b8aWlc" role="3clF47">
-        <node concept="3clFbF" id="1Tx15Zduv$" role="3cqZAp">
-          <node concept="2OqwBi" id="1Tx15Zd_4A" role="3clFbG">
-            <node concept="2OqwBi" id="1Tx15ZdvPA" role="2Oq$k0">
-              <node concept="2OqwBi" id="1Tx15ZduvA" role="2Oq$k0">
-                <node concept="2YIFZM" id="1Tx15ZduvB" role="2Oq$k0">
-                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                  <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                </node>
-                <node concept="liA8E" id="1Tx15ZduvC" role="2OqNvi">
-                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                </node>
-              </node>
-              <node concept="liA8E" id="1Tx15ZdwYu" role="2OqNvi">
-                <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                <node concept="3VsKOn" id="1Tx15Zdzng" role="37wK5m">
-                  <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+        <node concept="3clFbJ" id="3bOfznyvOTP" role="3cqZAp">
+          <property role="TyiWK" value="true" />
+          <node concept="3clFbS" id="3bOfznyvOTR" role="3clFbx">
+            <node concept="YS8fn" id="3bOfznyvSLe" role="3cqZAp">
+              <node concept="2ShNRf" id="3bOfznyvSRQ" role="YScLw">
+                <node concept="1pGfFk" id="3bOfznywnw$" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="wyt6:~IllegalStateException.&lt;init&gt;(java.lang.String)" resolve="IllegalStateException" />
+                  <node concept="Xl_RD" id="3bOfznywolY" role="37wK5m">
+                    <property role="Xl_RC" value="SelectionIntentionsManager already initialized" />
+                  </node>
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="1Tx15ZdA5z" role="2OqNvi">
-              <ref role="37wK5l" to="3qmy:~ClassLoaderManager.addListener(jetbrains.mps.classloading.DeployListener)" resolve="addListener" />
-              <node concept="37vLTw" id="1Tx15ZdAWF" role="37wK5m">
+          </node>
+          <node concept="3y3z36" id="3bOfznyvRs_" role="3clFbw">
+            <node concept="10Nm6u" id="3bOfznyvR_o" role="3uHU7w" />
+            <node concept="37vLTw" id="3bOfznyvQas" role="3uHU7B">
+              <ref role="3cqZAo" node="3bOfznyvMm0" resolve="myLanguageRegistry" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3bOfznywuWD" role="3cqZAp" />
+        <node concept="3clFbF" id="3bOfznywwTp" role="3cqZAp">
+          <node concept="37vLTI" id="3bOfznywy08" role="3clFbG">
+            <node concept="37vLTw" id="3bOfznywzx0" role="37vLTx">
+              <ref role="3cqZAo" node="3bOfznyvrqk" resolve="languageRegistry" />
+            </node>
+            <node concept="37vLTw" id="3bOfznywwTn" role="37vLTJ">
+              <ref role="3cqZAo" node="3bOfznyvMm0" resolve="myLanguageRegistry" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4e238oULZ07" role="3cqZAp">
+          <node concept="2OqwBi" id="4e238oUM0o6" role="3clFbG">
+            <node concept="37vLTw" id="4e238oULZ05" role="2Oq$k0">
+              <ref role="3cqZAo" node="3bOfznyvrqk" resolve="languageRegistry" />
+            </node>
+            <node concept="liA8E" id="4e238oUM1sb" role="2OqNvi">
+              <ref role="37wK5l" to="vndm:~LanguageRegistry.addRegistryListener(jetbrains.mps.smodel.runtime.ModuleDeploymentListener)" resolve="addRegistryListener" />
+              <node concept="37vLTw" id="4e238oUM3ac" role="37wK5m">
                 <ref role="3cqZAo" node="630t2b8bnYg" resolve="myClasseslistener" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1Tx15Zduv4" role="3cqZAp" />
-        <node concept="1QHqEK" id="2hnwIrOiPsR" role="3cqZAp">
-          <node concept="1QHqEC" id="2hnwIrOiPsT" role="1QHqEI">
-            <node concept="3clFbS" id="2hnwIrOiPsV" role="1bW5cS">
-              <node concept="2Gpval" id="630t2b8b$SY" role="3cqZAp">
-                <node concept="2GrKxI" id="630t2b8b$T0" role="2Gsz3X">
-                  <property role="TrG5h" value="module" />
-                </node>
-                <node concept="3clFbS" id="630t2b8b$T2" role="2LFqv$">
-                  <node concept="3clFbJ" id="630t2b8b_4j" role="3cqZAp">
-                    <node concept="3clFbS" id="630t2b8b_4l" role="3clFbx">
-                      <node concept="3clFbF" id="630t2b8b$Yq" role="3cqZAp">
-                        <node concept="1rXfSq" id="630t2b8b$Yp" role="3clFbG">
-                          <ref role="37wK5l" node="630t2b8bpLU" resolve="loadModule" />
-                          <node concept="10QFUN" id="630t2b8b_j5" role="37wK5m">
-                            <node concept="3uibUv" id="630t2b8b_lr" role="10QFUM">
-                              <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
-                            </node>
-                            <node concept="2GrUjf" id="630t2b8b_0k" role="10QFUP">
-                              <ref role="2Gs0qQ" node="630t2b8b$T0" resolve="module" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
+        <node concept="3clFbF" id="4e238oUOf$F" role="3cqZAp">
+          <node concept="2OqwBi" id="4e238oUOgT2" role="3clFbG">
+            <node concept="37vLTw" id="4e238oUOf$D" role="2Oq$k0">
+              <ref role="3cqZAo" node="3bOfznyvrqk" resolve="languageRegistry" />
+            </node>
+            <node concept="liA8E" id="4e238oUOiKO" role="2OqNvi">
+              <ref role="37wK5l" to="vndm:~LanguageRegistry.withModuleRuntime(java.util.stream.Stream,java.util.function.Consumer)" resolve="withModuleRuntime" />
+              <node concept="2OqwBi" id="4e238oUO8pQ" role="37wK5m">
+                <node concept="2OqwBi" id="4e238oUO4Vt" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4e238oUO2Fq" role="2Oq$k0">
+                    <node concept="37vLTw" id="4e238oUO1br" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3bOfznyvrqk" resolve="languageRegistry" />
                     </node>
-                    <node concept="2ZW3vV" id="630t2b8b_7$" role="3clFbw">
-                      <node concept="3uibUv" id="630t2b8b_9B" role="2ZW6by">
-                        <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
-                      </node>
-                      <node concept="2GrUjf" id="630t2b8b_6B" role="2ZW6bz">
-                        <ref role="2Gs0qQ" node="630t2b8b$T0" resolve="module" />
-                      </node>
+                    <node concept="liA8E" id="4e238oUO3Ei" role="2OqNvi">
+                      <ref role="37wK5l" to="vndm:~LanguageRegistry.getAllLanguages()" resolve="getAllLanguages" />
                     </node>
                   </node>
-                </node>
-                <node concept="2OqwBi" id="630t2b8b$An" role="2GsD0m">
-                  <node concept="liA8E" id="630t2b8b$Lv" role="2OqNvi">
-                    <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getModules()" resolve="getModules" />
+                  <node concept="liA8E" id="4e238oUO7b1" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
                   </node>
-                  <node concept="2OqwBi" id="45KItpiJOGz" role="2Oq$k0">
-                    <node concept="2OqwBi" id="45KItpiJOij" role="2Oq$k0">
-                      <node concept="2YIFZM" id="45KItpiJO6S" role="2Oq$k0">
-                        <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                        <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                      </node>
-                      <node concept="liA8E" id="45KItpiJOyO" role="2OqNvi">
-                        <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="45KItpiJOXp" role="2OqNvi">
-                      <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                      <node concept="3VsKOn" id="45KItpiJOYV" role="37wK5m">
-                        <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
+                </node>
+                <node concept="liA8E" id="4e238oUOaXi" role="2OqNvi">
+                  <ref role="37wK5l" to="1ctc:~Stream.map(java.util.function.Function)" resolve="map" />
+                  <node concept="37Ijox" id="4e238oUOc7z" role="37wK5m">
+                    <ref role="37Ijqf" to="c17a:~SLanguage.getSourceModuleReference()" resolve="getSourceModuleReference" />
+                    <node concept="2FaPjH" id="4e238oUOc7_" role="wWaWy">
+                      <node concept="3uibUv" id="4e238oUOc7A" role="2FaQuo">
+                        <ref role="3uigEE" to="c17a:~SLanguage" resolve="SLanguage" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
+              <node concept="37Ijox" id="4e238oUMhbm" role="37wK5m">
+                <ref role="37Ijqf" node="630t2b8bpLU" resolve="loadModule" />
+                <node concept="Xjq3P" id="4e238oUMfAP" role="wWaWy" />
+              </node>
             </node>
-          </node>
-          <node concept="2YIFZM" id="5OLC7TiMc_6" role="ukAjM">
-            <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
-            <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
           </node>
         </node>
       </node>
@@ -656,26 +585,43 @@
       <node concept="3cqZAl" id="630t2b8aWns" role="3clF45" />
       <node concept="3Tm1VV" id="630t2b8aWnt" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b8aWnu" role="3clF47">
-        <node concept="3clFbF" id="630t2b8bBiP" role="3cqZAp">
-          <node concept="2OqwBi" id="630t2b8bBlI" role="3clFbG">
-            <node concept="2YIFZM" id="630t2b8bBl2" role="2Oq$k0">
-              <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
-              <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+        <node concept="3clFbJ" id="3bOfznywGj4" role="3cqZAp">
+          <node concept="3clFbS" id="3bOfznywGj6" role="3clFbx">
+            <node concept="3clFbF" id="4e238oUMtGf" role="3cqZAp">
+              <node concept="2OqwBi" id="4e238oUMve0" role="3clFbG">
+                <node concept="37vLTw" id="3bOfznywL79" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3bOfznyvMm0" resolve="myLanguageRegistry" />
+                </node>
+                <node concept="liA8E" id="4e238oUMwdO" role="2OqNvi">
+                  <ref role="37wK5l" to="vndm:~LanguageRegistry.removeRegistryListener(jetbrains.mps.smodel.runtime.ModuleDeploymentListener)" resolve="removeRegistryListener" />
+                  <node concept="37vLTw" id="4e238oUM$iI" role="37wK5m">
+                    <ref role="3cqZAo" node="630t2b8bnYg" resolve="myClasseslistener" />
+                  </node>
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="630t2b8bByb" role="2OqNvi">
-              <ref role="37wK5l" to="3qmy:~ClassLoaderManager.removeListener(jetbrains.mps.classloading.DeployListener)" resolve="removeListener" />
-              <node concept="37vLTw" id="630t2b8bBz6" role="37wK5m">
-                <ref role="3cqZAo" node="630t2b8bnYg" resolve="myClasseslistener" />
+            <node concept="3clFbF" id="3bOfznywNZ1" role="3cqZAp">
+              <node concept="37vLTI" id="3bOfznywPvH" role="3clFbG">
+                <node concept="10Nm6u" id="3bOfznywQKS" role="37vLTx" />
+                <node concept="37vLTw" id="3bOfznywNYZ" role="37vLTJ">
+                  <ref role="3cqZAo" node="3bOfznyvMm0" resolve="myLanguageRegistry" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="630t2b8b_sj" role="3cqZAp">
+              <node concept="2OqwBi" id="630t2b8b_FW" role="3clFbG">
+                <node concept="37vLTw" id="630t2b8b_si" role="2Oq$k0">
+                  <ref role="3cqZAo" node="630t2b8bgH2" resolve="myFactories" />
+                </node>
+                <node concept="1yHZxX" id="630t2b8bBev" role="2OqNvi" />
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3clFbF" id="630t2b8b_sj" role="3cqZAp">
-          <node concept="2OqwBi" id="630t2b8b_FW" role="3clFbG">
-            <node concept="37vLTw" id="630t2b8b_si" role="2Oq$k0">
-              <ref role="3cqZAo" node="630t2b8bgH2" resolve="myFactories" />
+          <node concept="3y3z36" id="3bOfznywIP0" role="3clFbw">
+            <node concept="10Nm6u" id="3bOfznywIXN" role="3uHU7w" />
+            <node concept="37vLTw" id="3bOfznywHP4" role="3uHU7B">
+              <ref role="3cqZAo" node="3bOfznyvMm0" resolve="myLanguageRegistry" />
             </node>
-            <node concept="1yHZxX" id="630t2b8bBev" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -684,7 +630,6 @@
     <node concept="3clFb_" id="630t2b8bxhz" role="jymVt">
       <property role="TrG5h" value="unloadModule" />
       <node concept="3cqZAl" id="630t2b8bxh_" role="3clF45" />
-      <node concept="3Tm1VV" id="630t2b8bxhA" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b8bxhB" role="3clF47">
         <node concept="3clFbF" id="630t2b8by55" role="3cqZAp">
           <node concept="2OqwBi" id="630t2b8byAL" role="3clFbG">
@@ -692,8 +637,13 @@
               <ref role="3cqZAo" node="630t2b8bgH2" resolve="myFactories" />
             </node>
             <node concept="kI3uX" id="630t2b8b$8U" role="2OqNvi">
-              <node concept="37vLTw" id="630t2b8b$fN" role="kIiFs">
-                <ref role="3cqZAo" node="630t2b8bxWU" resolve="module" />
+              <node concept="2OqwBi" id="4e238oUMJ3A" role="kIiFs">
+                <node concept="37vLTw" id="630t2b8b$fN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="630t2b8bxWU" resolve="module" />
+                </node>
+                <node concept="liA8E" id="4e238oUN0cy" role="2OqNvi">
+                  <ref role="37wK5l" to="ze1i:~ModuleRuntime.getSourceModule()" resolve="getSourceModule" />
+                </node>
               </node>
             </node>
           </node>
@@ -702,7 +652,7 @@
       <node concept="37vLTG" id="630t2b8bxWU" role="3clF46">
         <property role="TrG5h" value="module" />
         <node concept="3uibUv" id="630t2b8bxWT" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+          <ref role="3uigEE" to="ze1i:~ModuleRuntime" resolve="ModuleRuntime" />
         </node>
       </node>
     </node>
@@ -710,7 +660,6 @@
     <node concept="3clFb_" id="630t2b8bpLU" role="jymVt">
       <property role="TrG5h" value="loadModule" />
       <node concept="3cqZAl" id="630t2b8bpLW" role="3clF45" />
-      <node concept="3Tmbuc" id="630t2b8bq3Q" role="1B3o_S" />
       <node concept="3clFbS" id="630t2b8bpLY" role="3clF47">
         <node concept="3cpWs8" id="630t2b8bs_G" role="3cqZAp">
           <node concept="3cpWsn" id="630t2b8bs_H" role="3cpWs9">
@@ -723,12 +672,17 @@
               <node concept="3cpWs3" id="630t2b8bten" role="3uHU7B">
                 <node concept="3cpWs3" id="630t2b8bsEG" role="3uHU7B">
                   <node concept="3cpWs3" id="630t2b8bsNu" role="3uHU7B">
-                    <node concept="2OqwBi" id="630t2b8bsTA" role="3uHU7B">
-                      <node concept="37vLTw" id="630t2b8bsP5" role="2Oq$k0">
-                        <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
+                    <node concept="2OqwBi" id="4e238oUN2tz" role="3uHU7B">
+                      <node concept="2OqwBi" id="4e238oUOtLm" role="2Oq$k0">
+                        <node concept="37vLTw" id="630t2b8bsP5" role="2Oq$k0">
+                          <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
+                        </node>
+                        <node concept="liA8E" id="4e238oUOuMZ" role="2OqNvi">
+                          <ref role="37wK5l" to="ze1i:~ModuleRuntime.getSourceModule()" resolve="getSourceModule" />
+                        </node>
                       </node>
-                      <node concept="liA8E" id="630t2b8bt6i" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                      <node concept="liA8E" id="4e238oUN4aL" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
                       </node>
                     </node>
                     <node concept="Xl_RD" id="630t2b8bsGk" role="3uHU7w">
@@ -759,13 +713,14 @@
                 <property role="TrG5h" value="descriptorClass" />
                 <node concept="3uibUv" id="630t2b8cmJe" role="1tU5fm">
                   <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+                  <node concept="3qTvmN" id="4e238oUPecY" role="11_B2D" />
                 </node>
                 <node concept="2OqwBi" id="630t2b8cmJG" role="33vP2m">
                   <node concept="37vLTw" id="630t2b8cmJH" role="2Oq$k0">
                     <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
                   </node>
                   <node concept="liA8E" id="630t2b8cmJI" role="2OqNvi">
-                    <ref role="37wK5l" to="j8aq:~ReloadableModule.getOwnClass(java.lang.String)" resolve="getOwnClass" />
+                    <ref role="37wK5l" to="ze1i:~ModuleRuntime.getOwnClass(java.lang.String)" resolve="getOwnClass" />
                     <node concept="37vLTw" id="630t2b8cmJJ" role="37wK5m">
                       <ref role="3cqZAo" node="630t2b8bs_H" resolve="className" />
                     </node>
@@ -773,34 +728,28 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="630t2b8cpcA" role="3cqZAp">
-              <node concept="3clFbS" id="630t2b8cpcC" role="3clFbx">
-                <node concept="3cpWs6" id="630t2b8cprA" role="3cqZAp" />
-              </node>
-              <node concept="3clFbC" id="630t2b8cpon" role="3clFbw">
-                <node concept="10Nm6u" id="630t2b8cpq2" role="3uHU7w" />
-                <node concept="37vLTw" id="630t2b8cpgc" role="3uHU7B">
-                  <ref role="3cqZAo" node="630t2b8cmJF" resolve="descriptorClass" />
-                </node>
-              </node>
-            </node>
             <node concept="3cpWs8" id="630t2b8coQh" role="3cqZAp">
               <node concept="3cpWsn" id="630t2b8coQi" role="3cpWs9">
-                <property role="TrG5h" value="desciptor" />
+                <property role="TrG5h" value="descriptor" />
                 <node concept="3uibUv" id="630t2b8cp1M" role="1tU5fm">
                   <ref role="3uigEE" node="630t2b86jvo" resolve="ISelectionIntentionsDescriptor" />
                 </node>
-                <node concept="10QFUN" id="630t2b8ctNU" role="33vP2m">
-                  <node concept="3uibUv" id="630t2b8ctV7" role="10QFUM">
-                    <ref role="3uigEE" node="630t2b86jvo" resolve="ISelectionIntentionsDescriptor" />
+                <node concept="10QFUN" id="4KwEt4eOhrM" role="33vP2m">
+                  <node concept="2OqwBi" id="4KwEt4eOhrH" role="10QFUP">
+                    <node concept="2OqwBi" id="4KwEt4eOhrI" role="2Oq$k0">
+                      <node concept="37vLTw" id="4KwEt4eOhrJ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="630t2b8cmJF" resolve="descriptorClass" />
+                      </node>
+                      <node concept="liA8E" id="4KwEt4eOhrK" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Class.getDeclaredConstructor(java.lang.Class...)" resolve="getDeclaredConstructor" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4KwEt4eOhrL" role="2OqNvi">
+                      <ref role="37wK5l" to="t6h5:~Constructor.newInstance(java.lang.Object...)" resolve="newInstance" />
+                    </node>
                   </node>
-                  <node concept="2OqwBi" id="630t2b8coQj" role="10QFUP">
-                    <node concept="37vLTw" id="630t2b8coQk" role="2Oq$k0">
-                      <ref role="3cqZAo" node="630t2b8cmJF" resolve="descriptorClass" />
-                    </node>
-                    <node concept="liA8E" id="630t2b8coQl" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~Class.newInstance()" resolve="newInstance" />
-                    </node>
+                  <node concept="3uibUv" id="4KwEt4eOhrG" role="10QFUM">
+                    <ref role="3uigEE" node="630t2b86jvo" resolve="ISelectionIntentionsDescriptor" />
                   </node>
                 </node>
               </node>
@@ -808,8 +757,13 @@
             <node concept="3clFbF" id="630t2b8cpVy" role="3cqZAp">
               <node concept="37vLTI" id="630t2b8cq$k" role="3clFbG">
                 <node concept="3EllGN" id="630t2b8cqei" role="37vLTJ">
-                  <node concept="37vLTw" id="630t2b8cqiW" role="3ElVtu">
-                    <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
+                  <node concept="2OqwBi" id="4e238oUNdvB" role="3ElVtu">
+                    <node concept="37vLTw" id="630t2b8cqiW" role="2Oq$k0">
+                      <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="4e238oUNekv" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleRuntime.getSourceModule()" resolve="getSourceModule" />
+                    </node>
                   </node>
                   <node concept="37vLTw" id="630t2b8cpVw" role="3ElQJh">
                     <ref role="3cqZAo" node="630t2b8bgH2" resolve="myFactories" />
@@ -817,7 +771,7 @@
                 </node>
                 <node concept="2OqwBi" id="630t2b8cpwC" role="37vLTx">
                   <node concept="37vLTw" id="630t2b8coQm" role="2Oq$k0">
-                    <ref role="3cqZAo" node="630t2b8coQi" resolve="desciptor" />
+                    <ref role="3cqZAo" node="630t2b8coQi" resolve="descriptor" />
                   </node>
                   <node concept="liA8E" id="630t2b8cpLU" role="2OqNvi">
                     <ref role="37wK5l" node="630t2b86pd9" resolve="getFactories" />
@@ -832,18 +786,140 @@
               <property role="TrG5h" value="ex" />
               <node concept="nSUau" id="o$qQITJaPE" role="1tU5fm">
                 <node concept="3uibUv" id="630t2b8bvL8" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~ClassNotFoundException" resolve="ClassNotFoundException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="630t2b8bvmk" role="1zc67A">
+              <node concept="3SKdUt" id="3bOfznyxRqt" role="3cqZAp">
+                <node concept="1PaTwC" id="3bOfznyxRqu" role="1aUNEU">
+                  <node concept="3oM_SD" id="3bOfznyxSa3" role="1PaTwD">
+                    <property role="3oM_SC" value="Module" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSby" role="1PaTwD">
+                    <property role="3oM_SC" value="does" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSb$" role="1PaTwD">
+                    <property role="3oM_SC" value="not" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSb_" role="1PaTwD">
+                    <property role="3oM_SC" value="have" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSbA" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxShx" role="1PaTwD">
+                    <property role="3oM_SC" value="selection" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSg2" role="1PaTwD">
+                    <property role="3oM_SC" value="intentions" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyxSd5" role="1PaTwD">
+                    <property role="3oM_SC" value="descriptor," />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyymVr" role="1PaTwD">
+                    <property role="3oM_SC" value="this" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyymVs" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyymVt" role="1PaTwD">
+                    <property role="3oM_SC" value="normal" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="3bOfznyxSkv" role="1zxBo5">
+            <node concept="XOnhg" id="3bOfznyxSkw" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="3bOfznyxSkx" role="1tU5fm">
+                <node concept="3uibUv" id="3bOfznyxT_U" role="nSUat">
                   <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="630t2b8bvmk" role="1zc67A" />
+            <node concept="3clFbS" id="3bOfznyxSky" role="1zc67A">
+              <node concept="3SKdUt" id="3bOfznyyolh" role="3cqZAp">
+                <node concept="1PaTwC" id="3bOfznyyoli" role="1aUNEU">
+                  <node concept="3oM_SD" id="3bOfznyyolj" role="1PaTwD">
+                    <property role="3oM_SC" value="Module" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyolm" role="1PaTwD">
+                    <property role="3oM_SC" value="has" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$w" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$x" role="1PaTwD">
+                    <property role="3oM_SC" value="descriptor" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$y" role="1PaTwD">
+                    <property role="3oM_SC" value="but" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$z" role="1PaTwD">
+                    <property role="3oM_SC" value="it" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$$" role="1PaTwD">
+                    <property role="3oM_SC" value="could" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$_" role="1PaTwD">
+                    <property role="3oM_SC" value="not" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyyp$A" role="1PaTwD">
+                    <property role="3oM_SC" value="be" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyypAP" role="1PaTwD">
+                    <property role="3oM_SC" value="loaded," />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyypAQ" role="1PaTwD">
+                    <property role="3oM_SC" value="report" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyypD7" role="1PaTwD">
+                    <property role="3oM_SC" value="and" />
+                  </node>
+                  <node concept="3oM_SD" id="3bOfznyypH$" role="1PaTwD">
+                    <property role="3oM_SC" value="continue" />
+                  </node>
+                </node>
+              </node>
+              <node concept="RRSsy" id="3bOfznyy6sk" role="3cqZAp">
+                <property role="RRSoG" value="gZ5fh_4/error" />
+                <node concept="3cpWs3" id="3bOfznyyg_Y" role="RRSoy">
+                  <node concept="2OqwBi" id="3bOfznyyjbu" role="3uHU7w">
+                    <node concept="37vLTw" id="3bOfznyyi9h" role="2Oq$k0">
+                      <ref role="3cqZAo" node="630t2b8bqjg" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="3bOfznyyk2b" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ModuleRuntime.getSourceModule()" resolve="getSourceModule" />
+                    </node>
+                  </node>
+                  <node concept="3cpWs3" id="3bOfznyycBh" role="3uHU7B">
+                    <node concept="3cpWs3" id="3bOfznyyaeR" role="3uHU7B">
+                      <node concept="Xl_RD" id="3bOfznyy6sm" role="3uHU7B">
+                        <property role="Xl_RC" value="Could not load class " />
+                      </node>
+                      <node concept="37vLTw" id="3bOfznyybiZ" role="3uHU7w">
+                        <ref role="3cqZAo" node="630t2b8bs_H" resolve="className" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="3bOfznyydUM" role="3uHU7w">
+                      <property role="Xl_RC" value=" from module " />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="3bOfznyyleD" role="RRSow">
+                  <ref role="3cqZAo" node="3bOfznyxSkw" resolve="e" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
       <node concept="37vLTG" id="630t2b8bqjg" role="3clF46">
         <property role="TrG5h" value="module" />
         <node concept="3uibUv" id="630t2b8bqjf" role="1tU5fm">
-          <ref role="3uigEE" to="j8aq:~ReloadableModule" resolve="ReloadableModule" />
+          <ref role="3uigEE" to="ze1i:~ModuleRuntime" resolve="ModuleRuntime" />
         </node>
       </node>
     </node>

--- a/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
+++ b/code/mouseselection/solutions/de.itemis.mps.selection.runtime/models/de/itemis/mps/selection/runtime/plugin.mps
@@ -25,6 +25,7 @@
     <import index="6tp1" ref="r:5c0390a8-12e2-407a-ba93-793107153436(de.itemis.mps.selection.runtime.mouse)" />
     <import index="wvnl" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.extensions(MPS.Editor/)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
     <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
@@ -459,6 +460,15 @@
             </node>
             <node concept="liA8E" id="630t2b8bDbx" role="2OqNvi">
               <ref role="37wK5l" to="hceu:630t2b8aWl8" resolve="init" />
+              <node concept="2OqwBi" id="3bOfznyyXed" role="37wK5m">
+                <node concept="XUXob" id="4e238oULuBJ" role="2Oq$k0" />
+                <node concept="liA8E" id="3bOfznyyXs0" role="2OqNvi">
+                  <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
+                  <node concept="3VsKOn" id="3bOfznyzeDM" role="37wK5m">
+                    <ref role="3VsUkX" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
CLM+ReloadableModule is way too low-level runtime management mechanism, which drags repository access. Use modern ModuleRuntime instead.

Based on a submission by Artem Tikhomirov (#1439). No user-visible changes.