### PR TITLE
fix(grammarcells): in some cases the cell creation failed when a property attribute was attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## May 2026
+
+### Fixed
+
+-  *de.slisson.mps.richtext.customcell* Add new switch for CellModel_CustomFactory to deal with cases where the cell creation failed when a property attribute was attached
+
 ## March 2026
 
 ### Added

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/editor.mps
@@ -44,6 +44,7 @@
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
+      <concept id="1134379236839" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedPropertyCell" flags="ng" index="uhnNJ" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -4092,6 +4093,27 @@
         <property role="3F0ifm" value=";" />
       </node>
       <node concept="l2Vlx" id="7NCbR4gZtWb" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2ab_dvCjTXh">
+    <ref role="1XX52x" to="ibwz:2ab_dvCjTpB" resolve="TEST_AnnotationOnRootProperty_Property" />
+    <node concept="1kIj98" id="2ab_dvCjU2L" role="2wV5jI">
+      <node concept="3F0A7n" id="2ab_dvCjU4Z" role="1kIj9b">
+        <ref role="1NtTu8" to="ibwz:2ab_dvCjTOC" resolve="propertyA" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2ab_dvCoZ5n">
+    <ref role="1XX52x" to="ibwz:2ab_dvCjSNN" resolve="TEST_AnnotationOnRootProperty_Annotation" />
+    <node concept="3EZMnI" id="2ab_dvCoZjt" role="2wV5jI">
+      <node concept="3F0ifn" id="2ab_dvCoZjx" role="3EZMnx">
+        <property role="3F0ifm" value="$/" />
+      </node>
+      <node concept="uhnNJ" id="2ab_dvCoZYM" role="3EZMnx" />
+      <node concept="3F0ifn" id="2ab_dvCoZq2" role="3EZMnx">
+        <property role="3F0ifm" value="/" />
+      </node>
+      <node concept="l2Vlx" id="2ab_dvCoZjw" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
+++ b/code/grammarcells/languages/com.mbeddr.mpsutil.grammarcells.sandboxlang/models/com/mbeddr/mpsutil/grammarcells/sandboxlang/structure.mps
@@ -17,11 +17,18 @@
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
+      <concept id="6054523464627964745" name="jetbrains.mps.lang.structure.structure.AttributeInfo_AttributedConcept" flags="ng" index="trNpa">
+        <reference id="6054523464627965081" name="concept" index="trN6q" />
+      </concept>
       <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
         <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
       </concept>
       <concept id="1082978499127" name="jetbrains.mps.lang.structure.structure.ConstrainedDataTypeDeclaration" flags="ng" index="Az7Fb">
         <property id="1083066089218" name="constraint" index="FLfZY" />
+      </concept>
+      <concept id="2992811758677295509" name="jetbrains.mps.lang.structure.structure.AttributeInfo" flags="ng" index="M6xJ_">
+        <property id="7588428831955550663" name="role" index="Hh88m" />
+        <child id="7588428831947959310" name="attributed" index="EQaZv" />
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
@@ -59,6 +66,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -987,6 +995,27 @@
     </node>
     <node concept="PrWs8" id="7NCbR4gZtKA" role="PzmwI">
       <ref role="PrY4T" node="1x69AmkdYA2" resolve="IStatement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2ab_dvCjSNN">
+    <property role="EcuMT" value="2489246874088738035" />
+    <property role="TrG5h" value="TEST_AnnotationOnRootProperty_Annotation" />
+    <ref role="1TJDcQ" to="tpck:2ULFgo8_XDm" resolve="PropertyAttribute" />
+    <node concept="M6xJ_" id="2ab_dvCjTli" role="lGtFl">
+      <property role="Hh88m" value="propertyAttribute" />
+      <node concept="trNpa" id="2ab_dvCtW_K" role="EQaZv">
+        <ref role="trN6q" node="2ab_dvCjTpB" resolve="TEST_AnnotationOnRootProperty_Property" />
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2ab_dvCjTpB">
+    <property role="EcuMT" value="2489246874088740455" />
+    <property role="TrG5h" value="TEST_AnnotationOnRootProperty_Property" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2ab_dvCjTOC" role="1TKVEl">
+      <property role="IQ2nx" value="2489246874088742184" />
+      <property role="TrG5h" value="propertyA" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
   </node>
 </model>

--- a/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
+++ b/code/grammarcells/solutions/com.mbeddr.mpsutil.grammarcells.tests/models/com/mbeddr/mpsutil/grammarcells/tests@tests.mps
@@ -25,6 +25,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -180,6 +181,10 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
+      <concept id="3364660638048049750" name="jetbrains.mps.lang.core.structure.PropertyAttribute" flags="ng" index="A9Btg">
+        <property id="1757699476691236117" name="name_DebugInfo" index="2qtEX9" />
+        <property id="1341860900487648621" name="propertyId" index="P4ACc" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -250,6 +255,10 @@
         <property id="5465812603479727090" name="flagA" index="34AmLC" />
         <child id="5465812603479727085" name="childA" index="34AmLR" />
       </concept>
