### PR TITLE
fix(projectview): expand a tree node without asking for the write intent lock

### DIFF
--- a/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
+++ b/code/projectview/com.mbeddr.mpsutil.projectview.runtime/models/com/mbeddr/mpsutil/projectview/runtime/tree.mps
@@ -9352,25 +9352,52 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="41joaxK2OVY" role="3cqZAp">
-                        <node concept="2YIFZM" id="6B579NGiWvQ" role="3clFbG">
+                      <node concept="3clFbJ" id="4R3dM06q7cW" role="3cqZAp">
+                        <node concept="2YIFZM" id="4R3dM06q7cZ" role="3clFbw">
                           <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
-                          <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
-                          <node concept="1bVj0M" id="6B579NGiWvR" role="37wK5m">
-                            <node concept="3clFbS" id="6B579NGiWvS" role="1bW5cS">
-                              <node concept="3clFbJ" id="6B579NGiWvT" role="3cqZAp">
-                                <node concept="3clFbS" id="6B579NGiWvU" role="3clFbx">
-                                  <node concept="3clFbF" id="6B579NGiWvV" role="3cqZAp">
-                                    <node concept="1rXfSq" id="6B579NGiWvW" role="3clFbG">
-                                      <ref role="37wK5l" node="Ggg0Z6Y9u_" resolve="loadChildElements" />
-                                      <node concept="37vLTw" id="6B579NGiWvX" role="37wK5m">
-                                        <ref role="3cqZAo" node="Ggg0Z6YAxq" resolve="queryResult" />
+                          <ref role="37wK5l" to="3a50:~ThreadUtils.isInEDT()" resolve="isInEDT" />
+                        </node>
+                        <node concept="3clFbS" id="4R3dM06q7d0" role="3clFbx">
+                          <node concept="3clFbJ" id="4R3dM06q7d1" role="3cqZAp">
+                            <node concept="1rXfSq" id="4R3dM06q7d4" role="3clFbw">
+                              <ref role="37wK5l" node="Ggg0Z743sM" resolve="isInTree" />
+                            </node>
+                            <node concept="3clFbS" id="4R3dM06q7d5" role="3clFbx">
+                              <node concept="3clFbF" id="4R3dM06q7d6" role="3cqZAp">
+                                <node concept="1rXfSq" id="4R3dM06q7d8" role="3clFbG">
+                                  <ref role="37wK5l" node="Ggg0Z6Y9u_" resolve="loadChildElements" />
+                                  <node concept="37vLTw" id="4R3dM06q7d9" role="37wK5m">
+                                    <ref role="3cqZAo" node="Ggg0Z6YAxq" resolve="queryResult" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="4R3dM06q7da" role="9aQIa">
+                          <node concept="3clFbS" id="4R3dM06q7dc" role="9aQI4">
+                            <node concept="3clFbF" id="4R3dM06q7dd" role="3cqZAp">
+                              <node concept="2YIFZM" id="4R3dM06q7df" role="3clFbG">
+                                <ref role="1Pybhc" to="3a50:~ThreadUtils" resolve="ThreadUtils" />
+                                <ref role="37wK5l" to="3a50:~ThreadUtils.runInUIThreadAndWait(java.lang.Runnable)" resolve="runInUIThreadAndWait" />
+                                <node concept="1bVj0M" id="4R3dM06q7dg" role="37wK5m">
+                                  <node concept="3clFbS" id="4R3dM06q7di" role="1bW5cS">
+                                    <node concept="3clFbJ" id="4R3dM06q7dj" role="3cqZAp">
+                                      <node concept="1rXfSq" id="4R3dM06q7dm" role="3clFbw">
+                                        <ref role="37wK5l" node="Ggg0Z743sM" resolve="isInTree" />
+                                      </node>
+                                      <node concept="3clFbS" id="4R3dM06q7dn" role="3clFbx">
+                                        <node concept="3clFbF" id="4R3dM06q7do" role="3cqZAp">
+                                          <node concept="1rXfSq" id="4R3dM06q7dq" role="3clFbG">
+                                            <ref role="37wK5l" node="Ggg0Z6Y9u_" resolve="loadChildElements" />
+                                            <node concept="37vLTw" id="4R3dM06q7dr" role="37wK5m">
+                                              <ref role="3cqZAo" node="Ggg0Z6YAxq" resolve="queryResult" />
+                                            </node>
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
-                                </node>
-                                <node concept="1rXfSq" id="6B579NGiWvY" role="3clFbw">
-                                  <ref role="37wK5l" node="Ggg0Z743sM" resolve="isInTree" />
                                 </node>
                               </node>
                             </node>


