### PR TITLE
fix(shadowmodels): only run commands against an initialized project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## June 2026
+
+### Fixed
+
+- *de.q60.mps.shadowmodels.runtime* [SM_CommandHelper](http://127.0.0.1:63320/node?ref=r%3A97875f9c-321e-405e-a344-6d3deab2bdba%28de.q60.mps.shadowmodels.runtime.smodel%29%2F7709076119916772664) now only runs commands on fully initialized projects.
+
 ## May 2026
 
 ### Fixed

--- a/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/smodel.mps
+++ b/code/shadowmodels/solutions/de.q60.mps.shadowmodels.runtime/models/smodel.mps
@@ -61,6 +61,8 @@
     <import index="ouht" ref="cc99dce1-49f3-4392-8dbf-e22ca47bd0af/java:kotlin.jvm.functions(org.modelix.model.api/)" />
     <import index="y071" ref="r:57711a24-29ad-4bd9-8062-d4259c0a2ba5(de.q60.mps.logging.runtime)" />
     <import index="z1o6" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.serviceContainer(MPS.IDEA/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
     <import index="jh6v" ref="r:f2f39a18-fd23-4090-b7f2-ba8da340eec2(org.modelix.model.repositoryconcepts.structure)" implicit="true" />
     <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
@@ -18115,7 +18117,74 @@
                 <node concept="37vLTw" id="6HiBqPCpGBx" role="2Oq$k0">
                   <ref role="3cqZAo" node="6HiBqPCpGBn" resolve="projects" />
                 </node>
-                <node concept="1uHKPH" id="6HiBqPCpGBy" role="2OqNvi" />
+                <node concept="1z4cxt" id="7WYWMBv0tCt" role="2OqNvi">
+                  <node concept="1bVj0M" id="7WYWMBv0tCv" role="23t8la">
+                    <node concept="3clFbS" id="7WYWMBv0tCw" role="1bW5cS">
+                      <node concept="3cpWs8" id="7WYWMBv0xsu" role="3cqZAp">
+                        <node concept="3cpWsn" id="7WYWMBv0xsv" role="3cpWs9">
+                          <property role="TrG5h" value="ideaProject" />
+                          <node concept="3uibUv" id="7WYWMBv0wWp" role="1tU5fm">
+                            <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+                          </node>
+                          <node concept="2YIFZM" id="7WYWMBv0xsw" role="33vP2m">
+                            <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                            <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                            <node concept="37vLTw" id="7WYWMBv0xsx" role="37wK5m">
+                              <ref role="3cqZAo" node="7WYWMBv0tCx" resolve="it" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3SKdUt" id="7WYWMBv0WTX" role="3cqZAp">
+                        <node concept="1PaTwC" id="7WYWMBv0WTY" role="1aUNEU">
+                          <node concept="3oM_SD" id="7WYWMBv0ZGH" role="1PaTwD">
+                            <property role="3oM_SC" value="We" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv108C" role="1PaTwD">
+                            <property role="3oM_SC" value="only" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv108E" role="1PaTwD">
+                            <property role="3oM_SC" value="want" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv108F" role="1PaTwD">
+                            <property role="3oM_SC" value="an" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv10pZ" role="1PaTwD">
+                            <property role="3oM_SC" value="initialized" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv10Fj" role="1PaTwD">
+                            <property role="3oM_SC" value="IDEA" />
+                          </node>
+                          <node concept="3oM_SD" id="7WYWMBv12fQ" role="1PaTwD">
+                            <property role="3oM_SC" value="project" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="7WYWMBv0tU6" role="3cqZAp">
+                        <node concept="1Wc70l" id="7WYWMBv0Ewr" role="3clFbG">
+                          <node concept="3y3z36" id="7WYWMBv0G8B" role="3uHU7B">
+                            <node concept="10Nm6u" id="7WYWMBv0Gqq" role="3uHU7w" />
+                            <node concept="37vLTw" id="7WYWMBv0FyI" role="3uHU7B">
+                              <ref role="3cqZAo" node="7WYWMBv0xsv" resolve="ideaProject" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="7WYWMBv0uYb" role="3uHU7w">
+                            <node concept="37vLTw" id="7WYWMBv0xsy" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7WYWMBv0xsv" resolve="ideaProject" />
+                            </node>
+                            <node concept="liA8E" id="7WYWMBv0wx0" role="2OqNvi">
+                              <ref role="37wK5l" to="4nm9:~Project.isInitialized()" resolve="isInitialized" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="7WYWMBv0tCx" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7WYWMBv0tCy" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
+++ b/code/solutions/de.itemis.mps.extensions.changelog/de.itemis.mps.extensions.changelog.msd
@@ -15,6 +15,7 @@
     <dependency reexport="false">9d69e719-78c8-4286-90db-fb19c107d049(com.mbeddr.mpsutil.grammarcells)</dependency>
     <dependency reexport="false">b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)</dependency>
     <dependency reexport="false">953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)</dependency>