+      <concept id="2489246874088740455" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Property" flags="ng" index="3aL0aK">
+        <property id="2489246874088742184" name="propertyA" index="3aL0BZ" />
+      </concept>
+      <concept id="2489246874088738035" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Annotation" flags="ng" index="3aL1w$" />
       <concept id="1811135247170681488" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.StmtContainerAncestor" flags="ng" index="1eV$HT" />
       <concept id="8622846647855906237" name="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_optionalInComponent" flags="ng" index="1hHfNE">
         <child id="8622846647855952043" name="optionalChildren" index="1hHr7W" />
@@ -4195,6 +4204,174 @@
         </node>
         <node concept="2cssZD" id="7NCbR4hezv9" role="2cssWm" />
       </node>
+    </node>
+  </node>
+  <node concept="LiM7Y" id="2ab_dvCoYvV">
+    <property role="TrG5h" value="AnnotationOnRootProperty" />
+    <node concept="1qefOq" id="2ab_dvCoYJg" role="25YQCW">
+      <node concept="3aL0aK" id="2ab_dvCoYQ0" role="1qenE9">
+        <property role="3aL0BZ" value="abc" />
+        <node concept="3aL1w$" id="2ab_dvCu03O" role="lGtFl">
+          <property role="2qtEX9" value="propertyA" />
+          <property role="P4ACc" value="a257f68c-93a3-47b0-838b-6905dd9c20f6/2489246874088740455/2489246874088742184" />
+          <node concept="LIFWc" id="2ab_dvCHZBe" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Constant_p92ya0_a0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2ab_dvCu74g" role="LjaKd">
+      <node concept="3clFbH" id="2ab_dvCu74h" role="3cqZAp" />
+      <node concept="3SKdUt" id="2ab_dvCua4M" role="3cqZAp">
+        <node concept="1PaTwC" id="2ab_dvCua4N" role="1aUNEU">
+          <node concept="3oM_SD" id="2ab_dvCuaHx" role="1PaTwD">
+            <property role="3oM_SC" value="The" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaMT" role="1PaTwD">
+            <property role="3oM_SC" value="editor" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaP4" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaP_" role="1PaTwD">
+            <property role="3oM_SC" value="throwing" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaS0" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaUr" role="1PaTwD">
+            <property role="3oM_SC" value="following" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaWA" role="1PaTwD">
+            <property role="3oM_SC" value="exception" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCuaZ1" role="1PaTwD">
+            <property role="3oM_SC" value="while" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCub1s" role="1PaTwD">
+            <property role="3oM_SC" value="trying" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCub3R" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCub62" role="1PaTwD">
+            <property role="3oM_SC" value="create" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCub8t" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubaS" role="1PaTwD">
+            <property role="3oM_SC" value="cells:" />
+          </node>
+        </node>
+      </node>
+      <node concept="3SKdUt" id="2ab_dvCubha" role="3cqZAp">
+        <node concept="1PaTwC" id="2ab_dvCubhb" role="1aUNEU">
+          <node concept="3oM_SD" id="2ab_dvCubvS" role="1PaTwD">
+            <property role="3oM_SC" value="java.lang.AssertionError:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvT" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;Not" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvU" role="1PaTwD">
+            <property role="3oM_SC" value="big&quot;" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvV" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvW" role="1PaTwD">
+            <property role="3oM_SC" value="found." />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvX" role="1PaTwD">
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvY" role="1PaTwD">
+            <property role="3oM_SC" value="cell:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubvZ" role="1PaTwD">
+            <property role="3oM_SC" value="Collection_p92ya0_a," />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw0" role="1PaTwD">
+            <property role="3oM_SC" value="node:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw1" role="1PaTwD">
+            <property role="3oM_SC" value="(instance" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw2" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw3" role="1PaTwD">
+            <property role="3oM_SC" value="TEST_AnnotationOnRootProperty_Annotation)," />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw4" role="1PaTwD">
+            <property role="3oM_SC" value="concept:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw5" role="1PaTwD">
+            <property role="3oM_SC" value="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Annotation." />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw6" role="1PaTwD">
+            <property role="3oM_SC" value="Found" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw7" role="1PaTwD">
+            <property role="3oM_SC" value="cell:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw8" role="1PaTwD">
+            <property role="3oM_SC" value="property_propertyA," />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubw9" role="1PaTwD">
+            <property role="3oM_SC" value="node:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwa" role="1PaTwD">
+            <property role="3oM_SC" value="(instance" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwb" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwc" role="1PaTwD">
+            <property role="3oM_SC" value="TEST_AnnotationOnRootProperty_Property)," />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwd" role="1PaTwD">
+            <property role="3oM_SC" value="concept:" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwe" role="1PaTwD">
+            <property role="3oM_SC" value="com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Property" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwf" role="1PaTwD">
+            <property role="3oM_SC" value="&#9;at" />
+          </node>
+          <node concept="3oM_SD" id="2ab_dvCubwg" role="1PaTwD">
+            <property role="3oM_SC" value="jetbrains.mps.nodeEditor.EditorManager.getUnwrappedNodeBigCell(EditorManager.java:472)" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2ab_dvCub$Q" role="3cqZAp" />
+      <node concept="3vlDli" id="2ab_dvCHi_V" role="3cqZAp">
+        <node concept="Xl_RD" id="2ab_dvCHiFm" role="3tpDZB">
+          <property role="Xl_RC" value="$/ abc /" />
+        </node>
+        <node concept="2OqwBi" id="2ab_dvCHhq1" role="3tpDZA">
+          <node concept="2OqwBi" id="2ab_dvCHgVl" role="2Oq$k0">
+            <node concept="2OqwBi" id="2ab_dvCHfT9" role="2Oq$k0">
+              <node concept="369mXd" id="2ab_dvCHd_K" role="2Oq$k0" />
+              <node concept="liA8E" id="2ab_dvCHgGD" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2ab_dvCHhgA" role="2OqNvi">
+              <ref role="37wK5l" to="f4zo:~EditorCell.renderText()" resolve="renderText" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2ab_dvCHhBT" role="2OqNvi">
+            <ref role="37wK5l" to="cj4x:~TextBuilder.getText()" resolve="getText" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2ab_dvCua1c" role="3cqZAp" />
+      <node concept="3clFbH" id="2ab_dvCu76G" role="3cqZAp" />
     </node>
   </node>
 </model>

