### PR TITLE
fix(richtext): new Word instances are initialzed with an empty string…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is *loosely* based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) .The project does *not* follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## August 2026
+
+### Fixed
+
+- *de.slisson.mps.richtext* Word instances were initialized with a single space. Restored previous behavior of initializing them with an empty string.
+
 ## July 2026
 
 ### Fixed

--- a/code/richtext/languages/richtext/languageModels/behavior.mps
+++ b/code/richtext/languages/richtext/languageModels/behavior.mps
@@ -1461,21 +1461,7 @@
       </node>
     </node>
     <node concept="13hLZK" id="2dWzqxECGL6" role="13h7CW">
-      <node concept="3clFbS" id="2dWzqxECGL7" role="2VODD2">
-        <node concept="3clFbF" id="2J_r35sReb7" role="3cqZAp">
-          <node concept="37vLTI" id="2J_r35sRfa4" role="3clFbG">
-            <node concept="Xl_RD" id="2J_r35sRfb0" role="37vLTx">
-              <property role="Xl_RC" value=" " />
-            </node>
-            <node concept="2OqwBi" id="2J_r35sReml" role="37vLTJ">
-              <node concept="13iPFW" id="2J_r35sReb6" role="2Oq$k0" />
-              <node concept="3TrcHB" id="2J_r35sReCT" role="2OqNvi">
-                <ref role="3TsBF5" to="87nw:2dWzqxEBMSe" resolve="escapedValue" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
+      <node concept="3clFbS" id="2dWzqxECGL7" role="2VODD2" />
     </node>
   </node>
   <node concept="13h7C7" id="4Lll81Ty9op">

--- a/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
+++ b/code/solutions/de.itemis.mps.extensions.changelog/models/de.itemis.mps.extensions.changelog.mps
@@ -237,6 +237,78 @@
         </node>
       </node>
     </node>
+    <node concept="15bmVD" id="5$8py1vDzrN" role="15bmVC">
+      <node concept="15ShDW" id="5$8py1vDzrK" role="15bq2Y">
+        <property role="15ShDY" value="Po4Z58IgAR/August" />
+        <property role="15ShDw" value="2026" />
+      </node>
+      <node concept="15bAme" id="5$8py1vDzrL" role="15bAlL">
+        <node concept="2DRihI" id="5$8py1vDzrM" role="15bAlk">
+          <node concept="15Ami3" id="5$8py1vDzsi" role="1PaTwD">
+            <node concept="37shsh" id="5$8py1vDzsj" role="15Aodc">
+              <node concept="1dCxOk" id="5$8py1vDzsG" role="37shsm">
+                <property role="1XweGW" value="92d2ea16-5a42-4fdf-a676-c7604efe3504" />
+                <property role="1XxBO9" value="de.slisson.mps.richtext" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzBc" role="1PaTwD">
+            <property role="3oM_SC" value="Word" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzCx" role="1PaTwD">
+            <property role="3oM_SC" value="instances" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzCG" role="1PaTwD">
+            <property role="3oM_SC" value="were" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzCR" role="1PaTwD">
+            <property role="3oM_SC" value="initialized" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzD2" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzDd" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzDe" role="1PaTwD">
+            <property role="3oM_SC" value="single" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzDp" role="1PaTwD">
+            <property role="3oM_SC" value="space." />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzCm" role="1PaTwD">
+            <property role="3oM_SC" value="Restored" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzBx" role="1PaTwD">
+            <property role="3oM_SC" value="previous" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzEm" role="1PaTwD">
+            <property role="3oM_SC" value="behavior" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzET" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzEU" role="1PaTwD">
+            <property role="3oM_SC" value="initializing" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzFf" role="1PaTwD">
+            <property role="3oM_SC" value="them" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzFg" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzFr" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzFs" role="1PaTwD">
+            <property role="3oM_SC" value="empty" />
+          </node>
+          <node concept="3oM_SD" id="5$8py1vDzFB" role="1PaTwD">
+            <property role="3oM_SC" value="string." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="15bmVD" id="1G9SdpwmZ3D" role="15bmVC">
       <node concept="15ShDW" id="1G9SdpwmZ3A" role="15bq2Y">
         <property role="15ShDY" value="Po4Z58IgAJ/July" />


### PR DESCRIPTION
… again instead of a space

9dc8b0219b9ffa919986f16ce333888d0a879717 changed the constructor of Word to initialize the text with a single space. The commit messages is about the a different change and there is no reasoning anywhere for this change. https://github.com/JetBrains/MPS-extensions/pull/805 has only a title "Richtext improvements" and no description.

If this is supposed to be an improvement then it's too broad and should be done somewhere else. 00447ba0342d0ac5f216f49495375d0c81ae157a even had to work around this unjustified change of behavior. In a customer project tests are failing because every new Text is now initialized with a single space instead of being empty.

Reverted this change since there is no reason given for it and there are no tests that demonstrate the intended "improvement".