### PR TITLE
linenumbers: silence 'Do not create alarm without coroutineScope' warning

### DIFF
--- a/code/linenumbers/de.itemis.mps.linenumbers/models/de.itemis.mps.linenumbers.plugin.mps
+++ b/code/linenumbers/de.itemis.mps.linenumbers/models/de.itemis.mps.linenumbers.plugin.mps
@@ -142,6 +142,10 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -5279,7 +5283,11 @@
       <node concept="2ShNRf" id="2wnTj_dgd0X" role="33vP2m">
         <node concept="1pGfFk" id="2wnTj_dgkfL" role="2ShVmc">
           <property role="373rjd" value="true" />
-          <ref role="37wK5l" to="9w4s:~Alarm.&lt;init&gt;()" resolve="Alarm" />
+          <ref role="37wK5l" to="9w4s:~Alarm.&lt;init&gt;(com.intellij.util.Alarm$ThreadToUse)" resolve="Alarm" />
+          <node concept="Rm8GO" id="5idiv9dBRR4" role="37wK5m">
+            <ref role="Rm8GQ" to="9w4s:~Alarm$ThreadToUse.SWING_THREAD" resolve="SWING_THREAD" />
+            <ref role="1Px2BO" to="9w4s:~Alarm$ThreadToUse" resolve="Alarm.ThreadToUse" />
+          </node>
         </node>
       </node>
     </node>


### PR DESCRIPTION
We still create alarm without coroutineScope because we don't want to mess with Kotlin. Passing ThreadToUse explicitly at least disables the warning.