### PR TITLE
fix(tables): IAE when trying to copy a table that has no copy-paste support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## November 2025
+
+### Fixed
+
+- *de.slisson.mps.tables* IllegalArgumentException thrown when copy-paste support is not defined for a table node (#1650).
+- *de.slisson.mps.tables* Textgen warning about duplicate unit name when an editor model contains multiple tables without an action map. 
+
 ## October 2025
 
 ### Fixed

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -234,6 +234,128 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="6Qwtr1aMjHs" role="15bmVC">
+      <node concept="15ShDW" id="6Qwtr1aMjHp" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgBl/November" />
+        <property role="15ShDw" value="2025" />
+      </node>
+      <node concept="15bAme" id="6Qwtr1aMjHq" role="15bAlL">
+        <node concept="2DRihI" id="6Qwtr1aMjHr" role="15bAlk">
+          <node concept="15Ami3" id="6Qwtr1aMjHt" role="1PaTwD">
+            <node concept="37shsh" id="6Qwtr1aMjHu" role="15Aodc">
+              <node concept="1dCxOk" id="6Qwtr1aMjMB" role="37shsm">
+                <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                <property role="1XxBO9" value="de.slisson.mps.tables" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjS4" role="1PaTwD">
+            <property role="3oM_SC" value="IllegalArgumentException" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRP" role="1PaTwD">
+            <property role="3oM_SC" value="thrown" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjS5" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRQ" role="1PaTwD">
+            <property role="3oM_SC" value="copy-paste" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRR" role="1PaTwD">
+            <property role="3oM_SC" value="support" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRS" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRW" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRT" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRU" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRV" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRX" role="1PaTwD">
+            <property role="3oM_SC" value="table" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjRY" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1aMjS3" role="1PaTwD">
+            <property role="3oM_SC" value="(#1650)." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="6Qwtr1b9aRL" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="6Qwtr1b9aSk" role="1PaTwD">
+            <node concept="37shsh" id="6Qwtr1b9aSm" role="15Aodc">
+              <node concept="1dCxOk" id="6Qwtr1b9aXA" role="37shsm">
+                <property role="1XweGW" value="7e450f4e-1ac3-41ef-a851-4598161bdb94" />
+                <property role="1XxBO9" value="de.slisson.mps.tables" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1beyyb" role="1PaTwD">
+            <property role="3oM_SC" value="Textgen" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1beyyc" role="1PaTwD">
+            <property role="3oM_SC" value="warning" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9b8H" role="1PaTwD">
+            <property role="3oM_SC" value="about" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9b8I" role="1PaTwD">
+            <property role="3oM_SC" value="duplicate" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9b8J" role="1PaTwD">
+            <property role="3oM_SC" value="unit" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1beyyd" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9b8L" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9be6" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9be7" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9be8" role="1PaTwD">
+            <property role="3oM_SC" value="model" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9be9" role="1PaTwD">
+            <property role="3oM_SC" value="contains" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9bea" role="1PaTwD">
+            <property role="3oM_SC" value="multiple" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9beb" role="1PaTwD">
+            <property role="3oM_SC" value="tables" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9bec" role="1PaTwD">
+            <property role="3oM_SC" value="without" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9bed" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9beg" role="1PaTwD">
+            <property role="3oM_SC" value="action" />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9bee" role="1PaTwD">
+            <property role="3oM_SC" value="map." />
+          </node>
+          <node concept="3oM_SD" id="6Qwtr1b9aXJ" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="7Ub7KQvMivS" role="15bmVC">
       <node concept="15ShDW" id="7Ub7KQvMivP" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgBa/October" />

--- a/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
+++ b/code/tables/languages/de.slisson.mps.tables/generator/template/main@generator.mps
@@ -13665,45 +13665,68 @@
     <property role="1v3jST" value="true" />
     <node concept="1pplIY" id="7NamNJWFqGU" role="1pqMTA">
       <node concept="3clFbS" id="7NamNJWFqGV" role="2VODD2">
+        <node concept="3cpWs8" id="6Qwtr1aYbyA" role="3cqZAp">
+          <node concept="3cpWsn" id="6Qwtr1aYbyD" role="3cpWs9">
+            <property role="TrG5h" value="tableSelectionActionMap" />
+            <node concept="3Tqbb2" id="6Qwtr1aYby$" role="1tU5fm">
+              <ref role="ehGHo" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
+            </node>
+            <node concept="10Nm6u" id="6Qwtr1aYbFt" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="6Qwtr1aYh4E" role="3cqZAp" />
         <node concept="3clFbF" id="7NamNJWFu6j" role="3cqZAp">
           <node concept="2OqwBi" id="7NamNJWFy94" role="3clFbG">
-            <node concept="2OqwBi" id="7NamNJWFufd" role="2Oq$k0">
-              <node concept="1Q6Npb" id="7NamNJWFu6i" role="2Oq$k0" />
-              <node concept="2SmgA7" id="7NamNJWFuuO" role="2OqNvi">
-                <node concept="chp4Y" id="7NamNJWFuvd" role="1dBWTz">
-                  <ref role="cht4Q" to="bnk3:1dAqnm8m1Em" resolve="Table" />
+            <node concept="2OqwBi" id="6Qwtr1aYkdp" role="2Oq$k0">
+              <node concept="2OqwBi" id="7NamNJWFufd" role="2Oq$k0">
+                <node concept="1Q6Npb" id="7NamNJWFu6i" role="2Oq$k0" />
+                <node concept="2SmgA7" id="7NamNJWFuuO" role="2OqNvi">
+                  <node concept="chp4Y" id="7NamNJWFuvd" role="1dBWTz">
+                    <ref role="cht4Q" to="bnk3:1dAqnm8m1Em" resolve="Table" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="6Qwtr1aYpem" role="2OqNvi">
+                <node concept="1bVj0M" id="6Qwtr1aYpeo" role="23t8la">
+                  <node concept="3clFbS" id="6Qwtr1aYpep" role="1bW5cS">
+                    <node concept="3clFbF" id="6Qwtr1aYpoN" role="3cqZAp">
+                      <node concept="3clFbC" id="6Qwtr1b3PSh" role="3clFbG">
+                        <node concept="2OqwBi" id="6Qwtr1aYpLT" role="3uHU7B">
+                          <node concept="37vLTw" id="6Qwtr1aYpoM" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6Qwtr1aYpeq" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="6Qwtr1aYswE" role="2OqNvi">
+                            <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="6Qwtr1aYtw4" role="3uHU7w" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="6Qwtr1aYpeq" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6Qwtr1aYper" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
             <node concept="2es0OD" id="7NamNJWF_97" role="2OqNvi">
               <node concept="1bVj0M" id="7NamNJWF_99" role="23t8la">
                 <node concept="3clFbS" id="7NamNJWF_9a" role="1bW5cS">
-                  <node concept="3clFbJ" id="7NamNJWF_cS" role="3cqZAp">
-                    <node concept="2OqwBi" id="7NamNJWFAzQ" role="3clFbw">
-                      <node concept="2OqwBi" id="7NamNJWF_zx" role="2Oq$k0">
-                        <node concept="37vLTw" id="7NamNJWF_hM" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7NamNJWF_9b" resolve="it" />
-                        </node>
-                        <node concept="3TrEf2" id="7NamNJWFA4O" role="2OqNvi">
-                          <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
-                        </node>
-                      </node>
-                      <node concept="3w_OXm" id="7NamNJWFB0H" role="2OqNvi" />
-                    </node>
-                    <node concept="3clFbS" id="7NamNJWF_cU" role="3clFbx">
-                      <node concept="3cpWs8" id="2CQc9DPhiHO" role="3cqZAp">
-                        <node concept="3cpWsn" id="2CQc9DPhiHR" role="3cpWs9">
-                          <property role="TrG5h" value="newCellActionMap" />
-                          <node concept="3Tqbb2" id="2CQc9DPhiHM" role="1tU5fm">
-                            <ref role="ehGHo" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
+                  <node concept="3clFbJ" id="6Qwtr1aYbNq" role="3cqZAp">
+                    <node concept="3clFbS" id="6Qwtr1aYbNs" role="3clFbx">
+                      <node concept="3clFbF" id="6Qwtr1aYdq2" role="3cqZAp">
+                        <node concept="37vLTI" id="6Qwtr1aYe6s" role="3clFbG">
+                          <node concept="37vLTw" id="6Qwtr1aYdq0" role="37vLTJ">
+                            <ref role="3cqZAo" node="6Qwtr1aYbyD" resolve="tableSelectionActionMap" />
                           </node>
-                          <node concept="2pJPEk" id="2CQc9DPhkwL" role="33vP2m">
+                          <node concept="2pJPEk" id="2CQc9DPhkwL" role="37vLTx">
                             <node concept="2pJPED" id="2CQc9DPhkwN" role="2pJPEn">
                               <ref role="2pJxaS" to="tpc2:g_h_SNY" resolve="CellActionMapDeclaration" />
                               <node concept="2pJxcG" id="2CQc9DPhkJ5" role="2pJxcM">
                                 <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
-                                <node concept="WxPPo" id="2CQc9DPhkOC" role="28ntcv">
-                                  <node concept="Xl_RD" id="2CQc9DPhkOB" role="WxPPp">
+                                <node concept="WxPPo" id="6Qwtr1aYeIq" role="28ntcv">
+                                  <node concept="Xl_RD" id="6Qwtr1aYeIp" role="WxPPp">
                                     <property role="Xl_RC" value="TableSelectionActionMap" />
                                   </node>
                                 </node>
@@ -13744,7 +13767,7 @@
                         <node concept="2OqwBi" id="2CQc9DPhqdU" role="3clFbG">
                           <node concept="2OqwBi" id="2CQc9DPhm$6" role="2Oq$k0">
                             <node concept="37vLTw" id="2CQc9DPhmhh" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
+                              <ref role="3cqZAo" node="6Qwtr1aYbyD" resolve="tableSelectionActionMap" />
                             </node>
                             <node concept="3Tsc0h" id="2CQc9DPhn4o" role="2OqNvi">
                               <ref role="3TtcxE" to="tpc2:g_h_SO1" resolve="item" />
@@ -13787,31 +13810,37 @@
                           <node concept="1Q6Npb" id="2CQc9DPhxnL" role="2Oq$k0" />
                           <node concept="3BYIHo" id="2CQc9DPhxTE" role="2OqNvi">
                             <node concept="37vLTw" id="2CQc9DPhy2F" role="3BYIHq">
-                              <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
+                              <ref role="3cqZAo" node="6Qwtr1aYbyD" resolve="tableSelectionActionMap" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="7NamNJWFBdY" role="3cqZAp">
-                        <node concept="37vLTI" id="7NamNJWFDRq" role="3clFbG">
-                          <node concept="2OqwBi" id="7NamNJWFBuQ" role="37vLTJ">
-                            <node concept="37vLTw" id="7NamNJWFBdX" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7NamNJWF_9b" resolve="it" />
-                            </node>
-                            <node concept="3TrEf2" id="7NamNJWFC1S" role="2OqNvi">
-                              <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="2CQc9DPhyAd" role="37vLTx">
-                            <ref role="3cqZAo" node="2CQc9DPhiHR" resolve="newCellActionMap" />
-                          </node>
+                    </node>
+                    <node concept="3clFbC" id="6Qwtr1aYcix" role="3clFbw">
+                      <node concept="10Nm6u" id="6Qwtr1aYci$" role="3uHU7w" />
+                      <node concept="37vLTw" id="6Qwtr1aYbUZ" role="3uHU7B">
+                        <ref role="3cqZAo" node="6Qwtr1aYbyD" resolve="tableSelectionActionMap" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="7NamNJWFBdY" role="3cqZAp">
+                    <node concept="37vLTI" id="7NamNJWFDRq" role="3clFbG">
+                      <node concept="2OqwBi" id="7NamNJWFBuQ" role="37vLTJ">
+                        <node concept="37vLTw" id="7NamNJWFBdX" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7NamNJWF_9b" resolve="table" />
                         </node>
+                        <node concept="3TrEf2" id="7NamNJWFC1S" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpc2:g_ERwze" resolve="actionMap" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="2CQc9DPhyAd" role="37vLTx">
+                        <ref role="3cqZAo" node="6Qwtr1aYbyD" resolve="tableSelectionActionMap" />
                       </node>
                     </node>
                   </node>
                 </node>
                 <node concept="gl6BB" id="7NamNJWF_9b" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
+                  <property role="TrG5h" value="table" />
                   <node concept="2jxLKc" id="7NamNJWF_9c" role="1tU5fm" />
                 </node>
               </node>

--- a/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
+++ b/code/tables/languages/de.slisson.mps.tables/languageModels/editor.mps
@@ -3565,20 +3565,6 @@
       </node>
       <node concept="jK8Ss" id="12YYiosXoA6" role="jK8aL">
         <node concept="3clFbS" id="12YYiosXoA7" role="2VODD2">
-          <node concept="3cpWs8" id="12YYiosXoQB" role="3cqZAp">
-            <node concept="3cpWsn" id="12YYiosXoQC" role="3cpWs9">
-              <property role="TrG5h" value="support" />
-              <node concept="3uibUv" id="12YYiosXoQD" role="1tU5fm">
-                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-              </node>
-              <node concept="2YIFZM" id="12YYiosXoQE" role="33vP2m">
-                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
-                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-                <node concept="0IXxy" id="12YYiosXoQF" role="37wK5m" />
-                <node concept="1Q80Hx" id="6hm_9jq2HBl" role="37wK5m" />
-              </node>
-            </node>
-          </node>
           <node concept="3cpWs8" id="12YYiosXoQG" role="3cqZAp">
             <node concept="3cpWsn" id="12YYiosXoQH" role="3cpWs9">
               <property role="TrG5h" value="selection" />
@@ -3611,11 +3597,11 @@
                   <ref role="3cqZAo" node="12YYiosXoQH" resolve="selection" />
                 </node>
               </node>
-              <node concept="3y3z36" id="12YYiosXpel" role="3uHU7B">
-                <node concept="37vLTw" id="12YYiosXp3B" role="3uHU7B">
-                  <ref role="3cqZAo" node="12YYiosXoQC" resolve="support" />
-                </node>
-                <node concept="10Nm6u" id="12YYiosXpU3" role="3uHU7w" />
+              <node concept="2YIFZM" id="6Qwtr1aLZr9" role="3uHU7B">
+                <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="6Qwtr1aM00R" role="37wK5m" />
+                <node concept="1Q80Hx" id="6Qwtr1aMbxg" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -3747,20 +3733,6 @@
       </node>
       <node concept="jK8Ss" id="12YYiosXsN4" role="jK8aL">
         <node concept="3clFbS" id="12YYiosXsN5" role="2VODD2">
-          <node concept="3cpWs8" id="12YYiosXsQQ" role="3cqZAp">
-            <node concept="3cpWsn" id="12YYiosXsQR" role="3cpWs9">
-              <property role="TrG5h" value="support" />
-              <node concept="3uibUv" id="12YYiosXsQS" role="1tU5fm">
-                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-              </node>
-              <node concept="2YIFZM" id="12YYiosXsQT" role="33vP2m">
-                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
-                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-                <node concept="0IXxy" id="12YYiosXsQU" role="37wK5m" />
-                <node concept="1Q80Hx" id="6hm_9jq2HUF" role="37wK5m" />
-              </node>
-            </node>
-          </node>
           <node concept="3cpWs8" id="12YYiosXsQV" role="3cqZAp">
             <node concept="3cpWsn" id="12YYiosXsQW" role="3cpWs9">
               <property role="TrG5h" value="selection" />
@@ -3787,17 +3759,17 @@
           </node>
           <node concept="3clFbF" id="12YYiosXt2N" role="3cqZAp">
             <node concept="1Wc70l" id="12YYiosXsZN" role="3clFbG">
-              <node concept="3y3z36" id="12YYiosXsXS" role="3uHU7B">
-                <node concept="37vLTw" id="12YYiosXsRd" role="3uHU7B">
-                  <ref role="3cqZAo" node="12YYiosXsQR" resolve="support" />
-                </node>
-                <node concept="10Nm6u" id="12YYiosXsRe" role="3uHU7w" />
-              </node>
               <node concept="3y3z36" id="12YYiosXtGs" role="3uHU7w">
                 <node concept="37vLTw" id="12YYiosXsRb" role="3uHU7B">
                   <ref role="3cqZAo" node="12YYiosXsQW" resolve="selection" />
                 </node>
                 <node concept="10Nm6u" id="12YYiosXsRa" role="3uHU7w" />
+              </node>
+              <node concept="2YIFZM" id="6Qwtr1aMbV$" role="3uHU7B">
+                <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="6Qwtr1aMbV_" role="37wK5m" />
+                <node concept="1Q80Hx" id="6Qwtr1aMbVA" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -3919,20 +3891,6 @@
       </node>
       <node concept="jK8Ss" id="12YYiosXtLP" role="jK8aL">
         <node concept="3clFbS" id="12YYiosXtLQ" role="2VODD2">
-          <node concept="3cpWs8" id="12YYiosXtZE" role="3cqZAp">
-            <node concept="3cpWsn" id="12YYiosXtZF" role="3cpWs9">
-              <property role="TrG5h" value="support" />
-              <node concept="3uibUv" id="12YYiosXtZG" role="1tU5fm">
-                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-              </node>
-              <node concept="2YIFZM" id="12YYiosXtZH" role="33vP2m">
-                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
-                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-                <node concept="0IXxy" id="12YYiosXtZI" role="37wK5m" />
-                <node concept="1Q80Hx" id="6hm_9jq2Jgj" role="37wK5m" />
-              </node>
-            </node>
-          </node>
           <node concept="3cpWs8" id="12YYiosXtZJ" role="3cqZAp">
             <node concept="3cpWsn" id="12YYiosXtZK" role="3cpWs9">
               <property role="TrG5h" value="selection" />
@@ -3959,17 +3917,17 @@
           </node>
           <node concept="3clFbF" id="12YYiosXu83" role="3cqZAp">
             <node concept="1Wc70l" id="12YYiosXw0_" role="3clFbG">
-              <node concept="3y3z36" id="12YYiosXuLS" role="3uHU7B">
-                <node concept="37vLTw" id="12YYiosXu01" role="3uHU7B">
-                  <ref role="3cqZAo" node="12YYiosXtZF" resolve="support" />
-                </node>
-                <node concept="10Nm6u" id="12YYiosXu02" role="3uHU7w" />
-              </node>
               <node concept="3y3z36" id="12YYiosXv0T" role="3uHU7w">
                 <node concept="37vLTw" id="12YYiosXtZZ" role="3uHU7B">
                   <ref role="3cqZAo" node="12YYiosXtZK" resolve="selection" />
                 </node>
                 <node concept="10Nm6u" id="12YYiosXtZY" role="3uHU7w" />
+              </node>
+              <node concept="2YIFZM" id="6Qwtr1aMc5T" role="3uHU7B">
+                <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="6Qwtr1aMc5U" role="37wK5m" />
+                <node concept="1Q80Hx" id="6Qwtr1aMc5V" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -4057,20 +4015,6 @@
       </node>
       <node concept="jK8Ss" id="12YYiosXwdx" role="jK8aL">
         <node concept="3clFbS" id="12YYiosXwdy" role="2VODD2">
-          <node concept="3cpWs8" id="12YYiosXwh4" role="3cqZAp">
-            <node concept="3cpWsn" id="12YYiosXwh5" role="3cpWs9">
-              <property role="TrG5h" value="support" />
-              <node concept="3uibUv" id="12YYiosXwh6" role="1tU5fm">
-                <ref role="3uigEE" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-              </node>
-              <node concept="2YIFZM" id="12YYiosXwh7" role="33vP2m">
-                <ref role="37wK5l" to="3bri:12YYiosIUi1" resolve="forNode" />
-                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
-                <node concept="0IXxy" id="12YYiosXwh8" role="37wK5m" />
-                <node concept="1Q80Hx" id="6hm_9jq2JG5" role="37wK5m" />
-              </node>
-            </node>
-          </node>
           <node concept="3cpWs8" id="12YYiosXwh9" role="3cqZAp">
             <node concept="3cpWsn" id="12YYiosXwha" role="3cpWs9">
               <property role="TrG5h" value="selection" />
@@ -4097,17 +4041,17 @@
           </node>
           <node concept="3clFbF" id="12YYiosXwpO" role="3cqZAp">
             <node concept="1Wc70l" id="12YYiosXws8" role="3clFbG">
-              <node concept="3y3z36" id="12YYiosXwue" role="3uHU7B">
-                <node concept="37vLTw" id="12YYiosXwhr" role="3uHU7B">
-                  <ref role="3cqZAo" node="12YYiosXwh5" resolve="support" />
-                </node>
-                <node concept="10Nm6u" id="12YYiosXwhs" role="3uHU7w" />
-              </node>
               <node concept="3y3z36" id="12YYiosXwwg" role="3uHU7w">
                 <node concept="37vLTw" id="12YYiosXwhp" role="3uHU7B">
                   <ref role="3cqZAo" node="12YYiosXwha" resolve="selection" />
                 </node>
                 <node concept="10Nm6u" id="12YYiosXwho" role="3uHU7w" />
+              </node>
+              <node concept="2YIFZM" id="6Qwtr1aMckW" role="3uHU7B">
+                <ref role="37wK5l" to="3bri:12YYiosIA6b" resolve="existsFor" />
+                <ref role="1Pybhc" to="3bri:12YYiosxYeH" resolve="CopyPasteSupport" />
+                <node concept="0IXxy" id="6Qwtr1aMckX" role="37wK5m" />
+                <node concept="1Q80Hx" id="6Qwtr1aMckY" role="37wK5m" />
               </node>
             </node>
           </node>

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/plugin.mps
@@ -1656,6 +1656,9 @@
           <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
         </node>
       </node>
+      <node concept="2AHcQZ" id="6Qwtr1aKRPF" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+      </node>
     </node>
     <node concept="3Tm1VV" id="12YYiosxYeI" role="1B3o_S" />
   </node>


### PR DESCRIPTION
Also, fix 'duplicate unit name' warning by sharing the TableSelectionActionMap between multiple tables in the same editor model.

fixes #1650 