### PR TITLE
Support for adding lifecycle methods to editor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/e
     - `seq.groupBy(keySelector)` allows given a sequence seq to group the elements of a sequence using the `keySelector` closure on each element 
     - `seq1.zip(seq2)` creates a sequence tuples where each element is a tuple from the element in the two sequences at that index
     - `seq.selectIdx({~it, int index => ...})` `seq.whereIdx({~it, int index => ...})` `seq.forEachIdx({~it, int index => ...})` are similar to `select` , `where` and `foreach` already present in the collections language, but the index of the current element is also an argument of the closure
+- *nl.f1re.testing* Add [EditorTestLifecycleMethods](http://127.0.0.1:63320/node?ref=r%3A8dfc935f-f6d1-4e4d-bfff-80832f08c4eb%28nl.f1re.testing.structure%29%2F2052872502397333186) attribute and associated intentions to extend an editor test with 'before/after test' methods.
 
 ### Fixed
 

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -7277,9 +7277,9 @@
               <ref role="3bR37D" to="ffeo:ymnOULAU1u" resolve="jetbrains.mps.lang.test.runtime" />
             </node>
           </node>
-          <node concept="1SiIV0" id="3OVhQEUSip_" role="3bR37C">
-            <node concept="3bR9La" id="3OVhQEUSipA" role="1SiIV1">
-              <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          <node concept="1SiIV0" id="2EmVdCCOlWG" role="3bR37C">
+            <node concept="3bR9La" id="2EmVdCCOlWH" role="1SiIV1">
+              <ref role="3bR37D" to="ffeo:1ULLXZL0gZG" resolve="org.junit.junit5" />
             </node>
           </node>
         </node>
@@ -7305,6 +7305,11 @@
         <node concept="1SiIV0" id="3OVhQEUSlqg" role="3bR37C">
           <node concept="1Busua" id="3OVhQEUSlqh" role="1SiIV1">
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4ieOWnG6$hj" role="3bR37C">
+          <node concept="3bR9La" id="4ieOWnG6$hk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
           </node>
         </node>
       </node>

--- a/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
+++ b/code/build/solutions/de.itemis.mps.extensions.build/models/de.itemis.mps.extensions.build.mps
@@ -7307,11 +7307,6 @@
             <ref role="1Busuk" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3OVhQEUSlqi" role="3bR37C">
-          <node concept="Rbm2T" id="3OVhQEUSlqj" role="1SiIV1">
-            <ref role="1E1Vl2" node="2Xjt3l57hh_" resolve="de.slisson.mps.reflection" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtA" id="3OVhQEUM97i" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.runtime/models/com/mbeddr/mpsutil/grammarcells/runtime.mps
@@ -24627,7 +24627,7 @@
     </node>
   </node>
   <node concept="312cEu" id="3pFNVizD_gr">
-    <property role="TrG5h" value="SplittablePropertCell" />
+    <property role="TrG5h" value="SplittablePropertyCell" />
     <node concept="2tJIrI" id="3pFNVizIaS$" role="jymVt" />
     <node concept="312cEg" id="3pFNVizIbCH" role="jymVt">
       <property role="TrG5h" value="myTokenizer" />
@@ -25360,11 +25360,11 @@
             <property role="3TUv4t" value="false" />
             <property role="TrG5h" value="result" />
             <node concept="3uibUv" id="3pFNVizKMJe" role="1tU5fm">
-              <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertCell" />
+              <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertyCell" />
             </node>
             <node concept="2ShNRf" id="3pFNVizDNZm" role="33vP2m">
               <node concept="1pGfFk" id="3pFNVizDNZn" role="2ShVmc">
-                <ref role="37wK5l" node="3pFNVizD_jy" resolve="SplittablePropertCell" />
+                <ref role="37wK5l" node="3pFNVizD_jy" resolve="SplittablePropertyCell" />
                 <node concept="37vLTw" id="3pFNVizDNOb" role="37wK5m">
                   <ref role="3cqZAo" node="3pFNVizDNNI" resolve="editorContext" />
                 </node>
@@ -25410,7 +25410,7 @@
       </node>
       <node concept="3Tm1VV" id="3pFNVizDNOq" role="1B3o_S" />
       <node concept="3uibUv" id="3pFNVizKKa0" role="3clF45">
-        <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertCell" />
+        <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertyCell" />
       </node>
     </node>
     <node concept="2tJIrI" id="3pFNVizDOCU" role="jymVt" />
@@ -25602,25 +25602,8 @@
             <node concept="3uibUv" id="3pFNVizDM$s" role="1tU5fm">
               <ref role="3uigEE" to="g51k:~PropertyAccessor" resolve="PropertyAccessor" />
             </node>
-            <node concept="2ShNRf" id="3pFNVizDM_c" role="33vP2m">
-              <node concept="1pGfFk" id="3pFNVizDM_F" role="2ShVmc">
-                <ref role="37wK5l" to="g51k:~PropertyAccessor.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SProperty,boolean,boolean,jetbrains.mps.openapi.editor.EditorContext)" resolve="PropertyAccessor" />
-                <node concept="1rXfSq" id="3pFNVizDM$u" role="37wK5m">
-                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
-                </node>
-                <node concept="1rXfSq" id="3pFNVizDN6e" role="37wK5m">
-                  <ref role="37wK5l" to="p9jd:~PropertyCellProvider.getProperty()" resolve="getProperty" />
-                </node>
-                <node concept="37vLTw" id="3pFNVizDM$w" role="37wK5m">
-                  <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
-                </node>
-                <node concept="37vLTw" id="3pFNVizDM$x" role="37wK5m">
-                  <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myAllowsEmptyTarget" resolve="myAllowsEmptyTarget" />
-                </node>
-                <node concept="37vLTw" id="3pFNVizDM$y" role="37wK5m">
-                  <ref role="3cqZAo" node="3pFNVizDMw2" resolve="context" />
-                </node>
-              </node>
+            <node concept="1rXfSq" id="bpuQGTGoPP" role="33vP2m">
+              <ref role="37wK5l" node="bpuQGTGoPL" resolve="createModelAccessor" />
             </node>
           </node>
         </node>
@@ -25629,10 +25612,10 @@
             <property role="3TUv4t" value="false" />
             <property role="TrG5h" value="editorCell" />
             <node concept="3uibUv" id="3pFNVizKJSM" role="1tU5fm">
-              <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertCell" />
+              <ref role="3uigEE" node="3pFNVizD_gr" resolve="SplittablePropertyCell" />
             </node>
             <node concept="2YIFZM" id="3pFNVizDM_H" role="33vP2m">
-              <ref role="1Pybhc" node="3pFNVizD_gr" resolve="SplittablePropertCell" />
+              <ref role="1Pybhc" node="3pFNVizD_gr" resolve="SplittablePropertyCell" />
               <ref role="37wK5l" node="3pFNVizDNNH" resolve="create" />
               <node concept="37vLTw" id="3pFNVizDM$B" role="37wK5m">
                 <ref role="3cqZAo" node="3pFNVizDMw2" resolve="context" />
@@ -25777,6 +25760,35 @@
       </node>
       <node concept="2AHcQZ" id="3pFNVizDMw5" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="bpuQGTGp5x" role="jymVt" />
+    <node concept="3clFb_" id="bpuQGTGoPL" role="jymVt">
+      <property role="TrG5h" value="createModelAccessor" />
+      <node concept="3Tmbuc" id="bpuQGTGpl5" role="1B3o_S" />
+      <node concept="3uibUv" id="bpuQGTGoPN" role="3clF45">
+        <ref role="3uigEE" to="g51k:~PropertyAccessor" resolve="PropertyAccessor" />
+      </node>
+      <node concept="3clFbS" id="bpuQGTGoPu" role="3clF47">
+        <node concept="3cpWs6" id="bpuQGTGoPE" role="3cqZAp">
+          <node concept="2ShNRf" id="bpuQGTGoP$" role="3cqZAk">
+            <node concept="1pGfFk" id="bpuQGTGoP_" role="2ShVmc">
+              <ref role="37wK5l" to="g51k:~PropertyAccessor.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SProperty,boolean,boolean)" resolve="PropertyAccessor" />
+              <node concept="1rXfSq" id="bpuQGTGoPA" role="37wK5m">
+                <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+              </node>
+              <node concept="1rXfSq" id="bpuQGTGoPB" role="37wK5m">
+                <ref role="37wK5l" to="p9jd:~PropertyCellProvider.getProperty()" resolve="getProperty" />
+              </node>
+              <node concept="37vLTw" id="bpuQGTGoPI" role="37wK5m">
+                <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myReadOnly" resolve="myReadOnly" />
+              </node>
+              <node concept="37vLTw" id="bpuQGTGoPD" role="37wK5m">
+                <ref role="3cqZAo" to="emqf:~CellProviderWithRole.myAllowsEmptyTarget" resolve="myAllowsEmptyTarget" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
+++ b/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
@@ -14,6 +14,7 @@
     <dependency reexport="false">63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)</dependency>
     <dependency reexport="false">9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)</dependency>
     <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
