### PR TITLE
build: add SCM information to the POM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -316,6 +316,12 @@ publishing {
             artifactId = "extensions"
 
             pom {
+                scm {
+                    url = "https://github.com/JetBrains/MPS-extensions"
+                    connection = "scm:git:git://github.com/JetBrains/MPS-extensions.git"
+                    developerConnection = "scm:git:ssh://git@github.com/JetBrains/MPS-extensions.git"
+                    tag = "HEAD"
+                }
                 licenses {
                     // official SPDX identifier
                     // see https://spdx.org/licenses/ for list


### PR DESCRIPTION
Add SCM information to help automated license scanners.