### PR TITLE
Use JBR marker artifact for the JBR version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("de.itemis.mps.gradle.launcher") version "2.8.0.+"
     id("org.cyclonedx.bom") version "3.2.4"
 
-    id("com.specificlanguages.mps") version "2.0.1"
+    id("com.specificlanguages.mps") version "2.1.0"
 }
 
 // Detect if we are in a CI build

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,6 @@
+[versions]
+mps = "2024.1.6"
+
 [libraries]
-mps = "com.jetbrains:mps:2024.1.6"
-jbr = "com.jetbrains.jdk:jbr_jcef:17.0.11-b1207.30"
+mps = { module = "com.jetbrains:mps", version.ref = "mps" }
+jbr = { module = "com.jetbrains.mps:mps-jbr", version.ref = "mps" }


### PR DESCRIPTION
Keep MPS and JBR versions in sync automatically.