+    <dependency reexport="false">953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:638c9345-2613-49dc-b2ae-8ceadef24141:de.itemis.mps.changelog" version="0" />
@@ -57,6 +58,7 @@
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -15,6 +15,7 @@
     <import index="teg0" ref="r:96165ed2-ef22-48c7-bfe5-8fce083cbabb(com.mbeddr.mpsutil.grammarcells.structure)" />
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
     <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
+    <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
   </imports>
   <registry>
     <language id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog">
@@ -601,6 +602,66 @@
           </node>
           <node concept="3oM_SD" id="1vwG8eaqSdx" role="1PaTwD">
             <property role="3oM_SC" value="closure" />
+          </node>
+        </node>
+        <node concept="2DRihI" id="4ieOWnG6zFZ" role="15bAlk">
+          <property role="2RT3bR" value="0" />
+          <node concept="15Ami3" id="4ieOWnG6zH0" role="1PaTwD">
+            <node concept="37shsh" id="4ieOWnG6zH2" role="15Aodc">
+              <node concept="1dCxOk" id="4ieOWnG6zH8" role="37shsm">
+                <property role="1XweGW" value="953e4089-c643-455b-8629-636de7085d1c" />
+                <property role="1XxBO9" value="nl.f1re.testing" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zHr" role="1PaTwD">
+            <property role="3oM_SC" value="Add" />
+          </node>
+          <node concept="15BRQy" id="4ieOWnG6zHt" role="1PaTwD">
+            <node concept="2tJFMh" id="4ieOWnG6zHv" role="15BRQ_">
+              <node concept="ZC_QK" id="4ieOWnG6zH_" role="2tJFKM">
+                <ref role="2aWVGs" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRD" role="1PaTwD">
+            <property role="3oM_SC" value="attribute" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRH" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRI" role="1PaTwD">
+            <property role="3oM_SC" value="associated" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRJ" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRK" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRM" role="1PaTwD">
+            <property role="3oM_SC" value="extend" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRN" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRO" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRP" role="1PaTwD">
+            <property role="3oM_SC" value="test" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRQ" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRW" role="1PaTwD">
+            <property role="3oM_SC" value="'before/after" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRU" role="1PaTwD">
+            <property role="3oM_SC" value="test'" />
+          </node>
+          <node concept="3oM_SD" id="4ieOWnG6zRX" role="1PaTwD">
+            <property role="3oM_SC" value="methods." />
           </node>
         </node>
       </node>

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.editor.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.editor.mps
@@ -11,6 +11,7 @@
   </languages>
   <imports>
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="jv43" ref="r:b442f00b-6e9a-4c5a-b266-fc3101923e23(nl.f1re.testing.examples.lang.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
@@ -33,6 +34,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -43,6 +45,7 @@
         <reference id="9115396979021131941" name="conceptDeclaration" index="2RIln$" />
       </concept>
       <concept id="7250830207897895678" name="jetbrains.mps.lang.editor.structure.CompletionCustomizationConceptCreatingSpecificator" flags="ng" index="KNhPm" />
+      <concept id="4323500428121233431" name="jetbrains.mps.lang.editor.structure.EditorCellId" flags="ng" index="2SqB2G" />
       <concept id="7818019076292260194" name="jetbrains.mps.lang.editor.structure.CompletionStyling" flags="ig" index="3dRTYf">
         <child id="7250830207897909099" name="specificator" index="KNiz3" />
         <child id="772883491827840107" name="customizeFunction" index="3l$a4r" />