+    <dependency reexport="false">e52a4835-844d-46a1-99f8-c06129db796f(de.q60.mps.shadowmodels.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:638c9345-2613-49dc-b2ae-8ceadef24141:de.itemis.mps.changelog" version="0" />
@@ -43,6 +44,9 @@
     <module reference="b4f35ed8-45af-4efa-abe4-00ac26956e69(com.mbeddr.mpsutil.grammarcells.runtimelang)" version="0" />
     <module reference="b92f861d-0184-446d-b88b-6dcf0e070241(com.mbeddr.mpsutil.intentions)" version="0" />
     <module reference="12cc529a-5bc1-40a0-b44a-d814ba237eae(de.itemis.mps.extensions.changelog)" version="0" />
+    <module reference="95085166-3236-4dd7-bd8e-e753c8d20885(de.q60.mps.incremental.runtime)" version="0" />
+    <module reference="18463265-6d45-4514-82f1-cf7eb1222492(de.q60.mps.polymorphicfunctions.runtime)" version="0" />
+    <module reference="e52a4835-844d-46a1-99f8-c06129db796f(de.q60.mps.shadowmodels.runtime)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
@@ -59,6 +63,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="953e4089-c643-455b-8629-636de7085d1c(nl.f1re.testing)" version="0" />
+    <module reference="cc99dce1-49f3-4392-8dbf-e22ca47bd0af(org.modelix.model.api)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -16,6 +16,7 @@
     <import index="tegv" ref="r:b91d2412-f094-4e55-8db6-3c782d7edc40(com.mbeddr.mpsutil.intentions.structure)" />
     <import index="kz9k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.navigation(MPS.Editor/)" />
     <import index="rl2y" ref="r:8dfc935f-f6d1-4e4d-bfff-80832f08c4eb(nl.f1re.testing.structure)" />
+    <import index="l6bp" ref="r:97875f9c-321e-405e-a344-6d3deab2bdba(de.q60.mps.shadowmodels.runtime.smodel)" />
   </imports>
   <registry>
     <language id="638c9345-2613-49dc-b2ae-8ceadef24141" name="de.itemis.mps.changelog">
@@ -233,6 +234,55 @@
         </node>
         <node concept="3oM_SD" id="1$KnWE8iTo8" role="1PaTwD">
           <property role="3oM_SC" value="month." />
+        </node>
+      </node>
+    </node>
+    <node concept="15bmVD" id="7WYWMBv164i" role="15bmVC">
+      <node concept="15ShDW" id="7WYWMBv164f" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAC/June" />
+        <property role="15ShDw" value="2026" />
+      </node>
+      <node concept="15bAme" id="7WYWMBv164g" role="15bAlL">
+        <node concept="2DRihI" id="7WYWMBv164h" role="15bAlk">
+          <node concept="15Ami3" id="7WYWMBv164j" role="1PaTwD">
+            <node concept="37shsh" id="7WYWMBv164k" role="15Aodc">
+              <node concept="1dCxOk" id="7WYWMBv164p" role="37shsm">
+                <property role="1XweGW" value="e52a4835-844d-46a1-99f8-c06129db796f" />
+                <property role="1XxBO9" value="de.q60.mps.shadowmodels.runtime" />
+              </node>
+            </node>
+          </node>
+          <node concept="15BRQy" id="7WYWMBv164v" role="1PaTwD">
+            <node concept="2tJFMh" id="7WYWMBv164x" role="15BRQ_">
+              <node concept="ZC_QK" id="7WYWMBv16c9" role="2tJFKM">
+                <ref role="2aWVGs" to="l6bp:6FW8YbU5vOS" resolve="SM_CommandHelper" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16DB" role="1PaTwD">
+            <property role="3oM_SC" value="now" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16DC" role="1PaTwD">
+            <property role="3oM_SC" value="only" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16qT" role="1PaTwD">
+            <property role="3oM_SC" value="runs" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16qU" role="1PaTwD">
+            <property role="3oM_SC" value="commands" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16qV" role="1PaTwD">
+            <property role="3oM_SC" value="on" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16qW" role="1PaTwD">
+            <property role="3oM_SC" value="fully" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16yi" role="1PaTwD">
+            <property role="3oM_SC" value="initialized" />
+          </node>
+          <node concept="3oM_SD" id="7WYWMBv16yh" role="1PaTwD">
+            <property role="3oM_SC" value="projects." />
+          </node>
         </node>
       </node>
     </node>


### PR DESCRIPTION
Running commands against an uninitialized project causes an unrelated third-party plugin to fail because it attaches a command listener that then fires too early and tries to retrieve a component from the uninitialized project, causing an exception.