--- a/code/richtext/languages/de.slisson.richtext.customcell/generator/template/main@generator.mps
+++ b/code/richtext/languages/de.slisson.richtext.customcell/generator/template/main@generator.mps
@@ -130,6 +130,10 @@
         <child id="1167328349397" name="reductionMappingRule" index="3acgRq" />
       </concept>
       <concept id="1168559333462" name="jetbrains.mps.lang.generator.structure.TemplateDeclarationReference" flags="ln" index="j$656" />
+      <concept id="1112730859144" name="jetbrains.mps.lang.generator.structure.TemplateSwitch" flags="ig" index="jVnub">
+        <reference id="1112820671508" name="modifiedSwitch" index="phYkn" />
+        <child id="1167340453568" name="reductionMappingRule" index="3aUrZf" />
+      </concept>
       <concept id="1095672379244" name="jetbrains.mps.lang.generator.structure.TemplateFragment" flags="ng" index="raruj">
         <reference id="1200916687663" name="labelDeclaration" index="2sdACS" />
       </concept>
@@ -139,6 +143,7 @@
       <concept id="1167168920554" name="jetbrains.mps.lang.generator.structure.BaseMappingRule_Condition" flags="in" index="30G5F_" />
       <concept id="1167169188348" name="jetbrains.mps.lang.generator.structure.TemplateFunctionParameter_sourceNode" flags="nn" index="30H73N" />
       <concept id="1167169308231" name="jetbrains.mps.lang.generator.structure.BaseMappingRule" flags="ng" index="30H$t8">
+        <property id="1167272244852" name="applyToConceptInheritors" index="36QftV" />
         <reference id="1167169349424" name="applicableConcept" index="30HIoZ" />
         <child id="1167169362365" name="conditionFunction" index="30HLyM" />
       </concept>
@@ -186,6 +191,9 @@
       <concept id="1204851882688" name="jetbrains.mps.lang.smodel.structure.LinkRefQualifier" flags="ng" index="26LbJo">
         <reference id="1204851882689" name="link" index="26LbJp" />
       </concept>
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
@@ -193,6 +201,10 @@
       <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
         <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