@@ -57,6 +60,7 @@
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+        <child id="4323500428121274054" name="id" index="2SqHTX" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -88,6 +92,7 @@
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -98,10 +103,12 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -109,6 +116,7 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -118,8 +126,15 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
@@ -145,13 +160,18 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
@@ -399,6 +419,135 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="24kQdi" id="4ieOWnG2H5U">
+    <ref role="1XX52x" to="jv43:4ieOWnG2H5T" resolve="LifecycleTesting" />
+    <node concept="3EZMnI" id="4ieOWnG2H5W" role="2wV5jI">
+      <node concept="3F0ifn" id="4ieOWnG2H62" role="3EZMnx">
+        <property role="3F0ifm" value="LifecyleTestingSupport top of stack:" />
+      </node>
+      <node concept="1HlG4h" id="4ieOWnG2H65" role="3EZMnx">
+        <node concept="1HfYo3" id="4ieOWnG2H67" role="1HlULh">
+          <node concept="3TQlhw" id="4ieOWnG2H69" role="1Hhtcw">
+            <node concept="3clFbS" id="4ieOWnG2H6b" role="2VODD2">
+              <node concept="3clFbF" id="4ieOWnG2IJ2" role="3cqZAp">
+                <node concept="2YIFZM" id="4ieOWnG4aZ1" role="3clFbG">
+                  <ref role="37wK5l" node="4ieOWnG43TU" resolve="topOrDefault" />
+                  <ref role="1Pybhc" node="4ieOWnG2Hcs" resolve="LifecycleTestingSupport" />
+                  <node concept="Xl_RD" id="4ieOWnG5aXa" role="37wK5m">
+                    <property role="Xl_RC" value="Hello, MPS!" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2SqB2G" id="4ieOWnG4aXC" role="2SqHTX">
+          <property role="TrG5h" value="peek" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="4ieOWnG2H5Z" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="312cEu" id="4ieOWnG2Hcs">
+    <property role="TrG5h" value="LifecycleTestingSupport" />
+    <node concept="Wx3nA" id="4ieOWnG3N_R" role="jymVt">
+      <property role="TrG5h" value="values" />
+      <node concept="3Tm1VV" id="4ieOWnG3kSn" role="1B3o_S" />
+      <node concept="3uibUv" id="4ieOWnG3N_F" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Stack" resolve="Stack" />
+        <node concept="17QB3L" id="4ieOWnG3PoM" role="11_B2D" />
+      </node>
+      <node concept="2ShNRf" id="4ieOWnG3NOE" role="33vP2m">
+        <node concept="1pGfFk" id="4ieOWnG3Pdw" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="33ny:~Stack.&lt;init&gt;()" resolve="Stack" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4ieOWnG3PqL" role="jymVt" />
+    <node concept="2YIFZL" id="4ieOWnG3PQQ" role="jymVt">
+      <property role="TrG5h" value="push" />
+      <node concept="3clFbS" id="4ieOWnG3PQS" role="3clF47">
+        <node concept="3clFbF" id="4ieOWnG3QdV" role="3cqZAp">
+          <node concept="2OqwBi" id="4ieOWnG3SVS" role="3clFbG">
+            <node concept="37vLTw" id="4ieOWnG3QdU" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ieOWnG3N_R" resolve="values" />
+            </node>
+            <node concept="liA8E" id="4ieOWnG3VLL" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Stack.push(java.lang.Object)" resolve="push" />
+              <node concept="37vLTw" id="4ieOWnG3Wgb" role="37wK5m">
+                <ref role="3cqZAo" node="4ieOWnG3PQV" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="4ieOWnG3PQU" role="3clF45" />
+      <node concept="37vLTG" id="4ieOWnG3PQV" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="17QB3L" id="4ieOWnG3PQW" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="4ieOWnG3PQT" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4ieOWnG3WxM" role="jymVt" />
+    <node concept="2YIFZL" id="4ieOWnG3X4c" role="jymVt">
+      <property role="TrG5h" value="pop" />
+      <node concept="3clFbS" id="4ieOWnG3X4f" role="3clF47">
+        <node concept="3clFbF" id="4ieOWnG3Xz5" role="3cqZAp">
+          <node concept="2OqwBi" id="4ieOWnG40h2" role="3clFbG">
+            <node concept="37vLTw" id="4ieOWnG3Xz4" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ieOWnG3N_R" resolve="values" />
+            </node>
+            <node concept="liA8E" id="4ieOWnG42Oy" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Stack.pop()" resolve="pop" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4ieOWnG3WJa" role="1B3o_S" />
+      <node concept="3cqZAl" id="4ieOWnG3X3P" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="4ieOWnG4304" role="jymVt" />
+    <node concept="2YIFZL" id="4ieOWnG43TU" role="jymVt">
+      <property role="TrG5h" value="topOrDefault" />
+      <node concept="3clFbS" id="4ieOWnG43TX" role="3clF47">
+        <node concept="3clFbJ" id="4ieOWnG53GA" role="3cqZAp">
+          <node concept="3clFbS" id="4ieOWnG53GC" role="3clFbx">
+            <node concept="3cpWs6" id="4ieOWnG5918" role="3cqZAp">
+              <node concept="37vLTw" id="4ieOWnG5aHc" role="3cqZAk">
+                <ref role="3cqZAo" node="4ieOWnG59Jo" resolve="defaultValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4ieOWnG55Gk" role="3clFbw">
+            <node concept="37vLTw" id="4ieOWnG542x" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ieOWnG3N_R" resolve="values" />
+            </node>
+            <node concept="liA8E" id="4ieOWnG58oK" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Stack.empty()" resolve="empty" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4ieOWnG44AY" role="3cqZAp">
+          <node concept="2OqwBi" id="4ieOWnG47Cx" role="3clFbG">
+            <node concept="37vLTw" id="4ieOWnG44AX" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ieOWnG3N_R" resolve="values" />
+            </node>
+            <node concept="liA8E" id="4ieOWnG4avJ" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Stack.peek()" resolve="peek" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4ieOWnG43nz" role="1B3o_S" />
+      <node concept="17QB3L" id="4ieOWnG43Tt" role="3clF45" />
+      <node concept="37vLTG" id="4ieOWnG59Jo" role="3clF46">
+        <property role="TrG5h" value="defaultValue" />
+        <node concept="17QB3L" id="4ieOWnG59Jn" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4ieOWnG2Hct" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.structure.mps
+++ b/code/testing/languages/nl.f1re.testing.examples.lang/models/nl.f1re.testing.examples.lang.structure.mps
@@ -114,5 +114,10 @@
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
+  <node concept="1TIwiD" id="4ieOWnG2H5T">
+    <property role="EcuMT" value="4940118688294162809" />
+    <property role="TrG5h" value="LifecycleTesting" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+  </node>
 </model>
 

--- a/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
+++ b/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
@@ -2,34 +2,31 @@
 <model ref="r:9dd92fa8-16f6-44db-ad34-9fc99b0abd5d(nl.f1re.testing.generator.templates@generator)">
   <persistence version="9" />
   <languages>
-    <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
     <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
+    <import index="m531" ref="r:e0971d7a-26cb-4f9b-923b-022db20993f1(nl.f1re.testing.runtime)" />
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
   </imports>
   <registry>
-    <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
-      <concept id="8473566765275063380" name="de.slisson.mps.reflection.structure.ReflectionFieldAccess" flags="ng" index="1PnCL0">
-        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
-      </concept>
-    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
-        <child id="1224071154657" name="classifierType" index="0kSFW" />
-        <child id="1224071154656" name="expression" index="0kSFX" />
-      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -60,10 +57,12 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -142,18 +141,21 @@
         <property role="od$2w" value="false" />
         <property role="DiZV1" value="false" />
         <node concept="3clFbS" id="5s44y2KUdni" role="3clF47">
-          <node concept="3clFbF" id="2$zHkrOw1II" role="3cqZAp">
-            <node concept="2OqwBi" id="2$zHkrOw31D" role="3clFbG">
-              <node concept="0kSF2" id="2$zHkrOw2vc" role="2Oq$k0">
-                <node concept="3uibUv" id="2$zHkrOw2ve" role="0kSFW">
-                  <ref role="3uigEE" to="tp6m:hPMdj4e" resolve="BaseEditorTestBody" />
+          <node concept="3clFbF" id="4ieOWnFWPoa" role="3cqZAp">
+            <node concept="2OqwBi" id="4ieOWnFWSYe" role="3clFbG">
+              <node concept="2ShNRf" id="4ieOWnFWPo6" role="2Oq$k0">
+                <node concept="1pGfFk" id="4ieOWnFWSzu" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="m531:6HRhZeXDGQF" resolve="EditorComponentTestHelper" />
+                  <node concept="1rXfSq" id="4ieOWnFWSGH" role="37wK5m">
+                    <ref role="37wK5l" to="tp6m:1BrKW0d9mQ7" resolve="getEditorComponent" />
+                  </node>
                 </node>
-                <node concept="Xjq3P" id="2$zHkrOw1IG" role="0kSFX" />
               </node>
-              <node concept="1PnCL0" id="2$zHkrOw3qY" role="2OqNvi">
-                <ref role="2Oxat5" to="tp6m:4wzlvyewbW2" resolve="myFileNodeEditor" />
+              <node concept="liA8E" id="4ieOWnFWTbY" role="2OqNvi">
+                <ref role="37wK5l" to="m531:4ieOWnFWOSS" resolve="getFileEditor" />
               </node>
-              <node concept="raruj" id="2$zHkrOw6DP" role="lGtFl" />
+              <node concept="raruj" id="4ieOWnFWU8U" role="lGtFl" />
             </node>
           </node>
         </node>