### PR DESCRIPTION
Fixes #1847.

## What was broken

Expanding any not-already-expanded node in a custom project view threw:

```
java.lang.IllegalStateException: WriteIntentReadAction can not be called from ReadAction
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runWriteIntentReadAction(NestedLocksThreadingSupport.kt:699)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:1094)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:593)
	at jetbrains.mps.ide.ThreadUtils.runInUIThreadAndWait(ThreadUtils.java:44)
	at ...CustomTreeNode.lambda$queryAndLoadChildren$0(CustomTreeNode.java:120)
```

Reported against MPS 2026.1 / extensions 2026.1.3635.9adafe9; fine on MPS 2025.2.1.

## Why

`CustomProjectTree.doInit` wraps every node initialization in a `ModelReadRunnable`, so the synchronous branch of `CustomTreeNode.doInit` → `queryAndLoadChildren` runs **on the EDT inside a read action**. From there it called `ThreadUtils.runInUIThreadAndWait`, which unconditionally goes through `Application.invokeAndWait` — and that acquires the write-intent lock even when it does not have to switch threads.

This used to work by accident. `IdeEventQueue` dispatched every mouse event inside `runPreventiveWriteIntentReadAction`, so the EDT already held a `WriteIntent` permit; `NestedLocksThreadingSupport.runReadAction` takes a read permit only when the thread holds none, so the permit stayed `WriteIntent` and the later `runWriteIntentReadAction` was a no-op.

That wrapping was removed under [IJPL-219144](https://youtrack.jetbrains.com/issue/IJPL-219144) — [`0c5b1bd`](https://github.com/JetBrains/intellij-community/commit/0c5b1bdceb0699aca6f709abb768085df1eb9232) flipped `idea.wrap.high.level.input.events.in.write.intent` to `false`, which ships in 2026.1 and is absent from the 252 branch. With no write-intent lock on the EDT, MPS's read action becomes the outermost permit and the platform refuses to upgrade it.

Note the `ReadPermit` check itself is not new — the deleted `AnyThreadWriteThreadingSupport` raised the same error. What changed is only where the EDT's permit comes from.

## The change

`CustomTreeNode.queryAndLoadChildren` now dispatches only when it actually has to:

```java
final list<ViewElement> queryResult = queryChildElements();
if (ThreadUtils.isInEDT()) {
  if (isInTree()) {
    loadChildElements(queryResult);
  }
} else {
  ThreadUtils.runInUIThreadAndWait({ =>
    if (isInTree()) {
      loadChildElements(queryResult);
    }
  });
}
```

- The synchronous branch (`load children async: false`, the default) is already on the EDT, so it updates the tree directly — no lock upgrade, no exception.
- The async branch (`doInit` → `executeOnPooledThread`) is off the EDT with no read action held, so `runInUIThreadAndWait` is still correct and still used there.
- `loadChildElements` opens its own `execute lightweight command`, which is a *read* action, so nesting it inside the outer model read is fine.

## Notes for the reviewer

- This is the only `invokeAndWait` / `runInUIThreadAndWait` in the `com.mbeddr.mpsutil.projectview*` models — I checked every `IMethodCall` in them. `CustomTreeNodesUpdater.update` uses `runInUIThreadNoWait`, which already runs inline when in the EDT.
- Built clean: 0 errors, 0 warnings.
- Not verified against a live custom project view — I have no reproducer project for #1847, so a manual check by someone who does would be welcome.
- As a stopgap for anyone on an unpatched build, `-Didea.wrap.high.level.input.events.in.write.intent=true` restores the old dispatch, but the flag is `@ApiStatus.Internal` and clearly on its way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
