### PR TITLE
ci(renovate): pin xtext.xbase.lib to <2.43.0 on maintenance/mps20241

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,14 @@
     },
 
     {
+      // xtext 2.43+ is compiled for Java 21, but MPS 2024.1 runs tests on the bundled JBR 17, so xbase.lib (a runtime
+      // dependency of the bundled ELK) must stay on the last Java-17 build. Later branches run on newer JBRs and can update.
+      "matchPackageNames": ["org.eclipse.xtext:org.eclipse.xtext.xbase.lib"],
+      "matchBaseBranches": ["maintenance/mps20241"],
+      "allowedVersions": "< 2.43.0"
+    },
+
+    {
       "matchPackageNames": ["com.miglayout*"],
       "groupName": "miglayout"
     },


### PR DESCRIPTION
## Problem

The PR-validation build on `maintenance/mps20241` fails ([example build](https://mps.builds.itemis.cloud/buildConfiguration/Mbeddr2_Mbeddr_Gradle_MpsExtensions_PullRequests/394413)) with:

```
java.lang.UnsupportedClassVersionError: org/eclipse/xtext/xbase/lib/CollectionLiterals
has been compiled by a more recent version of the Java Runtime (class file version 65.0),
this version of the Java Runtime only recognizes class file versions up to 61.0
```

Renovate PR JetBrains/MPS-extensions#1818 bumps `org.eclipse.xtext:org.eclipse.xtext.xbase.lib` 2.42.0 → 2.43.0. Verified against Maven Central:

| Version | Class file version | Runtime |
|---|---|---|
| `xbase.lib:2.42.0` | 61 | Java 17 |
| `xbase.lib:2.43.0` | 65 | Java 21 |

`xbase.lib` is bundled into the diagram runtime as a runtime dependency of ELK. MPS 2024.1 runs its tests on the bundled JBR 17, so 2.43.0 cannot load → ELK's `LayeredMetaDataProvider` fails to initialize → every diagram editor test crashes.

## Fix

Add a branch-scoped renovate rule constraining `xbase.lib` to `< 2.43.0` **only** on `maintenance/mps20241`, using the same `matchBaseBranches` mechanism already used for JBR and Python. `master` and later maintenance branches (e.g. `maintenance/mps20251`) run on newer JBRs and can still update to 2.43.0+.

The `< 2.43.0` ceiling is tied to the package's Java baseline (not the minor number), so future Java-21 releases (2.43.x / 2.44.x) stay blocked on this branch too.

Once merged, renovate will stop re-proposing the bump for `maintenance/mps20241`; PR #1818 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)