--- a/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
+++ b/code/testing/languages/nl.f1re.testing/generator/templates/nl.f1re.testing.generator.templates@generator.mps
@@ -9,10 +9,22 @@
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
     <import index="m531" ref="r:e0971d7a-26cb-4f9b-923b-022db20993f1(nl.f1re.testing.runtime)" />
     <import index="k3nr" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.ide.editor(MPS.Editor/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="yqm7" ref="63b449db-0918-4a4a-a891-2c430ab133e4/java:org.junit.jupiter.api(org.junit.junit5/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -20,7 +32,14 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
       <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
@@ -66,14 +85,24 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1114729360583" name="jetbrains.mps.lang.generator.structure.CopySrcListMacro" flags="ln" index="2b32R4">
+        <child id="1168278589236" name="sourceNodesQuery" index="2P8S$" />
+      </concept>
       <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="7473026166162327259" name="dropAttrubuteRule" index="CYSdJ" />
+        <child id="1167172143858" name="weavingMappingRule" index="30SoJX" />
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
       </concept>
       <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
@@ -81,8 +110,16 @@
       <concept id="1722980698497626400" name="jetbrains.mps.lang.generator.structure.ITemplateCall" flags="ngI" index="v9R3L">
         <reference id="1722980698497626483" name="template" index="v9R2y" />
       </concept>
+      <concept id="7473026166162297915" name="jetbrains.mps.lang.generator.structure.DropAttributeRule" flags="lg" index="CY16f">
+        <reference id="7473026166162297918" name="applicableConcept" index="CY16a" />
+      </concept>
+      <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
       <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
         <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
+      </concept>
+      <concept id="1167171569011" name="jetbrains.mps.lang.generator.structure.Weaving_MappingRule" flags="lg" index="30QchW">
+        <child id="1169570368028" name="ruleConsequence" index="1fOSGc" />
+        <child id="1184616230853" name="contextNodeQuery" index="3gCiVm" />
       </concept>
       <concept id="1092059087312" name="jetbrains.mps.lang.generator.structure.TemplateDeclaration" flags="ig" index="13MO4I">
         <reference id="1168285871518" name="applicableConcept" index="3gUMe" />
@@ -90,6 +127,39 @@
       </concept>
       <concept id="1167327847730" name="jetbrains.mps.lang.generator.structure.Reduction_MappingRule" flags="lg" index="3aamgX">
         <child id="1169672767469" name="ruleConsequence" index="1lVwrX" />
+      </concept>
+      <concept id="1184616041890" name="jetbrains.mps.lang.generator.structure.Weaving_MappingRule_ContextNodeQuery" flags="in" index="3gB$ML" />
+      <concept id="1167945743726" name="jetbrains.mps.lang.generator.structure.IfMacro_Condition" flags="in" index="3IZrLx" />
+      <concept id="1167951910403" name="jetbrains.mps.lang.generator.structure.SourceSubstituteMacro_SourceNodesQuery" flags="in" index="3JmXsc" />
+      <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
+      </concept>
+    </language>
+    <language id="d7706f63-9be2-479c-a3da-ae92af1e64d5" name="jetbrains.mps.lang.generator.generationContext">
+      <concept id="1217884725453" name="jetbrains.mps.lang.generator.generationContext.structure.GenerationContextOp_GetCopiedOutputByInput" flags="nn" index="2f_y7m">
+        <child id="1217884725459" name="inputNode" index="2f_y78" />
+      </concept>
+      <concept id="1216860049635" name="jetbrains.mps.lang.generator.generationContext.structure.TemplateFunctionParameter_generationContext" flags="nn" index="1iwH7S" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -108,6 +178,30 @@
       <node concept="j$656" id="3OVhQEUSdJ5" role="1lVwrX">
         <ref role="v9R2y" node="50vRVameRNm" resolve="reduce_FileNodeEditorExpression" />
       </node>
+    </node>
+    <node concept="30QchW" id="1LXhaCizQV8" role="30SoJX">
+      <ref role="30HIoZ" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+      <node concept="3gB$ML" id="1LXhaCizQVa" role="3gCiVm">
+        <node concept="3clFbS" id="1LXhaCizQVb" role="2VODD2">
+          <node concept="3clFbF" id="1LXhaCizR4W" role="3cqZAp">
+            <node concept="2OqwBi" id="1LXhaCizRUa" role="3clFbG">
+              <node concept="1iwH7S" id="1LXhaCizRur" role="2Oq$k0" />
+              <node concept="2f_y7m" id="1LXhaCizRZH" role="2OqNvi">
+                <node concept="2OqwBi" id="1LXhaCizSkX" role="2f_y78">
+                  <node concept="30H73N" id="1LXhaCizS0o" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="1LXhaCizUoP" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="j$656" id="1LXhaCi$bh6" role="1fOSGc">
+        <ref role="v9R2y" node="1LXhaCi$bh4" resolve="weave_EditorTestLifecycle" />
+      </node>
+    </node>
+    <node concept="CY16f" id="1LXhaCi_hCd" role="CYSdJ">
+      <ref role="CY16a" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
     </node>
   </node>
   <node concept="13MO4I" id="50vRVameRNm">
@@ -167,6 +261,224 @@
       <node concept="3uibUv" id="5s44y2KUezZ" role="1zkMxy">
         <ref role="3uigEE" to="tp6m:hPMdj4e" resolve="BaseEditorTestBody" />
       </node>
+    </node>
+  </node>
+  <node concept="13MO4I" id="1LXhaCi$bh4">
+    <property role="TrG5h" value="weave_EditorTestLifecycle" />
+    <ref role="3gUMe" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+    <node concept="312cEu" id="1LXhaCi$k23" role="13RCb5">
+      <property role="TrG5h" value="EditorTestCase" />
+      <node concept="2YIFZL" id="6J4VGlipZZv" role="jymVt">
+        <property role="TrG5h" value="beforeTests" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="2AHcQZ" id="6J4VGlipnU8" role="2AJF6D">
+          <ref role="2AI5Lk" to="yqm7:~BeforeAll" resolve="BeforeAll" />
+        </node>
+        <node concept="3clFbS" id="7ApXrTOHQcI" role="3clF47">
+          <node concept="3clFbF" id="7ApXrTOHQcJ" role="3cqZAp">
+            <node concept="2OqwBi" id="7ApXrTOHQcK" role="3clFbG">
+              <node concept="10M0yZ" id="7ApXrTOHQcL" role="2Oq$k0">
+                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              </node>
+              <node concept="liA8E" id="7ApXrTOHQcM" role="2OqNvi">
+                <ref role="37wK5l" to="guwi:~PrintStream.println()" resolve="println" />
+              </node>
+            </node>
+            <node concept="2b32R4" id="7ApXrTOHQcN" role="lGtFl">
+              <node concept="3JmXsc" id="7ApXrTOHQcO" role="2P8S$">
+                <node concept="3clFbS" id="7ApXrTOHQcP" role="2VODD2">
+                  <node concept="3clFbF" id="7ApXrTOHQcQ" role="3cqZAp">
+                    <node concept="2OqwBi" id="7ApXrTOHQcR" role="3clFbG">
+                      <node concept="2OqwBi" id="7ApXrTOHQcS" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7ApXrTOHQcT" role="2Oq$k0">
+                          <node concept="30H73N" id="7ApXrTOHQcU" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7ApXrTOHQcV" role="2OqNvi">
+                            <ref role="3Tt5mk" to="rl2y:2154_0wVVpx" resolve="beforeTests" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="71HWW_wlUA_" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="7ApXrTOHQcX" role="2OqNvi">
+                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqZAl" id="7ApXrTOHQcY" role="3clF45" />
+        <node concept="3Tm1VV" id="7ApXrTOHQpj" role="1B3o_S" />
+        <node concept="raruj" id="1LXhaCi$_D0" role="lGtFl" />
+        <node concept="1W57fq" id="7ApXrTOHQda" role="lGtFl">
+          <node concept="3IZrLx" id="7ApXrTOHQdb" role="3IZSJc">
+            <node concept="3clFbS" id="7ApXrTOHQdc" role="2VODD2">
+              <node concept="3clFbF" id="7ApXrTOHQdd" role="3cqZAp">
+                <node concept="1Wc70l" id="6I8tQNTtj6E" role="3clFbG">
+                  <node concept="2OqwBi" id="6I8tQNTto44" role="3uHU7w">
+                    <node concept="2OqwBi" id="6I8tQNTtkiC" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6I8tQNTtjsU" role="2Oq$k0">
+                        <node concept="30H73N" id="6I8tQNTtjdb" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="6I8tQNTtjwm" role="2OqNvi">
+                          <ref role="3Tt5mk" to="rl2y:2154_0wVVpx" resolve="beforeTests" />
+                        </node>
+                      </node>
+                      <node concept="2Xjw5R" id="6I8tQNTtntE" role="2OqNvi">
+                        <node concept="1xMEDy" id="6I8tQNTtntG" role="1xVPHs">
+                          <node concept="chp4Y" id="6I8tQNTtnD3" role="ri$Ld">
+                            <ref role="cht4Q" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3w_OXm" id="6I8tQNTtqKS" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="7ApXrTOHQde" role="3uHU7B">
+                    <node concept="2OqwBi" id="7ApXrTOHQdf" role="2Oq$k0">
+                      <node concept="30H73N" id="7ApXrTOHQdg" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="7ApXrTOHQdh" role="2OqNvi">
+                        <ref role="3Tt5mk" to="rl2y:2154_0wVVpx" resolve="beforeTests" />
+                      </node>
+                    </node>
+                    <node concept="3x8VRR" id="7ApXrTOHQdi" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="2154_0wWfIx" role="jymVt">
+        <node concept="raruj" id="1LXhaCi$_QU" role="lGtFl" />
+        <node concept="1W57fq" id="6UbzZKmPSvL" role="lGtFl">
+          <node concept="3IZrLx" id="6UbzZKmPSvO" role="3IZSJc">
+            <node concept="3clFbS" id="6UbzZKmPSvP" role="2VODD2">
+              <node concept="3clFbF" id="6UbzZKmPVaS" role="3cqZAp">
+                <node concept="2OqwBi" id="6UbzZKmPVaU" role="3clFbG">
+                  <node concept="2OqwBi" id="6UbzZKmPVaV" role="2Oq$k0">
+                    <node concept="30H73N" id="6UbzZKmPVaW" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6UbzZKmPYe5" role="2OqNvi">
+                      <ref role="3Tt5mk" to="rl2y:2154_0wVVpx" resolve="beforeTests" />
+                    </node>
+                  </node>
+                  <node concept="3x8VRR" id="6UbzZKmPVaY" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2YIFZL" id="6J4VGliq2cG" role="jymVt">
+        <property role="TrG5h" value="afterTests" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="2AHcQZ" id="6J4VGlip2mD" role="2AJF6D">
+          <ref role="2AI5Lk" to="yqm7:~AfterAll" resolve="AfterAll" />
+        </node>
+        <node concept="3clFbS" id="7ApXrTOHQj0" role="3clF47">
+          <node concept="3clFbF" id="7ApXrTOHQj1" role="3cqZAp">
+            <node concept="2OqwBi" id="7ApXrTOHQj2" role="3clFbG">
+              <node concept="10M0yZ" id="7ApXrTOHQj3" role="2Oq$k0">
+                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              </node>
+              <node concept="liA8E" id="7ApXrTOHQj4" role="2OqNvi">
+                <ref role="37wK5l" to="guwi:~PrintStream.println()" resolve="println" />
+              </node>
+            </node>
+            <node concept="2b32R4" id="7ApXrTOHQj5" role="lGtFl">
+              <node concept="3JmXsc" id="7ApXrTOHQj6" role="2P8S$">
+                <node concept="3clFbS" id="7ApXrTOHQj7" role="2VODD2">
+                  <node concept="3clFbF" id="7ApXrTOHQj8" role="3cqZAp">
+                    <node concept="2OqwBi" id="7ApXrTOHQj9" role="3clFbG">
+                      <node concept="2OqwBi" id="7ApXrTOHQja" role="2Oq$k0">
+                        <node concept="2OqwBi" id="7ApXrTOHQjb" role="2Oq$k0">
+                          <node concept="30H73N" id="7ApXrTOHQjc" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="7ApXrTOHQjd" role="2OqNvi">
+                            <ref role="3Tt5mk" to="rl2y:2154_0wVVpG" resolve="afterTests" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="71HWW_wlRxH" role="2OqNvi">
+                          <ref role="3Tt5mk" to="tpee:gyVODHa" resolve="body" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="7ApXrTOHQjf" role="2OqNvi">
+                        <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqZAl" id="7ApXrTOHQjg" role="3clF45" />
+        <node concept="3Tm1VV" id="7ApXrTOHQpa" role="1B3o_S" />
+        <node concept="raruj" id="1LXhaCi$_RY" role="lGtFl" />
+        <node concept="1W57fq" id="7ApXrTOHQjs" role="lGtFl">
+          <node concept="3IZrLx" id="7ApXrTOHQjt" role="3IZSJc">
+            <node concept="3clFbS" id="7ApXrTOHQju" role="2VODD2">
+              <node concept="3clFbF" id="7ApXrTOHQjv" role="3cqZAp">
+                <node concept="1Wc70l" id="6I8tQNTtp4t" role="3clFbG">
+                  <node concept="2OqwBi" id="7ApXrTOHQjw" role="3uHU7B">
+                    <node concept="2OqwBi" id="7ApXrTOHQjx" role="2Oq$k0">
+                      <node concept="30H73N" id="7ApXrTOHQjy" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="7ApXrTOHQjz" role="2OqNvi">
+                        <ref role="3Tt5mk" to="rl2y:2154_0wVVpG" resolve="afterTests" />
+                      </node>
+                    </node>
+                    <node concept="3x8VRR" id="7ApXrTOHQj$" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="6I8tQNTtqcj" role="3uHU7w">
+                    <node concept="2OqwBi" id="6I8tQNTtphY" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6I8tQNTtphZ" role="2Oq$k0">
+                        <node concept="30H73N" id="6I8tQNTtpi0" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="6I8tQNTtpi1" role="2OqNvi">
+                          <ref role="3Tt5mk" to="rl2y:2154_0wVVpG" resolve="afterTests" />
+                        </node>
+                      </node>
+                      <node concept="2Xjw5R" id="6I8tQNTtpi2" role="2OqNvi">
+                        <node concept="1xMEDy" id="6I8tQNTtpi3" role="1xVPHs">
+                          <node concept="chp4Y" id="6I8tQNTtpi4" role="ri$Ld">
+                            <ref role="cht4Q" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3w_OXm" id="6I8tQNTtqtL" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="2154_0wVcWI" role="jymVt">
+        <node concept="raruj" id="1LXhaCi$A5R" role="lGtFl" />
+        <node concept="1W57fq" id="6UbzZKmPGW_" role="lGtFl">
+          <node concept="3IZrLx" id="6UbzZKmPGWC" role="3IZSJc">
+            <node concept="3clFbS" id="6UbzZKmPGWD" role="2VODD2">
+              <node concept="3clFbF" id="6UbzZKmPPMk" role="3cqZAp">
+                <node concept="2OqwBi" id="6UbzZKmPPMm" role="3clFbG">
+                  <node concept="2OqwBi" id="6UbzZKmPPMn" role="2Oq$k0">
+                    <node concept="30H73N" id="6UbzZKmPPMo" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6UbzZKmPPMp" role="2OqNvi">
+                      <ref role="3Tt5mk" to="rl2y:2154_0wVVpG" resolve="afterTests" />
+                    </node>
+                  </node>
+                  <node concept="3x8VRR" id="6UbzZKmPPMq" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1LXhaCi$k24" role="1B3o_S" />
     </node>
   </node>
 </model>

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.behavior.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.behavior.mps
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b30bf83e-7523-4ffb-a1c5-168b585996df(nl.f1re.testing.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.editor.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.editor.mps
@@ -13,12 +13,32 @@
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
+      <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
+        <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -28,6 +48,32 @@
     <ref role="1XX52x" to="rl2y:2$zHkrOt$DN" resolve="FileNodeEditorExpression" />
     <node concept="PMmxH" id="2wdLO7KhY3L" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="1LXhaCi$Etv">
+    <ref role="1XX52x" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+    <node concept="3EZMnI" id="1LXhaCi$Etx" role="2wV5jI">
+      <node concept="2SsqMj" id="1LXhaCi$Et_" role="3EZMnx">
+        <node concept="ljvvj" id="1LXhaCi$EtB" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1LXhaCi$EtD" role="3EZMnx">
+        <property role="3F0ifm" value="" />
+        <node concept="ljvvj" id="1LXhaCi$EtG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="1LXhaCi$EtI" role="3EZMnx">
+        <ref role="1NtTu8" to="rl2y:2154_0wVVpx" resolve="beforeTests" />
+        <node concept="ljvvj" id="1LXhaCi$EtL" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="1LXhaCi$EtM" role="3EZMnx">
+        <ref role="1NtTu8" to="rl2y:2154_0wVVpG" resolve="afterTests" />
+      </node>
+      <node concept="l2Vlx" id="1LXhaCi$Et$" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.intentions.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.intentions.mps
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:928bdb55-0ebd-419a-a147-5fa1a66aa76c(nl.f1re.testing.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
+      <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
+        <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
+      </concept>
+      <concept id="6407023681583031218" name="jetbrains.mps.lang.smodel.structure.AttributeAccess" flags="nn" index="3CFZ6_">
+        <child id="6407023681583036852" name="qualifier" index="3CFYIz" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="1LXhaCi$E$P">
+    <property role="TrG5h" value="addRemove_TestEditorLifecycle" />
+    <ref role="2ZfgGC" to="tp5g:hSLiM3w" resolve="EditorTestCase" />
+    <node concept="2S6ZIM" id="1LXhaCi$E$Q" role="2ZfVej">
+      <node concept="3clFbS" id="1LXhaCi$E$R" role="2VODD2">
+        <node concept="3clFbJ" id="1LXhaCi$EPH" role="3cqZAp">
+          <node concept="3clFbC" id="1LXhaCi$GPl" role="3clFbw">
+            <node concept="2OqwBi" id="1LXhaCi$Fsr" role="3uHU7B">
+              <node concept="2Sf5sV" id="1LXhaCi$EQh" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="1LXhaCi$G3z" role="2OqNvi">
+                <node concept="3CFYIy" id="1LXhaCi$Gqw" role="3CFYIz">
+                  <ref role="3CFYIx" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+                </node>
+              </node>
+            </node>
+            <node concept="10Nm6u" id="1LXhaCi$GIi" role="3uHU7w" />
+          </node>
+          <node concept="3clFbS" id="1LXhaCi$EPJ" role="3clFbx">
+            <node concept="3cpWs6" id="1LXhaCi$H7G" role="3cqZAp">
+              <node concept="Xl_RD" id="1LXhaCi$H7H" role="3cqZAk">
+                <property role="Xl_RC" value="Add Lifecycle Methods" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="1LXhaCi$GMV" role="9aQIa">
+            <node concept="3clFbS" id="1LXhaCi$GMW" role="9aQI4">
+              <node concept="3cpWs6" id="1LXhaCi$I9j" role="3cqZAp">
+                <node concept="Xl_RD" id="1LXhaCi$I9k" role="3cqZAk">
+                  <property role="Xl_RC" value="Remove Lifecycle Methods" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="1LXhaCi$E$S" role="2ZfgGD">
+      <node concept="3clFbS" id="1LXhaCi$E$T" role="2VODD2">
+        <node concept="3clFbJ" id="1LXhaCi$Ias" role="3cqZAp">
+          <node concept="3clFbC" id="1LXhaCi$J9B" role="3clFbw">
+            <node concept="10Nm6u" id="1LXhaCi$Jao" role="3uHU7w" />
+            <node concept="2OqwBi" id="1LXhaCi$Ixh" role="3uHU7B">
+              <node concept="2Sf5sV" id="1LXhaCi$IaU" role="2Oq$k0" />
+              <node concept="3CFZ6_" id="1LXhaCi$J8j" role="2OqNvi">
+                <node concept="3CFYIy" id="1LXhaCi$J8U" role="3CFYIz">
+                  <ref role="3CFYIx" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1LXhaCi$Iau" role="3clFbx">
+            <node concept="3clFbF" id="1LXhaCi$Jb8" role="3cqZAp">
+              <node concept="2OqwBi" id="1LXhaCi$JjO" role="3clFbG">
+                <node concept="2OqwBi" id="1LXhaCi$Jfd" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="1LXhaCi$Jb7" role="2Oq$k0" />
+                  <node concept="3CFZ6_" id="1LXhaCi$Jgm" role="2OqNvi">
+                    <node concept="3CFYIy" id="1LXhaCi$JgU" role="3CFYIz">
+                      <ref role="3CFYIx" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="zfrQC" id="1LXhaCi$JBF" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="1LXhaCi$JEP" role="9aQIa">
+            <node concept="3clFbS" id="1LXhaCi$JEQ" role="9aQI4">
+              <node concept="3clFbF" id="1LXhaCi$JGB" role="3cqZAp">
+                <node concept="2OqwBi" id="1LXhaCi$JJ2" role="3clFbG">
+                  <node concept="2OqwBi" id="1LXhaCi$JGV" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="1LXhaCi$JGA" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="1LXhaCi$JI4" role="2OqNvi">
+                      <node concept="3CFYIy" id="1LXhaCi$JIC" role="3CFYIz">
+                        <ref role="3CFYIx" to="rl2y:1LXhaCizQV2" resolve="EditorTestLifecycleMethods" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3YRAZt" id="1LXhaCi$JNl" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.structure.mps
+++ b/code/testing/languages/nl.f1re.testing/models/nl.f1re.testing.structure.mps
@@ -3,24 +3,69 @@
   <persistence version="9" />
   <languages>
     <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <use id="343f8205-dc88-465b-9c5b-ce46b5f1c193" name="jetbrains.mps.lang.core.doc" version="1" />
+    <use id="d304f247-4944-479d-ac8b-972b953bcdfe" name="jetbrains.mps.lang.doctext" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
   </imports>
   <registry>
+    <language id="d304f247-4944-479d-ac8b-972b953bcdfe" name="jetbrains.mps.lang.doctext">
+      <concept id="747542936069611173" name="jetbrains.mps.lang.doctext.structure.DocText" flags="ng" index="3W_X3N">
+        <child id="4404258161274814728" name="lines" index="2WYp1Y" />
+      </concept>
+    </language>
+    <language id="343f8205-dc88-465b-9c5b-ce46b5f1c193" name="jetbrains.mps.lang.core.doc">
+      <concept id="4293932951803486388" name="jetbrains.mps.lang.core.doc.structure.DocumentationAnnotation" flags="ng" index="3207RK">
+        <child id="2217810310728609106" name="text" index="SU_fC" />
+      </concept>
+    </language>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="6054523464626862044" name="jetbrains.mps.lang.structure.structure.AttributeInfo_IsMultiple" flags="ng" index="tn0Fv" />
+      <concept id="6054523464627964745" name="jetbrains.mps.lang.structure.structure.AttributeInfo_AttributedConcept" flags="ng" index="trNpa">
+        <reference id="6054523464627965081" name="concept" index="trN6q" />
+      </concept>
+      <concept id="2992811758677295509" name="jetbrains.mps.lang.structure.structure.AttributeInfo" flags="ng" index="M6xJ_">
+        <property id="7588428831955550663" name="role" index="Hh88m" />
+        <child id="7588428831947959310" name="attributed" index="EQaZv" />
+        <child id="7588428831955550186" name="multiple" index="HhnKV" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
       </concept>
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
       </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="7836372964445990119" name="jetbrains.mps.lang.text.structure.TextNodeReference" flags="ng" index="1lxOXm">
+        <reference id="491191292298774843" name="reference" index="2SUGrr" />
+      </concept>
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
   </registry>
@@ -29,6 +74,60 @@
     <property role="TrG5h" value="FileNodeEditorExpression" />
     <property role="34LRSv" value="fileNodeEditor" />
     <ref role="1TJDcQ" to="tpee:fz3vP1J" resolve="Expression" />
+  </node>
+  <node concept="1TIwiD" id="1LXhaCizQV2">
+    <property role="EcuMT" value="2052872502397333186" />
+    <property role="TrG5h" value="EditorTestLifecycleMethods" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDk" resolve="NodeAttribute" />
+    <node concept="3207RK" id="bpuQGUaw01" role="lGtFl">
+      <node concept="3W_X3N" id="bpuQGUaw03" role="SU_fC">
+        <node concept="1PaTwC" id="bpuQGUaw31" role="2WYp1Y">
+          <node concept="3oM_SD" id="bpuQGUaw32" role="1PaTwD">
+            <property role="3oM_SC" value="Extends" />
+          </node>
+          <node concept="1lxOXm" id="bpuQGUaw3t" role="1PaTwD">
+            <ref role="2SUGrr" to="tp5g:hSLiM3w" resolve="EditorTestCase" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw48" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw4b" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;before&quot;" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw4c" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw4d" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;after" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw4e" role="1PaTwD">
+            <property role="3oM_SC" value="tests&quot;" />
+          </node>
+          <node concept="3oM_SD" id="bpuQGUaw4f" role="1PaTwD">
+            <property role="3oM_SC" value="methods" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2154_0wVVpx" role="1TKVEi">
+      <property role="IQ2ns" value="2325284917965993569" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="beforeTests" />
+      <ref role="20lvS9" to="tp5g:2154_0wV2x7" resolve="BeforeTestsMethod" />
+    </node>
+    <node concept="1TJgyj" id="2154_0wVVpG" role="1TKVEi">
+      <property role="IQ2ns" value="2325284917965993580" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="afterTests" />
+      <ref role="20lvS9" to="tp5g:2154_0wV2x8" resolve="AfterTestsMethod" />
+    </node>
+    <node concept="M6xJ_" id="1LXhaCizQV3" role="lGtFl">
+      <property role="Hh88m" value="editorTestLifecycleMethods" />
+      <node concept="tn0Fv" id="1LXhaCizQV4" role="HhnKV" />
+      <node concept="trNpa" id="1LXhaCizQV7" role="EQaZv">
+        <ref role="trN6q" to="tp5g:hSLiM3w" resolve="EditorTestCase" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
+++ b/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
@@ -26,10 +26,8 @@
       <external-templates />
       <dependencies>
         <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
-        <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
       </dependencies>
       <languageVersions>
-        <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
         <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
         <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
@@ -77,7 +75,6 @@
   </generators>
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
-    <dependency reexport="false" scope="generate-into">654422bf-e75f-44dc-936d-188890a746ce(de.slisson.mps.reflection)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -109,8 +106,6 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="654422bf-e75f-44dc-936d-188890a746ce(de.slisson.mps.reflection)" version="0" />
-    <module reference="7037b32c-9607-4f8e-81bd-1f028a4c117b(de.slisson.mps.reflection.runtime)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
+++ b/code/testing/languages/nl.f1re.testing/nl.f1re.testing.mpl
@@ -26,6 +26,7 @@
       <external-templates />
       <dependencies>
         <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
+        <dependency reexport="false">63b449db-0918-4a4a-a891-2c430ab133e4(org.junit.junit5)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -69,12 +70,14 @@
         <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
         <module reference="ce328797-6b80-4260-85af-aea5722a56c7(nl.f1re.testing.generator)" version="0" />
         <module reference="f4eaf5cb-c1e6-4968-831c-c28a93349488(nl.f1re.testing.runtime)" version="0" />
+        <module reference="63b449db-0918-4a4a-a891-2c430ab133e4(org.junit.junit5)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>
   </generators>
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -82,12 +85,17 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:343f8205-dc88-465b-9c5b-ce46b5f1c193:jetbrains.mps.lang.core.doc" version="1" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:d304f247-4944-479d-ac8b-972b953bcdfe:jetbrains.mps.lang.doctext" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="15" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="1" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
@@ -107,10 +115,13 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
   </dependencyVersions>

--- a/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples@tests.mps
+++ b/code/testing/solutions/nl.f1re.testing.examples/models/nl.f1re.testing.examples@tests.mps
@@ -115,6 +115,7 @@
     <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
     <import index="t335" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui.update(MPS.IDEA/)" />
     <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+    <import index="cdna" ref="r:241d801e-1003-46f0-9785-1157a06b80af(nl.f1re.testing.examples.lang.editor)" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -501,6 +502,10 @@
       </concept>
     </language>
     <language id="953e4089-c643-455b-8629-636de7085d1c" name="nl.f1re.testing">
+      <concept id="2052872502397333186" name="nl.f1re.testing.structure.EditorTestLifecycleMethods" flags="ng" index="eWyDC">
+        <child id="2325284917965993569" name="beforeTests" index="0EEgM" />
+        <child id="2325284917965993580" name="afterTests" index="0EEgX" />
+      </concept>
       <concept id="2964412296093649523" name="nl.f1re.testing.structure.FileNodeEditorExpression" flags="ng" index="3tlvWP" />
     </language>
     <language id="6b3888c1-9802-44d8-8baf-f8e6c33ed689" name="jetbrains.mps.kotlin">
@@ -534,6 +539,7 @@
       </concept>
     </language>
     <language id="87e083b3-d1b3-4c3f-9d8c-b24d74710f49" name="nl.f1re.testing.examples.lang">
+      <concept id="4940118688294162809" name="nl.f1re.testing.examples.lang.structure.LifecycleTesting" flags="ng" index="2Cx0aW" />
       <concept id="6801793966041277396" name="nl.f1re.testing.examples.lang.structure.SlowEditor" flags="ng" index="13bv17" />
       <concept id="6382061996743463528" name="nl.f1re.testing.examples.lang.structure.CompletionStylingExample" flags="ng" index="3iYV7U" />
       <concept id="2964412296095260730" name="nl.f1re.testing.examples.lang.structure.Readme" flags="ng" index="3tFllW">
@@ -6640,6 +6646,103 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="6H1$aDlmM9C" role="1B3o_S" />
+  </node>
+  <node concept="LiM7Y" id="4ieOWnG2$Zy">
+    <property role="3GE5qa" value="editor" />
+    <property role="TrG5h" value="EditorLifecycle" />
+    <node concept="eWyDC" id="4ieOWnG2N9k" role="lGtFl">
+      <node concept="0EjCn" id="4ieOWnG2Nar" role="0EEgM">
+        <node concept="3clFbS" id="4ieOWnG2Nas" role="2VODD2">
+          <node concept="3clFbF" id="4ieOWnG3eQ2" role="3cqZAp">
+            <node concept="2YIFZM" id="4ieOWnG4b7R" role="3clFbG">
+              <ref role="37wK5l" to="cdna:4ieOWnG3PQQ" resolve="push" />
+              <ref role="1Pybhc" to="cdna:4ieOWnG2Hcs" resolve="LifecycleTestingSupport" />
+              <node concept="Xl_RD" id="4ieOWnG3fro" role="37wK5m">
+                <property role="Xl_RC" value="Hello, lifecycle tests!" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="0EjCo" id="4ieOWnG3fLS" role="0EEgX">
+        <node concept="3clFbS" id="4ieOWnG3fLT" role="2VODD2">
+          <node concept="3clFbF" id="4ieOWnG4c4m" role="3cqZAp">
+            <node concept="2YIFZM" id="4ieOWnG4c6x" role="3clFbG">
+              <ref role="37wK5l" to="cdna:4ieOWnG3X4c" resolve="pop" />
+              <ref role="1Pybhc" to="cdna:4ieOWnG2Hcs" resolve="LifecycleTestingSupport" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4ieOWnG4c7R" role="25YQCW">
+      <node concept="2Cx0aW" id="4ieOWnG4c7Q" role="1qenE9">
+        <node concept="LIFWc" id="4ieOWnG5Vnn" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="peek" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="4ieOWnG4c9V" role="LjaKd">
+      <node concept="3cpWs8" id="4ieOWnG4j4U" role="3cqZAp">
+        <node concept="3cpWsn" id="4ieOWnG4j4V" role="3cpWs9">
+          <property role="TrG5h" value="selectedCell" />
+          <node concept="3uibUv" id="4ieOWnG4j4q" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+          </node>
+          <node concept="2OqwBi" id="4ieOWnG4j4W" role="33vP2m">
+            <node concept="369mXd" id="4ieOWnG4j4X" role="2Oq$k0" />
+            <node concept="liA8E" id="4ieOWnG4j4Y" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getSelectedCell()" resolve="getSelectedCell" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="4ieOWnG4kB2" role="3cqZAp">
+        <node concept="2ZW3vV" id="4ieOWnG4kRm" role="3vwVQn">
+          <node concept="3uibUv" id="4ieOWnG4nGH" role="2ZW6by">
+            <ref role="3uigEE" to="f4zo:~EditorCell_Label" resolve="EditorCell_Label" />
+          </node>
+          <node concept="37vLTw" id="4ieOWnG4kDD" role="2ZW6bz">
+            <ref role="3cqZAo" node="4ieOWnG4j4V" resolve="selectedCell" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="4ieOWnG4pcH" role="3cqZAp">
+        <node concept="3cpWsn" id="4ieOWnG4pcI" role="3cpWs9">
+          <property role="TrG5h" value="label" />
+          <node concept="3uibUv" id="4ieOWnG4pcJ" role="1tU5fm">
+            <ref role="3uigEE" to="f4zo:~EditorCell_Label" resolve="EditorCell_Label" />
+          </node>
+          <node concept="1eOMI4" id="4ieOWnG4pl_" role="33vP2m">
+            <node concept="10QFUN" id="4ieOWnG4ply" role="1eOMHV">
+              <node concept="3uibUv" id="4ieOWnG4plB" role="10QFUM">
+                <ref role="3uigEE" to="f4zo:~EditorCell_Label" resolve="EditorCell_Label" />
+              </node>
+              <node concept="37vLTw" id="4ieOWnG4pmW" role="10QFUP">
+                <ref role="3cqZAo" node="4ieOWnG4j4V" resolve="selectedCell" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3vlDli" id="4ieOWnG4dqR" role="3cqZAp">
+        <node concept="Xl_RD" id="4ieOWnG4pSU" role="3tpDZB">
+          <property role="Xl_RC" value="Hello, lifecycle tests!" />
+        </node>
+        <node concept="2OqwBi" id="4ieOWnG4pxc" role="3tpDZA">
+          <node concept="37vLTw" id="4ieOWnG4j4Z" role="2Oq$k0">
+            <ref role="3cqZAo" node="4ieOWnG4pcI" resolve="label" />
+          </node>
+          <node concept="liA8E" id="4ieOWnG4pRo" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~EditorCell_Label.getText()" resolve="getText" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/testing/solutions/nl.f1re.testing.runtime/models/nl.f1re.testing.runtime.mps
+++ b/code/testing/solutions/nl.f1re.testing.runtime/models/nl.f1re.testing.runtime.mps
@@ -61,6 +61,9 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="1o1n" ref="r:028362d1-b964-410a-a3d5-6096bcd4a2b6(com.mbeddr.mpsutil.intentions.runtime.plugin)" />
+    <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="qq03" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.actions(MPS.Platform/)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -952,6 +955,60 @@
       <node concept="3uibUv" id="6HRhZeXH66V" role="3clF45">
         <ref role="3uigEE" to="2rdi:~ContextAssistantManager" resolve="ContextAssistantManager" />
       </node>
+    </node>
+    <node concept="2tJIrI" id="4ieOWnFTK$b" role="jymVt" />
+    <node concept="3clFb_" id="4ieOWnFWOSS" role="jymVt">
+      <property role="TrG5h" value="getFileEditor" />
+      <node concept="3clFbS" id="4ieOWnFWOSU" role="3clF47">
+        <node concept="3cpWs8" id="4ieOWnFWOSV" role="3cqZAp">
+          <node concept="3cpWsn" id="4ieOWnFWOSW" role="3cpWs9">
+            <property role="TrG5h" value="dataContext" />
+            <node concept="3uibUv" id="4ieOWnFWOSX" role="1tU5fm">
+              <ref role="3uigEE" to="qkt:~DataContext" resolve="DataContext" />
+            </node>
+            <node concept="2OqwBi" id="4ieOWnFWOSY" role="33vP2m">
+              <node concept="2YIFZM" id="4ieOWnFWOSZ" role="2Oq$k0">
+                <ref role="1Pybhc" to="ddhc:~DataManager" resolve="DataManager" />
+                <ref role="37wK5l" to="ddhc:~DataManager.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="4ieOWnFWOT0" role="2OqNvi">
+                <ref role="37wK5l" to="ddhc:~DataManager.getDataContext(java.awt.Component)" resolve="getDataContext" />
+                <node concept="10QFUN" id="4ieOWnFWOT1" role="37wK5m">
+                  <node concept="3uibUv" id="4ieOWnFWOT2" role="10QFUM">
+                    <ref role="3uigEE" to="z60i:~Component" resolve="Component" />
+                  </node>
+                  <node concept="37vLTw" id="4ieOWnFWOT3" role="10QFUP">
+                    <ref role="3cqZAo" node="6HRhZeXDGSq" resolve="editorComponent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4ieOWnFWOT4" role="3cqZAp">
+          <node concept="10QFUN" id="2EmVdCCM9gb" role="3cqZAk">
+            <node concept="2OqwBi" id="2EmVdCCM9g7" role="10QFUP">
+              <node concept="10M0yZ" id="2EmVdCCM9g8" role="2Oq$k0">
+                <ref role="3cqZAo" to="qkt:~PlatformCoreDataKeys.FILE_EDITOR" resolve="FILE_EDITOR" />
+                <ref role="1PxDUh" to="qq03:~MPSCommonDataKeys" resolve="MPSCommonDataKeys" />
+              </node>
+              <node concept="liA8E" id="2EmVdCCM9g9" role="2OqNvi">
+                <ref role="37wK5l" to="qkt:~DataKey.getData(com.intellij.openapi.actionSystem.DataContext)" resolve="getData" />
+                <node concept="37vLTw" id="2EmVdCCM9ga" role="37wK5m">
+                  <ref role="3cqZAo" node="4ieOWnFWOSW" resolve="dataContext" />
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="2EmVdCCM9g6" role="10QFUM">
+              <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4ieOWnFWOTa" role="3clF45">
+        <ref role="3uigEE" to="k3nr:~MPSFileNodeEditor" resolve="MPSFileNodeEditor" />
+      </node>
+      <node concept="3Tm1VV" id="4ieOWnFWOT9" role="1B3o_S" />
     </node>
     <node concept="3Tm1VV" id="6HRhZeXDGGo" role="1B3o_S" />
     <node concept="3UR2Jj" id="6HRhZeXG7rR" role="lGtFl">


### PR DESCRIPTION
Add an attribute to provide lifecycle (before/after tests) methods to editor test cases.

Also rewrite the generator of FileNodeEditorExpression without reflection. The type of the expression is changed from MPSFileNodeEditor to the more abstract FileEditor.