### PR TITLE
fix(tables): prevent inserting before/after a singular child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## January 2026
+
+### Fixed
+
+- *de.slisson.mps.tables.runtime* Prevent inserting a new row node before/after a singular cardinality child node
+
 ## November 2025
 
 ### Fixed

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -234,6 +234,60 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="54TnD34INwS" role="15bmVC">
+      <node concept="15ShDW" id="54TnD34INwP" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAl/January" />
+        <property role="15ShDw" value="2026" />
+      </node>
+      <node concept="15bAme" id="54TnD34INwQ" role="15bAlL">
+        <node concept="2DRihI" id="54TnD34INwR" role="15bAlk">
+          <node concept="15Ami3" id="54TnD34INwT" role="1PaTwD">
+            <node concept="37shsh" id="54TnD34INwU" role="15Aodc">
+              <node concept="1dCxOk" id="54TnD34INA9" role="37shsm">
+                <property role="1XweGW" value="da21218f-a674-474d-8b4e-d59e33007003" />
+                <property role="1XxBO9" value="de.slisson.mps.tables.runtime" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="54TnD34INFr" role="1PaTwD">
+            <property role="3oM_SC" value="Prevent" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INFs" role="1PaTwD">
+            <property role="3oM_SC" value="inserting" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INKJ" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INPZ" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INQ0" role="1PaTwD">
+            <property role="3oM_SC" value="row" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INPX" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INFt" role="1PaTwD">
+            <property role="3oM_SC" value="before/after" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INFu" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INKG" role="1PaTwD">
+            <property role="3oM_SC" value="singular" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INKH" role="1PaTwD">
+            <property role="3oM_SC" value="cardinality" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INKI" role="1PaTwD">
+            <property role="3oM_SC" value="child" />
+          </node>
+          <node concept="3oM_SD" id="54TnD34INPY" role="1PaTwD">
+            <property role="3oM_SC" value="node" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="6Qwtr1aMjHs" role="15bmVC">
       <node concept="15ShDW" id="6Qwtr1aMjHp" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgBl/November" />

--- a/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
+++ b/code/tables/languages/de.slisson.mps.tables/runtime/models/de/slisson/mps/tables/runtime/cells.mps
@@ -37125,6 +37125,65 @@
           <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
       </node>
+      <node concept="2tJIrI" id="6FKKvoE4Myw" role="jymVt" />
+      <node concept="3clFb_" id="6FKKvoE4Mzv" role="jymVt">
+        <property role="TrG5h" value="canExecute" />
+        <node concept="3Tm1VV" id="6FKKvoE4Mzw" role="1B3o_S" />
+        <node concept="10P_77" id="6FKKvoE4Mzx" role="3clF45" />
+        <node concept="37vLTG" id="6FKKvoE4Mzy" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="6FKKvoE4Mzz" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="6FKKvoE4M$j" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+        <node concept="3clFbS" id="6FKKvoE4M$k" role="3clF47">
+          <node concept="3clFbJ" id="4gOm2JeHyMx" role="3cqZAp">
+            <node concept="3clFbS" id="4gOm2JeHyMz" role="3clFbx">
+              <node concept="3cpWs6" id="4gOm2JeHEan" role="3cqZAp">
+                <node concept="3clFbT" id="4gOm2JeHFU$" role="3cqZAk" />
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="4gOm2JeHBPN" role="3clFbw">
+              <node concept="3nyPlj" id="4gOm2JeHBPP" role="3fr31v">
+                <ref role="37wK5l" node="7IUya7cjexf" resolve="canExecute" />
+                <node concept="37vLTw" id="4gOm2JeHHUx" role="37wK5m">
+                  <ref role="3cqZAo" node="6FKKvoE4Mzy" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="4gOm2JeHJ3z" role="3cqZAp" />
+          <node concept="3cpWs8" id="6FKKvoE4M$o" role="3cqZAp">
+            <node concept="3cpWsn" id="6FKKvoE4M$p" role="3cpWs9">
+              <property role="TrG5h" value="nodeOfRow" />
+              <node concept="3Tqbb2" id="6FKKvoE4M$q" role="1tU5fm" />
+              <node concept="2YIFZM" id="6FKKvoE4M$r" role="33vP2m">
+                <ref role="1Pybhc" node="6tOcB$JKlIC" resolve="TableUtils" />
+                <ref role="37wK5l" node="7IUya7c4DQS" resolve="getNodeOfRowNode" />
+                <node concept="1rXfSq" id="6FKKvoE4M$s" role="37wK5m">
+                  <ref role="37wK5l" node="7IUya7cczGL" resolve="getGridCell" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6FKKvoE5B9C" role="3cqZAp">
+            <node concept="2OqwBi" id="6FKKvoE4M$x" role="3clFbG">
+              <node concept="2OqwBi" id="6FKKvoE4M$y" role="2Oq$k0">
+                <node concept="37vLTw" id="6FKKvoE4M$z" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6FKKvoE4M$p" resolve="nodeOfRow" />
+                </node>
+                <node concept="2NL2c5" id="6FKKvoE4M$$" role="2OqNvi" />
+              </node>
+              <node concept="liA8E" id="6FKKvoE4M$_" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractLink.isMultiple()" resolve="isMultiple" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="2tJIrI" id="56WqtlUiF76" role="jymVt" />
       <node concept="3clFb_" id="4db20qfqkmQ" role="jymVt">
         <property role="1EzhhJ" value="false" />
@@ -37199,6 +37258,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="2AHcQZ" id="6FKKvoE4MAb" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
         </node>
       </node>
       <node concept="3Tm1VV" id="7IUya7cfFCG" role="1B3o_S" />


### PR DESCRIPTION
Fixes the issue in tables with a singular child link used in a row - an attempt to insert a new row broke the model by adding a second child node to a singular role.