### PR TITLE
feat(compare): add 'ignore annotations' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## December 2025
 
+### Added
+
+- *de.itemis.mps.compare* 'assert node equals' and ':isEqualTo:' expression can now ignore attributes (annotations) when comparing nodes.
+
+### Changed
+
+- *de.itemis.mps.compare* 'show diff' in assertions is now implemented using a transient property. Changing it will mark the node as changed but the property value is not written to disk and so will never be checked into version control.
+- *de.itemis.mps.compare* minor improvements to the editors of 'assert node equals' and 'show diff'.
+
 ### Fixed
 
 - Migrate all usages of deprecated getInstance() from [NavigationSupport](http://127.0.0.1:63320/node?ref=1ed103c3-3aa6-49b7-9c21-6765ee11f224%2Fjava%3Ajetbrains.mps.openapi.navigation%28MPS.Editor%2F%29%2F~NavigationSupport) to its replacement getInstance(Project mpsProject)

--- a/code/compare/languages/de.itemis.mps.compare/compare.mpl
+++ b/code/compare/languages/de.itemis.mps.compare/compare.mpl
@@ -147,6 +147,7 @@
     <dependency reexport="false" scope="generate-into">a247e09e-2435-45ba-b8d2-07e93feba96a(jetbrains.mps.baseLanguage.tuples)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/compare/languages/de.itemis.mps.compare/generator/template/de.itemis.mps.compare.generator.template.main@generator.mps
+++ b/code/compare/languages/de.itemis.mps.compare/generator/template/de.itemis.mps.compare.generator.template.main@generator.mps
@@ -466,6 +466,9 @@
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -744,6 +747,24 @@
                               <node concept="37vLTI" id="iyWIxsf$Xd" role="3clFbG">
                                 <node concept="3clFbT" id="iyWIxsf_2N" role="37vLTx">
                                   <property role="3clFbU" value="true" />
+                                  <node concept="17Uvod" id="6Vb09dgsqja" role="lGtFl">
+                                    <property role="2qtEX9" value="value" />
+                                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                                    <node concept="3zFVjK" id="6Vb09dgsqjb" role="3zH0cK">
+                                      <node concept="3clFbS" id="6Vb09dgsqjc" role="2VODD2">
+                                        <node concept="3clFbF" id="6Vb09dgsryX" role="3cqZAp">
+                                          <node concept="3fqX7Q" id="6Vb09dgsto3" role="3clFbG">
+                                            <node concept="2OqwBi" id="6Vb09dgsto5" role="3fr31v">
+                                              <node concept="30H73N" id="6Vb09dgsto6" role="2Oq$k0" />
+                                              <node concept="3TrcHB" id="6Vb09dgsto7" role="2OqNvi">
+                                                <ref role="3TsBF5" to="8do3:6Vb09dgp30e" resolve="ignoreAnnotations" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
                                 <node concept="2OqwBi" id="iyWIxsf$$H" role="37vLTJ">
                                   <node concept="37vLTw" id="iyWIxsf$nY" role="2Oq$k0">
@@ -1329,15 +1350,33 @@
                         </node>
                         <node concept="3clFbF" id="iyWIxsfmkN" role="3cqZAp">
                           <node concept="37vLTI" id="iyWIxsfmLp" role="3clFbG">
-                            <node concept="3clFbT" id="iyWIxsfmVG" role="37vLTx">
-                              <property role="3clFbU" value="true" />
-                            </node>
                             <node concept="2OqwBi" id="iyWIxsfmpi" role="37vLTJ">
                               <node concept="37vLTw" id="iyWIxsfmkL" role="2Oq$k0">
                                 <ref role="3cqZAo" node="iyWIxsfidM" resolve="options" />
                               </node>
                               <node concept="2OwXpG" id="iyWIxsfmA0" role="2OqNvi">
                                 <ref role="2Oxat5" to="mqum:E9Bg752xHS" resolve="compareAnnotations" />
+                              </node>
+                            </node>
+                            <node concept="3clFbT" id="2C1H_zkhl8M" role="37vLTx">
+                              <property role="3clFbU" value="true" />
+                              <node concept="17Uvod" id="2C1H_zkhlEc" role="lGtFl">
+                                <property role="2qtEX9" value="value" />
+                                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                                <node concept="3zFVjK" id="2C1H_zkhlEd" role="3zH0cK">
+                                  <node concept="3clFbS" id="2C1H_zkhlEe" role="2VODD2">
+                                    <node concept="3clFbF" id="2C1H_zkhlP7" role="3cqZAp">
+                                      <node concept="3fqX7Q" id="2C1H_zkhlP5" role="3clFbG">
+                                        <node concept="2OqwBi" id="2C1H_zkhmz6" role="3fr31v">
+                                          <node concept="30H73N" id="2C1H_zkhlPa" role="2Oq$k0" />
+                                          <node concept="3TrcHB" id="2C1H_zkhn3u" role="2OqNvi">
+                                            <ref role="3TsBF5" to="8do3:2C1H_zkhhtk" resolve="ignoreAnnotations" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
                               </node>
                             </node>
                           </node>

--- a/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.behavior.mps
+++ b/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.behavior.mps
@@ -20,7 +20,6 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="tp4k" ref="r:00000000-0000-4000-0000-011c89590368(jetbrains.mps.lang.plugin.structure)" />
     <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(de.itemis.mps.comparator.code)" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="tpc2" ref="r:00000000-0000-4000-0000-011c8959029e(jetbrains.mps.lang.editor.structure)" implicit="true" />
   </imports>
   <registry>
@@ -39,9 +38,9 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
-        <child id="1224071154657" name="classifierType" index="0kSFW" />
-        <child id="1224071154656" name="expression" index="0kSFX" />
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -53,9 +52,6 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
-      </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
-        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -69,6 +65,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -77,9 +74,13 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -98,7 +99,6 @@
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
-        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -107,13 +107,9 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
-      </concept>
-      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
-        <child id="1163668914799" name="condition" index="3K4Cdx" />
-        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
-        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
@@ -125,9 +121,6 @@
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
-        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
-      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -136,6 +129,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -177,18 +173,15 @@
       <node concept="3Tm1VV" id="6Od11GY7tDP" role="1B3o_S" />
       <node concept="3cqZAl" id="6Od11GY7tEI" role="3clF45" />
       <node concept="3clFbS" id="6Od11GY7tDR" role="3clF47">
-        <node concept="3clFbF" id="6Od11GY8L71" role="3cqZAp">
-          <node concept="2OqwBi" id="6Od11GY8L73" role="3clFbG">
-            <node concept="2JrnkZ" id="6Od11GY8L74" role="2Oq$k0">
-              <node concept="13iPFW" id="6Od11GY8L75" role="2JrQYb" />
+        <node concept="3clFbF" id="6Vb09dgqHQi" role="3cqZAp">
+          <node concept="37vLTI" id="6Vb09dgqJt3" role="3clFbG">
+            <node concept="37vLTw" id="6Vb09dgqJtU" role="37vLTx">
+              <ref role="3cqZAo" node="6Od11GY7vAi" resolve="flag" />
             </node>
-            <node concept="liA8E" id="6Od11GY8L76" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
-              <node concept="Xl_RD" id="6Od11GY8L77" role="37wK5m">
-                <property role="Xl_RC" value="diff" />
-              </node>
-              <node concept="37vLTw" id="6Od11GY8L78" role="37wK5m">
-                <ref role="3cqZAo" node="6Od11GY7vAi" resolve="flag" />
+            <node concept="2OqwBi" id="6Vb09dgqI2v" role="37vLTJ">
+              <node concept="13iPFW" id="6Vb09dgqHQg" role="2Oq$k0" />
+              <node concept="3TrcHB" id="6Vb09dgqIdw" role="2OqNvi">
+                <ref role="3TsBF5" to="8do3:6Vb09dgqHFa" resolve="showDiff" />
               </node>
             </node>
           </node>
@@ -200,49 +193,49 @@
       <node concept="3Tm1VV" id="6Od11GY7tN_" role="1B3o_S" />
       <node concept="10P_77" id="6Od11GY7tOd" role="3clF45" />
       <node concept="3clFbS" id="6Od11GY7tNB" role="3clF47">
-        <node concept="3clFbF" id="6Od11GY8LEV" role="3cqZAp">
-          <node concept="3K4zz7" id="6Od11GY8LEF" role="3clFbG">
-            <node concept="3clFbT" id="6Od11GY8LTJ" role="3K4E3e" />
-            <node concept="3clFbC" id="6Od11GY8LM1" role="3K4Cdx">
-              <node concept="10Nm6u" id="6Od11GY8LQK" role="3uHU7w" />
-              <node concept="2OqwBi" id="6Od11GY7wc4" role="3uHU7B">
-                <node concept="2JrnkZ" id="6Od11GY7vWZ" role="2Oq$k0">
-                  <node concept="13iPFW" id="6Od11GY7vH0" role="2JrQYb" />
-                </node>
-                <node concept="liA8E" id="6Od11GY7wjy" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
-                  <node concept="Xl_RD" id="6Od11GY7wj_" role="37wK5m">
-                    <property role="Xl_RC" value="diff" />
-                  </node>
-                </node>
+        <node concept="3clFbJ" id="6Vb09dgqLWu" role="3cqZAp">
+          <node concept="3clFbS" id="6Vb09dgqLWw" role="3clFbx">
+            <node concept="3cpWs6" id="6Vb09dgqNqv" role="3cqZAp">
+              <node concept="3clFbT" id="6Vb09dgqNqB" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="6Vb09dgqLY2" role="3clFbw">
+            <node concept="2OqwBi" id="6Vb09dgqM8T" role="3fr31v">
+              <node concept="13iPFW" id="6Vb09dgqLY4" role="2Oq$k0" />
+              <node concept="3TrcHB" id="6Vb09dgqMnh" role="2OqNvi">
+                <ref role="3TsBF5" to="8do3:6Vb09dgqHFa" resolve="showDiff" />
               </node>
             </node>
-            <node concept="1Wc70l" id="NgM4xWLlMc" role="3K4GZi">
-              <node concept="3fqX7Q" id="NgM4xWLoue" role="3uHU7w">
-                <node concept="2OqwBi" id="NgM4xWLoug" role="3fr31v">
-                  <node concept="2YIFZM" id="NgM4xWLouh" role="2Oq$k0">
-                    <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
-                    <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
-                  </node>
-                  <node concept="liA8E" id="NgM4xWLoui" role="2OqNvi">
-                    <ref role="37wK5l" to="bd8o:~Application.isHeadlessEnvironment()" resolve="isHeadlessEnvironment" />
-                  </node>
-                </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6Vb09dgqNse" role="3cqZAp" />
+        <node concept="3cpWs8" id="6Vb09dgqLRG" role="3cqZAp">
+          <node concept="3cpWsn" id="6Vb09dgqLRH" role="3cpWs9">
+            <property role="TrG5h" value="application" />
+            <node concept="3uibUv" id="6Vb09dgqLaF" role="1tU5fm">
+              <ref role="3uigEE" to="bd8o:~Application" resolve="Application" />
+            </node>
+            <node concept="2YIFZM" id="6Vb09dgqLRI" role="33vP2m">
+              <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+              <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6Vb09dgqO$f" role="3cqZAp">
+          <node concept="1Wc70l" id="6Vb09dgqOtL" role="3cqZAk">
+            <node concept="3y3z36" id="6Vb09dgqOa6" role="3uHU7B">
+              <node concept="37vLTw" id="6Vb09dgqNw0" role="3uHU7B">
+                <ref role="3cqZAo" node="6Vb09dgqLRH" resolve="application" />
               </node>
-              <node concept="0kSF2" id="6Od11GY8M34" role="3uHU7B">
-                <node concept="3uibUv" id="6Od11GY8M36" role="0kSFW">
-                  <ref role="3uigEE" to="wyt6:~Boolean" resolve="Boolean" />
+              <node concept="10Nm6u" id="6Vb09dgqOrP" role="3uHU7w" />
+            </node>
+            <node concept="3fqX7Q" id="6Vb09dgqKvl" role="3uHU7w">
+              <node concept="2OqwBi" id="6Vb09dgqKvm" role="3fr31v">
+                <node concept="37vLTw" id="6Vb09dgqLRJ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6Vb09dgqLRH" resolve="application" />
                 </node>
-                <node concept="2OqwBi" id="6Od11GY8LWJ" role="0kSFX">
-                  <node concept="2JrnkZ" id="6Od11GY8LWK" role="2Oq$k0">
-                    <node concept="13iPFW" id="6Od11GY8LWL" role="2JrQYb" />
-                  </node>
-                  <node concept="liA8E" id="6Od11GY8LWM" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
-                    <node concept="Xl_RD" id="6Od11GY8LWN" role="37wK5m">
-                      <property role="Xl_RC" value="diff" />
-                    </node>
-                  </node>
+                <node concept="liA8E" id="6Vb09dgqKvo" role="2OqNvi">
+                  <ref role="37wK5l" to="bd8o:~Application.isHeadlessEnvironment()" resolve="isHeadlessEnvironment" />
                 </node>
               </node>
             </node>

--- a/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.editor.mps
+++ b/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.editor.mps
@@ -5,6 +5,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing" version="0" />
+    <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -49,6 +50,7 @@
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
@@ -131,18 +133,13 @@
       <concept id="1176474535556" name="jetbrains.mps.lang.editor.structure.QueryFunction_JComponent" flags="in" index="3Fmcul" />
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="625126330682908270" name="jetbrains.mps.lang.editor.structure.CellModel_ReferencePresentation" flags="sg" stub="730538219795961225" index="3SHvHV" />
+      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
-        <child id="1224071154657" name="classifierType" index="0kSFW" />
-        <child id="1224071154656" name="expression" index="0kSFX" />
-      </concept>
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -174,9 +171,6 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
-        <reference id="1144433057691" name="classifier" index="1PxDUh" />
-      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
@@ -199,21 +193,17 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -258,7 +248,6 @@
     </language>
     <language id="62971cbe-fd2f-4135-b001-ee6cb7a74436" name="nl.f1re.mps.editor.swing">
       <concept id="8659612544244790000" name="nl.f1re.mps.editor.swing.structure.QueryFunction_String" flags="ig" index="05MPa" />
-      <concept id="8659612544247522174" name="nl.f1re.mps.editor.swing.structure.ConceptFunctionParameter_component" flags="ng" index="0jJN4" />
       <concept id="8659612544238797919" name="nl.f1re.mps.editor.swing.structure.CellModel_CustomJComponent" flags="sg" stub="8659612544238937882" index="fWXJ_">
         <child id="8659612544238938786" name="toStringFunction" index="fNvko" />
       </concept>
@@ -286,6 +275,9 @@
         <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
     </language>
+    <language id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool">
+      <concept id="4900677560559655527" name="de.itemis.mps.editor.bool.structure.CellModel_Checkbox" flags="sg" stub="416014060004381438" index="27S6Sx" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -293,7 +285,6 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
-      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -345,9 +336,12 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3F0ifn" id="h3vlOlH" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="35P6krskVwG" role="3F10Kt">
+      <node concept="3F0ifn" id="6Vb09dguozd" role="3EZMnx">
+        <property role="3F0ifm" value="with options {" />
+        <node concept="VechU" id="6Vb09dguoAg" role="3F10Kt">
+          <property role="Vb096" value="fLwANPu/blue" />
+        </node>
+        <node concept="ljvvj" id="2C1H_zkdHdE" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -359,12 +353,6 @@
           <node concept="VPM3Z" id="3C6_kMLMVMH" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
-          <node concept="3F0ifn" id="2lpUxXMduU_" role="3EZMnx">
-            <property role="3F0ifm" value="(" />
-            <node concept="11LMrY" id="2lpUxXMduZ4" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
           <node concept="3F0ifn" id="2lpUxXMduUZ" role="3EZMnx">
             <property role="3F0ifm" value="ignored properties:" />
             <node concept="11L4FC" id="2lpUxXMdv0_" role="3F10Kt">
@@ -373,12 +361,6 @@
           </node>
           <node concept="3F1sOY" id="2lpUxXMduVr" role="3EZMnx">
             <ref role="1NtTu8" to="8do3:2lpUxXMduaL" resolve="ignoredProperties" />
-          </node>
-          <node concept="3F0ifn" id="2lpUxXMduVS" role="3EZMnx">
-            <property role="3F0ifm" value=")" />
-            <node concept="11L4FC" id="2lpUxXMdv3J" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
           </node>
           <node concept="2iRfu4" id="3C6_kMLMVMK" role="2iSdaV" />
           <node concept="pkWqt" id="3C6_kMLMVNw" role="pqm2j">
@@ -415,12 +397,6 @@
           <node concept="VPM3Z" id="iyWIxs9eCL" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
-          <node concept="3F0ifn" id="iyWIxs9eCM" role="3EZMnx">
-            <property role="3F0ifm" value="(" />
-            <node concept="11LMrY" id="iyWIxs9eCN" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
           <node concept="3F0ifn" id="iyWIxs9eCO" role="3EZMnx">
             <property role="3F0ifm" value="ignored children:" />
             <node concept="11L4FC" id="iyWIxs9eCP" role="3F10Kt">
@@ -430,23 +406,11 @@
           <node concept="3F1sOY" id="iyWIxs9eCQ" role="3EZMnx">
             <ref role="1NtTu8" to="8do3:iyWIxs9bN3" resolve="ignoredChildren" />
           </node>
-          <node concept="3F0ifn" id="iyWIxs9eCR" role="3EZMnx">
-            <property role="3F0ifm" value=")" />
-            <node concept="11L4FC" id="iyWIxs9eCS" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
           <node concept="2iRfu4" id="iyWIxs9eCT" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="3qPjHtYqVRv" role="3EZMnx">
           <node concept="VPM3Z" id="3qPjHtYqVRw" role="3F10Kt">
             <property role="VOm3f" value="false" />
-          </node>
-          <node concept="3F0ifn" id="3qPjHtYqVRx" role="3EZMnx">
-            <property role="3F0ifm" value="(" />
-            <node concept="11LMrY" id="3qPjHtYqVRy" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
           </node>
           <node concept="3F0ifn" id="3qPjHtYqVRz" role="3EZMnx">
             <property role="3F0ifm" value="ignored references:" />
@@ -457,178 +421,57 @@
           <node concept="3F1sOY" id="3qPjHtYqVR_" role="3EZMnx">
             <ref role="1NtTu8" to="8do3:3qPjHtYqU7z" resolve="ignoredReferences" />
           </node>
-          <node concept="3F0ifn" id="3qPjHtYqVRA" role="3EZMnx">
-            <property role="3F0ifm" value=")" />
-            <node concept="11L4FC" id="3qPjHtYqVRB" role="3F10Kt">
-              <property role="VOm3f" value="true" />
+          <node concept="2iRfu4" id="3qPjHtYqVRC" role="2iSdaV" />
+        </node>
+        <node concept="3EZMnI" id="6Vb09dgp6mt" role="3EZMnx">
+          <node concept="VPM3Z" id="6Vb09dgp6mu" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="2iRfu4" id="6Vb09dgp6mv" role="2iSdaV" />
+          <node concept="3EZMnI" id="6Vb09dgpDXW" role="3EZMnx">
+            <node concept="3XFhqQ" id="6Vb09dgu19Z" role="3EZMnx" />
+            <node concept="2iRfu4" id="6Vb09dgpDXX" role="2iSdaV" />
+            <node concept="27S6Sx" id="6Vb09dgpbMU" role="3EZMnx">
+              <ref role="1NtTu8" to="8do3:6Vb09dgp30e" resolve="ignoreAnnotations" />
+            </node>
+            <node concept="3F0ifn" id="6Vb09dgp6mx" role="3EZMnx">
+              <property role="3F0ifm" value="ignore annotations" />
             </node>
           </node>
-          <node concept="2iRfu4" id="3qPjHtYqVRC" role="2iSdaV" />
+          <node concept="3F0ifn" id="6Vb09dgrYWg" role="3EZMnx">
+            <property role="3F0ifm" value="" />
+          </node>
         </node>
         <node concept="3EZMnI" id="2RIzFJ85D85" role="3EZMnx">
           <node concept="VPM3Z" id="2RIzFJ85D86" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="2iRfu4" id="2RIzFJ85D8e" role="2iSdaV" />
-          <node concept="3F0ifn" id="6Od11GY6B$F" role="3EZMnx">
-            <property role="3F0ifm" value="(" />
-          </node>
-          <node concept="3F0ifn" id="6Od11GY6B_f" role="3EZMnx">
-            <property role="3F0ifm" value="show diff:" />
-          </node>
-          <node concept="3EZMnI" id="6Od11GYaZ8i" role="3EZMnx">
-            <node concept="VPM3Z" id="6Od11GYaZ8k" role="3F10Kt" />
-            <node concept="2iRfu4" id="6Od11GYaZ8n" role="2iSdaV" />
-            <node concept="fWXJ_" id="7wH7VDSoPdM" role="3EZMnx">
-              <node concept="3Fmcul" id="7wH7VDSoPdO" role="3FoqZy">
-                <node concept="3clFbS" id="7wH7VDSoPdQ" role="2VODD2">
-                  <node concept="3cpWs8" id="6Od11GY5Too" role="3cqZAp">
-                    <node concept="3cpWsn" id="6Od11GY5Top" role="3cpWs9">
-                      <property role="TrG5h" value="box" />
-                      <node concept="3uibUv" id="6Od11GY5Toq" role="1tU5fm">
-                        <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
-                      </node>
-                      <node concept="2ShNRf" id="6Od11GY5Tpi" role="33vP2m">
-                        <node concept="1pGfFk" id="7wH7VDSoW5z" role="2ShVmc">
-                          <property role="373rjd" value="true" />
-                          <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;(java.lang.String)" resolve="JBCheckBox" />
-                          <node concept="Xl_RD" id="3R$uTsAi$8C" role="37wK5m">
-                            <property role="Xl_RC" value=" " />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="g4RruU2gcE" role="3cqZAp">
-                    <node concept="2OqwBi" id="g4RruU2gcF" role="3clFbG">
-                      <node concept="37vLTw" id="g4RruU2gcG" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6Od11GY5Top" resolve="box" />
-                      </node>
-                      <node concept="liA8E" id="g4RruU2gcH" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~AbstractButton.setSelected(boolean)" resolve="setSelected" />
-                        <node concept="2OqwBi" id="g4RruU2gcI" role="37wK5m">
-                          <node concept="pncrf" id="g4RruU2gcJ" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="g4RruU2gcK" role="2OqNvi">
-                            <ref role="37wK5l" to="qjvf:6Od11GY7tN$" resolve="isDiffEnabled" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="6Od11GY7dxq" role="3cqZAp">
-                    <node concept="2OqwBi" id="6Od11GY7esA" role="3clFbG">
-                      <node concept="37vLTw" id="6Od11GY7dxo" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6Od11GY5Top" resolve="box" />
-                      </node>
-                      <node concept="liA8E" id="6Od11GY7gdw" role="2OqNvi">
-                        <ref role="37wK5l" to="dxuu:~AbstractButton.addItemListener(java.awt.event.ItemListener)" resolve="addItemListener" />
-                        <node concept="2ShNRf" id="6Od11GY7gmK" role="37wK5m">
-                          <node concept="YeOm9" id="6Od11GY7hig" role="2ShVmc">
-                            <node concept="1Y3b0j" id="6Od11GY7hij" role="YeSDq">
-                              <property role="2bfB8j" value="true" />
-                              <ref role="1Y3XeK" to="hyam:~ItemListener" resolve="ItemListener" />
-                              <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                              <node concept="3Tm1VV" id="6Od11GY7hik" role="1B3o_S" />
-                              <node concept="3clFb_" id="6Od11GY7hip" role="jymVt">
-                                <property role="TrG5h" value="itemStateChanged" />
-                                <node concept="3Tm1VV" id="6Od11GY7hiq" role="1B3o_S" />
-                                <node concept="3cqZAl" id="6Od11GY7his" role="3clF45" />
-                                <node concept="37vLTG" id="6Od11GY7hit" role="3clF46">
-                                  <property role="TrG5h" value="e" />
-                                  <node concept="3uibUv" id="6Od11GY7hiu" role="1tU5fm">
-                                    <ref role="3uigEE" to="hyam:~ItemEvent" resolve="ItemEvent" />
-                                  </node>
-                                </node>
-                                <node concept="3clFbS" id="6Od11GY7hiv" role="3clF47">
-                                  <node concept="3clFbJ" id="6Od11GY7Qa5" role="3cqZAp">
-                                    <node concept="3clFbS" id="6Od11GY7Qa7" role="3clFbx">
-                                      <node concept="3clFbF" id="6Od11GY7SyY" role="3cqZAp">
-                                        <node concept="2OqwBi" id="6Od11GY7SXA" role="3clFbG">
-                                          <node concept="pncrf" id="6Od11GY7SyX" role="2Oq$k0" />
-                                          <node concept="2qgKlT" id="6Od11GY7UxQ" role="2OqNvi">
-                                            <ref role="37wK5l" to="qjvf:6Od11GY7tDO" resolve="setDiffFlag" />
-                                            <node concept="3clFbT" id="6Od11GY82en" role="37wK5m">
-                                              <property role="3clFbU" value="true" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbC" id="6Od11GY7QXU" role="3clFbw">
-                                      <node concept="10M0yZ" id="6Od11GY7QXV" role="3uHU7w">
-                                        <ref role="3cqZAo" to="hyam:~ItemEvent.SELECTED" resolve="SELECTED" />
-                                        <ref role="1PxDUh" to="hyam:~ItemEvent" resolve="ItemEvent" />
-                                      </node>
-                                      <node concept="2OqwBi" id="6Od11GY7QXW" role="3uHU7B">
-                                        <node concept="37vLTw" id="6Od11GY7QXX" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="6Od11GY7hit" resolve="e" />
-                                        </node>
-                                        <node concept="liA8E" id="6Od11GY7QXY" role="2OqNvi">
-                                          <ref role="37wK5l" to="hyam:~ItemEvent.getStateChange()" resolve="getStateChange" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="9aQIb" id="6Od11GY83IY" role="9aQIa">
-                                      <node concept="3clFbS" id="6Od11GY83IZ" role="9aQI4">
-                                        <node concept="3clFbF" id="6Od11GY85ng" role="3cqZAp">
-                                          <node concept="2OqwBi" id="6Od11GY85M7" role="3clFbG">
-                                            <node concept="pncrf" id="6Od11GY85nf" role="2Oq$k0" />
-                                            <node concept="2qgKlT" id="6Od11GY87Ur" role="2OqNvi">
-                                              <ref role="37wK5l" to="qjvf:6Od11GY7tDO" resolve="setDiffFlag" />
-                                              <node concept="3clFbT" id="6Od11GY882k" role="37wK5m" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2AHcQZ" id="6Od11GY7hix" role="2AJF6D">
-                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="6Od11GY6C6T" role="3cqZAp">
-                    <node concept="37vLTw" id="6Od11GY6C6R" role="3clFbG">
-                      <ref role="3cqZAo" node="6Od11GY5Top" resolve="box" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="05MPa" id="7wH7VDSoWaC" role="fNvko">
-                <node concept="3clFbS" id="7wH7VDSoWaD" role="2VODD2">
-                  <node concept="3clFbF" id="7wH7VDSqh6n" role="3cqZAp">
-                    <node concept="2YIFZM" id="7wH7VDSqh8u" role="3clFbG">
-                      <ref role="37wK5l" to="wyt6:~String.valueOf(boolean)" resolve="valueOf" />
-                      <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
-                      <node concept="2OqwBi" id="7wH7VDSprus" role="37wK5m">
-                        <node concept="0kSF2" id="7wH7VDSpq6P" role="2Oq$k0">
-                          <node concept="3uibUv" id="7wH7VDSpq6R" role="0kSFW">
-                            <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
-                          </node>
-                          <node concept="0jJN4" id="7wH7VDSpnBb" role="0kSFX" />
-                        </node>
-                        <node concept="liA8E" id="7wH7VDSpt67" role="2OqNvi">
-                          <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+          <node concept="3EZMnI" id="6Vb09dgqOS0" role="3EZMnx">
+            <node concept="2iRfu4" id="6Vb09dgqOS1" role="2iSdaV" />
+            <node concept="3XFhqQ" id="6Vb09dgu1ac" role="3EZMnx" />
+            <node concept="27S6Sx" id="6Vb09dgqOS2" role="3EZMnx">
+              <ref role="1NtTu8" to="8do3:6Vb09dgqHFa" resolve="showDiff" />
+            </node>
+            <node concept="3F0ifn" id="6Od11GY6B_f" role="3EZMnx">
+              <property role="3F0ifm" value="show diff" />
             </node>
           </node>
-          <node concept="3F0ifn" id="6Od11GY6B_Q" role="3EZMnx">
-            <property role="3F0ifm" value=")" />
-          </node>
+          <node concept="3F0ifn" id="6Vb09dgrYWm" role="3EZMnx" />
         </node>
-        <node concept="3F0ifn" id="6HovwvvKpY8" role="3EZMnx" />
         <node concept="2EHx9g" id="6HovwvvKqbc" role="2iSdaV" />
+        <node concept="ljvvj" id="6Vb09dguoGm" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="lj46D" id="2C1H_zkeR_G" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="6Vb09dguoDj" role="3EZMnx">
+        <property role="3F0ifm" value="}" />
+        <node concept="VechU" id="6Vb09dguoJq" role="3F10Kt">
+          <property role="Vb096" value="fLwANPu/blue" />
+        </node>
       </node>
       <node concept="l2Vlx" id="i0MG184" role="2iSdaV" />
     </node>
@@ -888,7 +731,23 @@
         </node>
         <node concept="2iRfu4" id="3qPjHtY$aln" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="3qPjHtY$akW" role="2iSdaV" />
+      <node concept="3EZMnI" id="2C1H_zkiTm$" role="3EZMnx">
+        <node concept="2iRfu4" id="2C1H_zkiTmA" role="2iSdaV" />
+        <node concept="3EZMnI" id="2C1H_zkiTmB" role="3EZMnx">
+          <node concept="3XFhqQ" id="2C1H_zkiTmC" role="3EZMnx" />
+          <node concept="2iRfu4" id="2C1H_zkiTmD" role="2iSdaV" />
+          <node concept="27S6Sx" id="2C1H_zkiTmE" role="3EZMnx">
+            <ref role="1NtTu8" to="8do3:2C1H_zkhhtk" resolve="ignoreAnnotations" />
+          </node>
+          <node concept="3F0ifn" id="2C1H_zkiTmF" role="3EZMnx">
+            <property role="3F0ifm" value="ignore annotations" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="2C1H_zkiTmG" role="3EZMnx">
+          <property role="3F0ifm" value="" />
+        </node>
+      </node>
+      <node concept="2EHx9g" id="2C1H_zkiT1$" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="1_DWnhqnL_6" role="2wV5jI">
       <node concept="3F1sOY" id="1_DWnhqnL_t" role="3EZMnx">
@@ -896,6 +755,57 @@
       </node>
       <node concept="3F0ifn" id="1_DWnhqnL_D" role="3EZMnx">
         <property role="3F0ifm" value=":isEqualTo:" />
+      </node>
+      <node concept="3F0ifn" id="2C1H_zklUEM" role="3EZMnx">
+        <property role="3F0ifm" value="*" />
+        <node concept="11L4FC" id="2C1H_zklUEO" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pkWqt" id="2C1H_zklUEP" role="pqm2j">
+          <node concept="3clFbS" id="2C1H_zklUEQ" role="2VODD2">
+            <node concept="3clFbF" id="2C1H_zklV7l" role="3cqZAp">
+              <node concept="22lmx$" id="2C1H_zkm2hf" role="3clFbG">
+                <node concept="3y3z36" id="2C1H_zkm4rI" role="3uHU7w">
+                  <node concept="10Nm6u" id="2C1H_zkm4zh" role="3uHU7w" />
+                  <node concept="2OqwBi" id="2C1H_zkm2Ik" role="3uHU7B">
+                    <node concept="pncrf" id="2C1H_zkm2j6" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2C1H_zkm33n" role="2OqNvi">
+                      <ref role="3Tt5mk" to="8do3:3qPjHtY$alZ" resolve="ignoredReferences" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="22lmx$" id="2C1H_zkm0tY" role="3uHU7B">
+                  <node concept="22lmx$" id="2C1H_zklXvZ" role="3uHU7B">
+                    <node concept="2OqwBi" id="2C1H_zklV$0" role="3uHU7B">
+                      <node concept="pncrf" id="2C1H_zklV7k" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="2C1H_zklW3L" role="2OqNvi">
+                        <ref role="3TsBF5" to="8do3:2C1H_zkhhtk" resolve="ignoreAnnotations" />
+                      </node>
+                    </node>
+                    <node concept="3y3z36" id="2C1H_zklYU7" role="3uHU7w">
+                      <node concept="2OqwBi" id="2C1H_zklYb3" role="3uHU7B">
+                        <node concept="pncrf" id="2C1H_zklXzv" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="2C1H_zklYIT" role="2OqNvi">
+                          <ref role="3Tt5mk" to="8do3:iyWIxs65gJ" resolve="ignoredChildren" />
+                        </node>
+                      </node>
+                      <node concept="10Nm6u" id="2C1H_zkm0fy" role="3uHU7w" />
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="2C1H_zkm1FF" role="3uHU7w">
+                    <node concept="2OqwBi" id="2C1H_zkm19P" role="3uHU7B">
+                      <node concept="pncrf" id="2C1H_zkm0IY" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="2C1H_zkm1vD" role="2OqNvi">
+                        <ref role="3Tt5mk" to="8do3:1_DWnhqnLaj" resolve="ignoredProperties" />
+                      </node>
+                    </node>
+                    <node concept="10Nm6u" id="2C1H_zkm1MP" role="3uHU7w" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="3F1sOY" id="1_DWnhqnL_V" role="3EZMnx">
         <ref role="1NtTu8" to="tpee:fJuHU4r" resolve="rightExpression" />
@@ -1699,148 +1609,8 @@
         </node>
       </node>
       <node concept="l2Vlx" id="H43MYuWsRX" role="2iSdaV" />
-      <node concept="fWXJ_" id="7wH7VDSqIp6" role="3EZMnx">
-        <node concept="3Fmcul" id="7wH7VDSqIp8" role="3FoqZy">
-          <node concept="3clFbS" id="7wH7VDSqIpa" role="2VODD2">
-            <node concept="3cpWs8" id="H43MYuWsRd" role="3cqZAp">
-              <node concept="3cpWsn" id="H43MYuWsRe" role="3cpWs9">
-                <property role="TrG5h" value="box" />
-                <node concept="3uibUv" id="H43MYuWsRf" role="1tU5fm">
-                  <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
-                </node>
-                <node concept="2ShNRf" id="H43MYuWsRg" role="33vP2m">
-                  <node concept="1pGfFk" id="7wH7VDSqMAX" role="2ShVmc">
-                    <property role="373rjd" value="true" />
-                    <ref role="37wK5l" to="qqrq:~JBCheckBox.&lt;init&gt;(java.lang.String)" resolve="JBCheckBox" />
-                    <node concept="Xl_RD" id="3R$uTsAiKGj" role="37wK5m">
-                      <property role="Xl_RC" value=" " />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="H43MYuWsRi" role="3cqZAp">
-              <node concept="2OqwBi" id="H43MYuWsRj" role="3clFbG">
-                <node concept="37vLTw" id="H43MYuWsRk" role="2Oq$k0">
-                  <ref role="3cqZAo" node="H43MYuWsRe" resolve="box" />
-                </node>
-                <node concept="liA8E" id="H43MYuWsRl" role="2OqNvi">
-                  <ref role="37wK5l" to="dxuu:~AbstractButton.setSelected(boolean)" resolve="setSelected" />
-                  <node concept="2OqwBi" id="H43MYuWsRm" role="37wK5m">
-                    <node concept="pncrf" id="H43MYuWsRn" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="H43MYuWsRo" role="2OqNvi">
-                      <ref role="37wK5l" to="qjvf:6Od11GY7tN$" resolve="isDiffEnabled" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="H43MYuWsRp" role="3cqZAp">
-              <node concept="2OqwBi" id="H43MYuWsRq" role="3clFbG">
-                <node concept="37vLTw" id="H43MYuWsRr" role="2Oq$k0">
-                  <ref role="3cqZAo" node="H43MYuWsRe" resolve="box" />
-                </node>
-                <node concept="liA8E" id="H43MYuWsRs" role="2OqNvi">
-                  <ref role="37wK5l" to="dxuu:~AbstractButton.addItemListener(java.awt.event.ItemListener)" resolve="addItemListener" />
-                  <node concept="2ShNRf" id="H43MYuWsRt" role="37wK5m">
-                    <node concept="YeOm9" id="H43MYuWsRu" role="2ShVmc">
-                      <node concept="1Y3b0j" id="H43MYuWsRv" role="YeSDq">
-                        <property role="2bfB8j" value="true" />
-                        <ref role="1Y3XeK" to="hyam:~ItemListener" resolve="ItemListener" />
-                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                        <node concept="3Tm1VV" id="H43MYuWsRw" role="1B3o_S" />
-                        <node concept="3clFb_" id="H43MYuWsRx" role="jymVt">
-                          <property role="TrG5h" value="itemStateChanged" />
-                          <node concept="3Tm1VV" id="H43MYuWsRy" role="1B3o_S" />
-                          <node concept="3cqZAl" id="H43MYuWsRz" role="3clF45" />
-                          <node concept="37vLTG" id="H43MYuWsR$" role="3clF46">
-                            <property role="TrG5h" value="e" />
-                            <node concept="3uibUv" id="H43MYuWsR_" role="1tU5fm">
-                              <ref role="3uigEE" to="hyam:~ItemEvent" resolve="ItemEvent" />
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="H43MYuWsRA" role="3clF47">
-                            <node concept="3clFbJ" id="H43MYuWsRB" role="3cqZAp">
-                              <node concept="3clFbS" id="H43MYuWsRC" role="3clFbx">
-                                <node concept="3clFbF" id="H43MYuWsRD" role="3cqZAp">
-                                  <node concept="2OqwBi" id="H43MYuWsRE" role="3clFbG">
-                                    <node concept="pncrf" id="H43MYuWsRF" role="2Oq$k0" />
-                                    <node concept="2qgKlT" id="H43MYuWsRG" role="2OqNvi">
-                                      <ref role="37wK5l" to="qjvf:6Od11GY7tDO" resolve="setDiffFlag" />
-                                      <node concept="3clFbT" id="H43MYuWsRH" role="37wK5m">
-                                        <property role="3clFbU" value="true" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbC" id="H43MYuWsRI" role="3clFbw">
-                                <node concept="10M0yZ" id="H43MYuWsRJ" role="3uHU7w">
-                                  <ref role="3cqZAo" to="hyam:~ItemEvent.SELECTED" resolve="SELECTED" />
-                                  <ref role="1PxDUh" to="hyam:~ItemEvent" resolve="ItemEvent" />
-                                </node>
-                                <node concept="2OqwBi" id="H43MYuWsRK" role="3uHU7B">
-                                  <node concept="37vLTw" id="H43MYuWsRL" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="H43MYuWsR$" resolve="e" />
-                                  </node>
-                                  <node concept="liA8E" id="H43MYuWsRM" role="2OqNvi">
-                                    <ref role="37wK5l" to="hyam:~ItemEvent.getStateChange()" resolve="getStateChange" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="9aQIb" id="H43MYuWsRN" role="9aQIa">
-                                <node concept="3clFbS" id="H43MYuWsRO" role="9aQI4">
-                                  <node concept="3clFbF" id="H43MYuWsRP" role="3cqZAp">
-                                    <node concept="2OqwBi" id="H43MYuWsRQ" role="3clFbG">
-                                      <node concept="pncrf" id="H43MYuWsRR" role="2Oq$k0" />
-                                      <node concept="2qgKlT" id="H43MYuWsRS" role="2OqNvi">
-                                        <ref role="37wK5l" to="qjvf:6Od11GY7tDO" resolve="setDiffFlag" />
-                                        <node concept="3clFbT" id="H43MYuWsRT" role="37wK5m" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2AHcQZ" id="H43MYuWsRU" role="2AJF6D">
-                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="H43MYuWsRV" role="3cqZAp">
-              <node concept="37vLTw" id="H43MYuWsRW" role="3clFbG">
-                <ref role="3cqZAo" node="H43MYuWsRe" resolve="box" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="05MPa" id="7wH7VDSqMG2" role="fNvko">
-          <node concept="3clFbS" id="7wH7VDSqMG3" role="2VODD2">
-            <node concept="3clFbF" id="7wH7VDSqTKk" role="3cqZAp">
-              <node concept="2YIFZM" id="7wH7VDSqTLo" role="3clFbG">
-                <ref role="37wK5l" to="wyt6:~String.valueOf(boolean)" resolve="valueOf" />
-                <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
-                <node concept="2OqwBi" id="7wH7VDSqRtV" role="37wK5m">
-                  <node concept="0kSF2" id="7wH7VDSqQl4" role="2Oq$k0">
-                    <node concept="3uibUv" id="7wH7VDSqQl6" role="0kSFW">
-                      <ref role="3uigEE" to="qqrq:~JBCheckBox" resolve="JBCheckBox" />
-                    </node>
-                    <node concept="0jJN4" id="7wH7VDSqNPq" role="0kSFX" />
-                  </node>
-                  <node concept="liA8E" id="7wH7VDSqT5A" role="2OqNvi">
-                    <ref role="37wK5l" to="dxuu:~AbstractButton.isSelected()" resolve="isSelected" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="27S6Sx" id="6Vb09dgqSe5" role="3EZMnx">
+        <ref role="1NtTu8" to="8do3:6Vb09dgqHFa" resolve="showDiff" />
       </node>
     </node>
   </node>

--- a/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.structure.mps
+++ b/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.structure.mps
@@ -13,6 +13,9 @@
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
+        <property id="7862711839422615217" name="text" index="t5JxN" />
+      </concept>
       <concept id="6054523464626862044" name="jetbrains.mps.lang.structure.structure.AttributeInfo_IsMultiple" flags="ng" index="tn0Fv">
         <property id="6054523464626875854" name="value" index="tnX3d" />
       </concept>
@@ -44,6 +47,7 @@
       </concept>
       <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
         <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <property id="5314546615192664131" name="transient" index="1H4juY" />
         <reference id="1082985295845" name="dataType" index="AX2Wp" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
@@ -89,6 +93,11 @@
     </node>
     <node concept="PrWs8" id="t0OlD0UlBB" role="PzmwI">
       <ref role="PrY4T" node="t0OlD0Ulrx" resolve="IDiffable" />
+    </node>
+    <node concept="1TJgyi" id="6Vb09dgp30e" role="1TKVEl">
+      <property role="IQ2nx" value="7983475397153271822" />
+      <property role="TrG5h" value="ignoreAnnotations" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
   <node concept="1TIwiD" id="3C6_kMLO68Y">
@@ -187,6 +196,11 @@
       <property role="IQ2ns" value="3942143736281081215" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
+    <node concept="1TJgyi" id="2C1H_zkhhtk" role="1TKVEl">
+      <property role="IQ2nx" value="3026900917204358996" />
+      <property role="TrG5h" value="ignoreAnnotations" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
   </node>
   <node concept="1TIwiD" id="5v943APOt_R">
     <property role="EcuMT" value="6325604991668181367" />
@@ -276,6 +290,15 @@
   <node concept="PlHQZ" id="t0OlD0Ulrx">
     <property role="EcuMT" value="522647742341273313" />
     <property role="TrG5h" value="IDiffable" />
+    <node concept="1TJgyi" id="6Vb09dgqHFa" role="1TKVEl">
+      <property role="IQ2nx" value="7983475397153708746" />
+      <property role="TrG5h" value="showDiff" />
+      <property role="1H4juY" value="true" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+      <node concept="t5JxF" id="6Vb09dgqHFb" role="lGtFl">
+        <property role="t5JxN" value="a transient property (will not be written to disk) - see inspector" />
+      </node>
+    </node>
   </node>
   <node concept="1TIwiD" id="1GvnUgo6Kzw">
     <property role="TrG5h" value="QueryFunction_PostProcess" />

--- a/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.typesystem.mps
+++ b/code/compare/languages/de.itemis.mps.compare/languageModels/de.itemis.mps.compare.typesystem.mps
@@ -28,9 +28,6 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
-        <child id="1145553007750" name="creator" index="2ShVmc" />
-      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -43,6 +40,7 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -141,9 +139,6 @@
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
-      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
-        <child id="1180636770616" name="createdType" index="3zrR0E" />
-      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -565,16 +560,8 @@
           <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
         </node>
       </node>
+      <node concept="3clFbH" id="2C1H_zkfyFs" role="3cqZAp" />
       <node concept="1Z5TYs" id="1_DWnhqnOv$" role="3cqZAp">
-        <node concept="mw_s8" id="1_DWnhqnOCu" role="1ZfhKB">
-          <node concept="2ShNRf" id="1_DWnhqnOCq" role="mwGJk">
-            <node concept="3zrR0B" id="1_DWnhqnOSE" role="2ShVmc">
-              <node concept="3Tqbb2" id="1_DWnhqnOSG" role="3zrR0E">
-                <ref role="ehGHo" to="tpee:f_0P_4Y" resolve="BooleanType" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="mw_s8" id="1_DWnhqnOvB" role="1ZfhK$">
           <node concept="1Z2H0r" id="1_DWnhqnOeK" role="mwGJk">
             <node concept="1YBJjd" id="1_DWnhqnOgC" role="1Z2MuG">
@@ -584,6 +571,11 @@
         </node>
         <node concept="1YBJjd" id="77BxNvs6v4o" role="1ZmcU8">
           <ref role="1YBMHb" node="1_DWnhqnLJ$" resolve="areEqualExpression" />
+        </node>
+        <node concept="mw_s8" id="2C1H_zkfA0y" role="1ZfhKB">
+          <node concept="2c44tf" id="2C1H_zkfA0z" role="mwGJk">
+            <node concept="10P_77" id="2C1H_zkfA0$" role="2c44tc" />
+          </node>
         </node>
       </node>
       <node concept="1ZoVOM" id="5qLQfLPiBfo" role="3cqZAp">

--- a/code/compare/solutions/test.de.itemis.mps.compare/models/test.de.itemis.mps.compare.ts@tests.mps
+++ b/code/compare/solutions/test.de.itemis.mps.compare/models/test.de.itemis.mps.compare.ts@tests.mps
@@ -12,11 +12,12 @@
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="0edf22a4-42bc-4e5d-954f-06aaaf51df00" name="jetbrains.mps.lang.makeup" version="0" />
   </languages>
   <imports>
     <import index="mqum" ref="r:ec874b45-e888-42e6-995a-a298cefdff55(de.itemis.mps.comparator.code)" />
     <import index="h34v" ref="r:008c5d7f-9462-49ec-82f5-b10b03307887(test.de.itemis.mps.compare.testlang.structure)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -184,6 +185,7 @@
         <child id="8427750732757990724" name="tolerance" index="3tpDZB" />
       </concept>
       <concept id="1831260205537497726" name="de.itemis.mps.compare.structure.AreEqualExpression" flags="ng" index="13dIca">
+        <property id="3026900917204358996" name="ignoreAnnotations" index="3Yha4c" />
         <child id="1831260205537497747" name="ignoredProperties" index="13dIfB" />
         <child id="334096402170270767" name="ignoredChildren" index="1oIEr7" />
       </concept>
@@ -191,7 +193,9 @@
         <reference id="334096402171923514" name="conceptDeclaration" index="1o$RVi" />
         <reference id="334096402171923515" name="linkDeclaration" index="1o$RVj" />
       </concept>
-      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
+      <concept id="756135271275943220" name="de.itemis.mps.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L">
+        <property id="7983475397153271822" name="ignoreAnnotations" index="YFN2t" />
+      </concept>
     </language>
     <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
       <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
@@ -221,6 +225,11 @@
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
         <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+    </language>
+    <language id="0edf22a4-42bc-4e5d-954f-06aaaf51df00" name="jetbrains.mps.lang.makeup">
+      <concept id="1223283106984741523" name="jetbrains.mps.lang.makeup.structure.CopyOutcome" flags="ng" index="Vtzci">
+        <property id="1223283106984741524" name="location" index="Vtzcl" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -1007,9 +1016,6 @@
       </node>
     </node>
   </node>
-  <node concept="2XOHcx" id="5kFTseQQT1w">
-    <property role="2XOHcw" value="${extensions.home}/code" />
-  </node>
   <node concept="1lH9Xt" id="6MWuQFM3IaF">
     <property role="TrG5h" value="DoubleComparison" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
@@ -1610,6 +1616,107 @@
                 </node>
               </node>
               <node concept="ANE8D" id="iyWIxsW1O6" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="5kFTseQQT1w">
+    <property role="2XOHcw" value="${extensions.home}/code" />
+  </node>
+  <node concept="1lH9Xt" id="2C1H_zkjfj$">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="CompareIgnoreAnnotations" />
+    <node concept="1qefOq" id="2C1H_zkjflY" role="1SKRRt">
+      <node concept="312cEu" id="2C1H_zkjfm0" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="2C1H_zkjfm1" role="1B3o_S" />
+        <node concept="Vtzci" id="2C1H_zkjfmu" role="lGtFl">
+          <property role="Vtzcl" value="irrelevantLocation" />
+        </node>
+        <node concept="3xLA65" id="2C1H_zkjf$F" role="lGtFl">
+          <property role="TrG5h" value="withAnnotation" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2C1H_zkjfn3" role="1SKRRt">
+      <node concept="312cEu" id="2C1H_zkjfn5" role="1qenE9">
+        <property role="TrG5h" value="A" />
+        <node concept="3Tm1VV" id="2C1H_zkjfn6" role="1B3o_S" />
+        <node concept="3xLA65" id="2C1H_zkjfos" role="lGtFl">
+          <property role="TrG5h" value="withoutAnnotation" />
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2C1H_zkcovy" role="1SL9yI">
+      <property role="TrG5h" value="compareAnnotations" />
+      <node concept="3cqZAl" id="2C1H_zkcovz" role="3clF45" />
+      <node concept="3clFbS" id="2C1H_zkcovB" role="3clF47">
+        <node concept="3vFxKo" id="2C1H_zkjvrP" role="3cqZAp">
+          <node concept="13dIca" id="2C1H_zkjvKe" role="3vFALc">
+            <node concept="3xONca" id="2C1H_zkjvLK" role="3uHU7w">
+              <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
+            </node>
+            <node concept="3xONca" id="2C1H_zkjvsb" role="3uHU7B">
+              <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="2C1H_zkmrpJ" role="3cqZAp">
+          <node concept="13dIca" id="2C1H_zkmrpK" role="3vFALc">
+            <node concept="3xONca" id="2C1H_zkmrpL" role="3uHU7w">
+              <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+            </node>
+            <node concept="3xONca" id="2C1H_zkmrpM" role="3uHU7B">
+              <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="2C1H_zkqhYI" role="1SL9yI">
+      <property role="TrG5h" value="ignoreAnnotations" />
+      <node concept="3cqZAl" id="2C1H_zkqhYJ" role="3clF45" />
+      <node concept="3clFbS" id="2C1H_zkqhYN" role="3clF47">
+        <node concept="3GXo0L" id="2C1H_zkcpsg" role="3cqZAp">
+          <property role="YFN2t" value="true" />
+          <node concept="3xONca" id="2C1H_zkjfp1" role="3tpDZC">
+            <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+          </node>
+          <node concept="3xONca" id="2C1H_zkjfqx" role="3tpDZA">
+            <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
+          </node>
+        </node>
+        <node concept="3GXo0L" id="2C1H_zkmrnf" role="3cqZAp">
+          <property role="YFN2t" value="true" />
+          <node concept="3xONca" id="2C1H_zkmrng" role="3tpDZC">
+            <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
+          </node>
+          <node concept="3xONca" id="2C1H_zkmrnh" role="3tpDZA">
+            <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="2C1H_zkmIC0" role="3cqZAp" />
+        <node concept="3vwNmj" id="2C1H_zkh8AS" role="3cqZAp">
+          <node concept="13dIca" id="2C1H_zkh8AT" role="3vwVQn">
+            <property role="3Yha4c" value="true" />
+            <node concept="3xONca" id="2C1H_zkjfrP" role="3uHU7w">
+              <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
+            </node>
+            <node concept="3xONca" id="2C1H_zkjfrh" role="3uHU7B">
+              <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="2C1H_zkmrsv" role="3cqZAp">
+          <node concept="13dIca" id="2C1H_zkmrsw" role="3vwVQn">
+            <property role="3Yha4c" value="true" />
+            <node concept="3xONca" id="2C1H_zkmrsx" role="3uHU7w">
+              <ref role="3xOPvv" node="2C1H_zkjfos" resolve="withoutAnnotation" />
+            </node>
+            <node concept="3xONca" id="2C1H_zkmrsy" role="3uHU7B">
+              <ref role="3xOPvv" node="2C1H_zkjf$F" resolve="withAnnotation" />
             </node>
           </node>
         </node>

--- a/code/compare/solutions/test.de.itemis.mps.compare/test.de.itemis.mps.compare.msd
+++ b/code/compare/solutions/test.de.itemis.mps.compare/test.de.itemis.mps.compare.msd
@@ -25,6 +25,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:0edf22a4-42bc-4e5d-954f-06aaaf51df00:jetbrains.mps.lang.makeup" version="0" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -236,6 +236,232 @@
       </node>
     </node>
     <node concept="15bmVD" id="6xbWs8QlwdI" role="15bmVC">
+      <node concept="15bAme" id="6Vb09dgv4Sc" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOE/added" />
+        <node concept="2DRihI" id="6Vb09dgv4Sd" role="15bAlk">
+          <node concept="15Ami3" id="6Vb09dgv4Sf" role="1PaTwD">
+            <node concept="37shsh" id="6Vb09dgv4Sg" role="15Aodc">
+              <node concept="1dCxOk" id="6Vb09dgv4Sl" role="37shsm">
+                <property role="1XweGW" value="f47b95d4-5e73-4c04-9204-18076950153b" />
+                <property role="1XxBO9" value="de.itemis.mps.compare" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Sq" role="1PaTwD">
+            <property role="3oM_SC" value="'assert" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y7" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y8" role="1PaTwD">
+            <property role="3oM_SC" value="equals'" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y9" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBxe" role="1PaTwD">
+            <property role="3oM_SC" value="':isEqualTo:'" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBxf" role="1PaTwD">
+            <property role="3oM_SC" value="expression" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBxg" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Ya" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Ye" role="1PaTwD">
+            <property role="3oM_SC" value="ignore" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y3" role="1PaTwD">
+            <property role="3oM_SC" value="attributes" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmIpx" role="1PaTwD">
+            <property role="3oM_SC" value="(annotations)" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y4" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y5" role="1PaTwD">
+            <property role="3oM_SC" value="comparing" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Ym" role="1PaTwD">
+            <property role="3oM_SC" value="nodes." />
+          </node>
+        </node>
+      </node>
+      <node concept="15bAme" id="6Vb09dgv4Yn" role="15bAlL">
+        <property role="15bAli" value="Po4Z58tnOF/changed" />
+        <node concept="2DRihI" id="6Vb09dgv4Yo" role="15bAlk">
+          <node concept="15Ami3" id="6Vb09dgv4Yp" role="1PaTwD">
+            <node concept="37shsh" id="6Vb09dgv4Yq" role="15Aodc">
+              <node concept="1dCxOk" id="6Vb09dgv4Yv" role="37shsm">
+                <property role="1XweGW" value="f47b95d4-5e73-4c04-9204-18076950153b" />
+                <property role="1XxBO9" value="de.itemis.mps.compare" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y$" role="1PaTwD">
+            <property role="3oM_SC" value="'show" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Y_" role="1PaTwD">
+            <property role="3oM_SC" value="diff'" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YA" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YT" role="1PaTwD">
+            <property role="3oM_SC" value="assertions" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YQ" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YB" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YC" role="1PaTwD">
+            <property role="3oM_SC" value="implemented" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgvbKJ" role="1PaTwD">
+            <property role="3oM_SC" value="using" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgvbKK" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YF" role="1PaTwD">
+            <property role="3oM_SC" value="transient" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4YW" role="1PaTwD">
+            <property role="3oM_SC" value="property." />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z3" role="1PaTwD">
+            <property role="3oM_SC" value="Changing" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z4" role="1PaTwD">
+            <property role="3oM_SC" value="it" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z5" role="1PaTwD">
+            <property role="3oM_SC" value="will" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z6" role="1PaTwD">
+            <property role="3oM_SC" value="mark" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z7" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z8" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Z9" role="1PaTwD">
+            <property role="3oM_SC" value="as" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Za" role="1PaTwD">
+            <property role="3oM_SC" value="changed" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zb" role="1PaTwD">
+            <property role="3oM_SC" value="but" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zc" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zd" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Ze" role="1PaTwD">
+            <property role="3oM_SC" value="value" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zf" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zg" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zh" role="1PaTwD">
+            <property role="3oM_SC" value="written" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zk" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zl" role="1PaTwD">
+            <property role="3oM_SC" value="disk" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zm" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zx" role="1PaTwD">
+            <property role="3oM_SC" value="so" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zn" role="1PaTwD">
+            <property role="3oM_SC" value="will" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zo" role="1PaTwD">
+            <property role="3oM_SC" value="never" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zr" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zs" role="1PaTwD">
+            <property role="3oM_SC" value="checked" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zt" role="1PaTwD">
+            <property role="3oM_SC" value="into" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zu" role="1PaTwD">
+            <property role="3oM_SC" value="version" />
+          </node>
+          <node concept="3oM_SD" id="6Vb09dgv4Zv" role="1PaTwD">
+            <property role="3oM_SC" value="control." />
+          </node>
+        </node>
+        <node concept="2DRihI" id="2C1H_zkmBBz" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="2C1H_zkmBCQ" role="1PaTwD">
+            <node concept="37shsh" id="2C1H_zkmBCS" role="15Aodc">
+              <node concept="1dCxOk" id="2C1H_zkmBCY" role="37shsm">
+                <property role="1XweGW" value="f47b95d4-5e73-4c04-9204-18076950153b" />
+                <property role="1XxBO9" value="de.itemis.mps.compare" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBD7" role="1PaTwD">
+            <property role="3oM_SC" value="minor" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBD8" role="1PaTwD">
+            <property role="3oM_SC" value="improvements" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDl" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDm" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDb" role="1PaTwD">
+            <property role="3oM_SC" value="editors" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDc" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDd" role="1PaTwD">
+            <property role="3oM_SC" value="'assert" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDe" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDf" role="1PaTwD">
+            <property role="3oM_SC" value="equals'" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDg" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDj" role="1PaTwD">
+            <property role="3oM_SC" value="'show" />
+          </node>
+          <node concept="3oM_SD" id="2C1H_zkmBDk" role="1PaTwD">
+            <property role="3oM_SC" value="diff'." />
+          </node>
+        </node>
+      </node>
       <node concept="15ShDW" id="6xbWs8QlwdF" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgBx/December" />
         <property role="15ShDw" value="2025" />
@@ -282,7 +508,7 @@
           <node concept="3oM_SD" id="6xbWs8Qlwk3" role="1PaTwD">
             <property role="3oM_SC" value="getInstance(Project" />
           </node>
-          <node concept="3oM_SD" id="6Ma6J$ktwcx" role="1PaTwD">
+          <node concept="3oM_SD" id="2C1H_zkmBBx" role="1PaTwD">
             <property role="3oM_SC" value="mpsProject)" />
           </node>
         </node>


### PR DESCRIPTION
* AssertNodeEquals, AreEqualExpression: add 'ignore annotations' property to ignore attributes (annotations) while comparing.
* IDiffable: replace the user object with a transient property. The main reason is actually to get consistent checkboxes in the editor of 'assert node equals'.
* AssertNodeEquals: show bounds of the statement in the editor.
* AreEqualExpression: indicate presence of ignores with an asterisk.