@@ -571,6 +583,34 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="h9B3Loo" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="jVnub" id="2ab_dvCC83s">
+    <property role="TrG5h" value="switch_SetBigCellProperty_CustomFactory" />
+    <ref role="phYkn" to="tpc3:4AbVKpmvegw" resolve="SetBigCellProperty" />
+    <node concept="3aamgX" id="4AbVKpmw2bT" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="5mdd:2af7$rtrDWk" resolve="CellModel_CustomFactory" />
+      <node concept="30G5F_" id="4AbVKpmzcw5" role="30HLyM">
+        <node concept="3clFbS" id="4AbVKpmzcw6" role="2VODD2">
+          <node concept="3clFbF" id="4AbVKpmzcEB" role="3cqZAp">
+            <node concept="2OqwBi" id="4AbVKpmzcEC" role="3clFbG">
+              <node concept="1mIQ4w" id="4AbVKpmzcED" role="2OqNvi">
+                <node concept="chp4Y" id="4AbVKpmzcEE" role="cj9EA">
+                  <ref role="cht4Q" to="tpc2:fA4kQeF" resolve="ConceptEditorDeclaration" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4AbVKpmzcEF" role="2Oq$k0">
+                <node concept="1mfA1w" id="4AbVKpmzcEG" role="2OqNvi" />
+                <node concept="30H73N" id="4AbVKpmzcEH" role="2Oq$k0" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="j$656" id="4AbVKpmzVFv" role="1lVwrX">
+        <ref role="v9R2y" to="tpc3:4AbVKpmzP_j" resolve="SetBigCellForImportedCell" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -236,6 +236,87 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="1gkZC7ksSqH" role="15bmVC">
+      <node concept="15ShDW" id="1gkZC7ksSqE" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAy/May" />
+        <property role="15ShDw" value="2026" />
+      </node>
+      <node concept="15bAme" id="1gkZC7ksSqF" role="15bAlL">
+        <node concept="2DRihI" id="1gkZC7ksSqG" role="15bAlk">
+          <node concept="3oM_SD" id="1gkZC7ksSyu" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="15Ami3" id="1gkZC7ksSS1" role="1PaTwD">
+            <node concept="37shsh" id="1gkZC7ksSS3" role="15Aodc">
+              <node concept="1dCxOk" id="1gkZC7ksSS9" role="37shsm">
+                <property role="1XweGW" value="52733268-be24-4f5f-ab84-a73b7c0c03b0" />
+                <property role="1XxBO9" value="de.slisson.mps.richtext.customcell" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksT0a" role="1PaTwD">
+            <property role="3oM_SC" value="Add" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZp" role="1PaTwD">
+            <property role="3oM_SC" value="new" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSy$" role="1PaTwD">
+            <property role="3oM_SC" value="switch" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSyx" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSDH" role="1PaTwD">
+            <property role="3oM_SC" value="CellModel_CustomFactory" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSDI" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZq" role="1PaTwD">
+            <property role="3oM_SC" value="deal" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZr" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZt" role="1PaTwD">
+            <property role="3oM_SC" value="cases" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZC" role="1PaTwD">
+            <property role="3oM_SC" value="where" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZu" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZv" role="1PaTwD">
+            <property role="3oM_SC" value="cell" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZw" role="1PaTwD">
+            <property role="3oM_SC" value="creation" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZx" role="1PaTwD">
+            <property role="3oM_SC" value="failed" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZy" role="1PaTwD">
+            <property role="3oM_SC" value="when" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZz" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZ$" role="1PaTwD">
+            <property role="3oM_SC" value="property" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZ_" role="1PaTwD">
+            <property role="3oM_SC" value="attribute" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZA" role="1PaTwD">
+            <property role="3oM_SC" value="was" />
+          </node>
+          <node concept="3oM_SD" id="1gkZC7ksSZB" role="1PaTwD">
+            <property role="3oM_SC" value="attached" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="1vwG8eaqFzK" role="15bmVC">
       <node concept="15ShDW" id="1vwG8eaqFzH" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgAp/March" />


### PR DESCRIPTION
For example, if a concept editor consists of a single property cell wrapped with a wrapper cell, and a property attribute was attached, then `setBigCell(true)` was called on the cell of the attribute and not on the property cells.
This resulted in the following exception:

```
java.lang.AssertionError: "Not big" cell found. Original cell: Collection_p92ya0_a, node: (instance of TEST_AnnotationOnRootProperty_Annotation), concept: com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Annotation. Found cell: property_propertyA, node: (instance of TEST_AnnotationOnRootProperty_Property), concept: com.mbeddr.mpsutil.grammarcells.sandboxlang.structure.TEST_AnnotationOnRootProperty_Property
	at jetbrains.mps.nodeEditor.EditorManager.getUnwrappedNodeBigCell(EditorManager.java:472)
	at jetbrains.mps.nodeEditor.EditorManager.createEditorCell_internal(EditorManager.java:419)
	at jetbrains.mps.nodeEditor.EditorManager.createEditorCellWithoutAttributes(EditorManager.java:259)
	at jetbrains.mps.nodeEditor.EditorManager.createEditorCell(EditorManager.java:272)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.lambda$updateChildNodeCell$2(UpdateSessionImpl.java:225)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.runWithExplicitEditorHints(UpdateSessionImpl.java:347)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.updateChildNodeCell(UpdateSessionImpl.java:225)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.updateChildNodeCell(UpdateSessionImpl.java:214)
```