### PR TITLE
docs: fix typos and copy-paste errors in the extension documentation

### DIFF
--- a/docs/extensions/editor/celllayout.md
+++ b/docs/extensions/editor/celllayout.md
@@ -60,7 +60,7 @@ installed recursively when any style property of the language is used.
 
 ### Grow and Push
 
-- **grow-x** is a flag that tells the layouter to grow the cell to the with of the parent.
+- **grow-x** is a flag that tells the layouter to grow the cell to the width of the parent.
 - **push-x** is a property that has the same effect as setting `grow-x` on the cell and all ancestor cells.
 - **grow-y** is a flag that tells the layouter to grow the cell to the height of the parent.
 - **push-y** is a property that has the same effect as setting `grow-y` on the cell and all ancestor cells.

--- a/docs/extensions/editor/grammar-cells.md
+++ b/docs/extensions/editor/grammar-cells.md
@@ -52,7 +52,7 @@ A cell that supports entering an optional text to add an optional containment li
 ## grammar.wrap
 
 A cell that lets you enter a child in a context where a parent is expected (e.g. enter the type of a 
- variable declaration to create the declaration itself). The editor cell of th child is wrapped and the instantiation of the
+ variable declaration to create the declaration itself). The editor cell of the child is wrapped and the instantiation of the
  child is triggered. It can be used for containment links of children with mandatory (1) or optional (0..1) cardinality.
 
 ### Supported properties (side transformations)

--- a/docs/extensions/editor/math.md
+++ b/docs/extensions/editor/math.md
@@ -9,7 +9,7 @@ layout that can't be achieved with the normal Editor cells.
 
 <img alt="example:math notation" src="../../img/math.png" />
 
-First you have to add some child cells. The need to have a name and a scale from 0 to 1. Next, some symbols can be added.
+First you have to add some child cells. They need to have a name and a scale from 0 to 1. Next, some symbols can be added.
 A symbol is a node that basically contains a paint method where you can draw anything within the bounds. The paint method
 uses a swing Graphics object to draw on.
 For more information about Swing,
@@ -40,8 +40,8 @@ symbol ArrowLeft {
 }
 ```
 
-After settings some variables and initializing the cell in the `init` method, the cells have to be placed in the
-`layout` method. The dimensions of the child cells should fit into the bounds of the math cells. The `paint`method
+After setting some variables and initializing the cell in the `init` method, the cells have to be placed in the
+`layout` method. The dimensions of the child cells should fit into the bounds of the math cells. The `paint` method
 can be used. The `getCenterY` method should specify the vertical center of the math cell.
 
 Example: generator for an editor of a fraction expression:
@@ -108,9 +108,9 @@ This language implements standard math cells that can be used in any editor:
   - **math.sqrt**: cell for root expressions 
 - **math.superscript**: cell for superscript text, also known as exponential expression in math: 2^3
 - **math.subscript**: cell for subscript text
-- **math.product**: cell for the math [sigma notation](https://mathmaine.com/2018/03/04/pi-notation/)
+- **math.product**: cell for the math [pi notation](https://mathmaine.com/2018/03/04/pi-notation/)
 - **math.subscripted-function**: cell for functions that have a subscripted text (e.g. logN)
-- **math.sum**: cell for the math [pi notation](https://mathmaine.com/2018/03/04/pi-notation/)
+- **math.sum**: cell for the math [sigma notation](https://mathmaine.com/2018/03/04/sigma-notation/)
 
 ## Java Math
 

--- a/docs/extensions/editor/richtext.md
+++ b/docs/extensions/editor/richtext.md
@@ -4,7 +4,7 @@
 
 This language adds support for non-structured, multi-line text editing cells. Nodes can be embedded inside the text.
 A checking rule enforces that the text is normalized: there has to be at least one child, it must start with a Word and
-a Word must always be between two embedded nodes and there are can't be two consecutive Words.
+a Word must always be between two embedded nodes and there can't be two consecutive Words.
 There is also the language `jetbrains.mps.lang.text` which is an official JetBrains language and works a bit differently.
 It is line-based and has built-in support for paragraphs, bullet points, urls and other features. The richtext language uses
 the multiline language to allow editing of multiline text with nodes that can be inserted between these text cells. The

--- a/docs/extensions/editor/tables.md
+++ b/docs/extensions/editor/tables.md
@@ -16,7 +16,7 @@ be done in other editors by using the `partial table` cell.
  for example, to set some additional cells, or add some dynamic row or column headers.
 - **disable left row end cells**: there's a special cell to the left of table rows that's used, for example, for inserting
  new table rows. This flag can disable this cell (default: *false*).
-- **disable right row end cells**: there's a special cell to the left of table rows that's used, for example, for inserting
+- **disable right row end cells**: there's a special cell to the right of table rows that's used, for example, for inserting
     new table rows. This flag can disable this cell (default: *false*).
 - **row UI actions (experimental)**: add actions to the MPS toolbar to add a new row above/below the current row or to delete the current row. These actions only work for simple tables that are based on rows (default: *false*).
 
@@ -38,7 +38,7 @@ A table cell query is the easiest way to create a full table.
 ### Supported parameters
 
 - **shared variables**: variables that can be accessed by the other parameters
-- **initialize**: a function that initialized the shared variables or other code
+- **initialize**: a function that initializes the shared variables or other code
 - **column count**: the number of columns to display
 - **row count**: the number of rows to display
 - **cell**: a function that creates the cell itself. Cells can be created automatically by providing a node or a string 
@@ -55,7 +55,7 @@ If you want to create a cell dynamically and want to use the normal editors for 
 
 ## Grid query
 
-The grid query is an even lower level form of declaration a table. It works by setting the cells directely in the grid
+The grid query is an even lower level form of declaring a table. It works by setting the cells directly in the grid
 object of type `ITableGrid`. There are various set methods that can be used to create the table such as `grid.setCell()`
  or `grid.setColumnHeader`. To support code completion, the substitution info must be set by calling `grid.setSubstituteInfo`
 for every cell by using its column and row index as a substitute info node as parameters. The substitute info node can

--- a/docs/extensions/utils/model-merger.md
+++ b/docs/extensions/utils/model-merger.md
@@ -22,16 +22,16 @@ To get started:
 ## Creating merging policies
 
 Create a new root node of concept [ModelMergingPolicy](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F1912777765298163335) inside the **plugin** model. The main language has to be defined. If there are additional languages involved, they can be specified as well. Now, merge policies can be defined for different concepts. The concepts need to be identifiable by a unique ID, for example, by an ID property. The scope of the uniqueness property depends on the context where the model merger is used. Normally, it's the project scope but there are cases where the ID needs to be globally unique.
-All concepts defined in those languages used in the merging policy shall have a `ConceptMergingPolicy` defined in the `ModelMergingPolicy`. For prototyping purpose or for big languages, there is an option to set the flag `Partial policy` to `true` so that some check for the ModelMerging are relaxed. However models used in the merging shall not contain concepts wihtout policies otherwise an exception will be throw.
+All concepts defined in those languages used in the merging policy shall have a `ConceptMergingPolicy` defined in the `ModelMergingPolicy`. For prototyping purpose or for big languages, there is an option to set the flag `Partial policy` to `true` so that some check for the ModelMerging are relaxed. However models used in the merging shall not contain concepts without policies otherwise an exception will be thrown.
 
-Each `ConceptMergingPolicy` is composed of an identification function and policies for Properties, Children, and Reference, as described bellow.
+Each `ConceptMergingPolicy` is composed of an identification function and policies for Properties, Children, and Reference, as described below.
 
 ### Properties
 
 For properties, three options are possible: 
 
 - **Left**: use the value of the left property, and discard the value of the right property.
-- **Right**: use the value of the right property, and discard the value of the right property.
+- **Right**: use the value of the right property, and discard the value of the left property.
 - **Manual**: a custom merger that must return a value of the same type as the property
 
 ### Children
@@ -62,7 +62,7 @@ For references, three options are possible:
 
 ## Running model merging
 
-The model merge can be executed by creating a [ModelMergingConfiguration](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F6402745832171993510) node in a model with dependencies to the models being merged and mde`de.itemis.model.merge` language. The following parameters must be defined in the configuraiton: 
+The model merge can be executed by creating a [ModelMergingConfiguration](http://127.0.0.1:63320/node?ref=r%3A58892eeb-9059-4684-af0a-e0f5f7f9800d%28de.itemis.model.merge.structure%29%2F6402745832171993510) node in a model with dependencies to the models being merged and the `de.itemis.model.merge` language. The following parameters must be defined in the configuration: 
 
 - **Left**: a model pointer to the first model
 - **Right**: a model pointer to the second model
@@ -71,7 +71,7 @@ The model merge can be executed by creating a [ModelMergingConfiguration](http:/
 - **Merge Policy**: the policy that should be applied to the left and right model
 
 In order to execute the merging one can use the intention `Run Model Merge` or call the `execute` method programmatically.
-Additonaly one can use the [ModelMerger](http://127.0.0.1:63320/node?ref=r%3Aa4055897-4d16-4474-96e9-a78cf2abfe5a%28de.itemis.model.merge.runtime.runtime%29%2F3370123198534290138) directly to control which root-nodes shall be provided for merging. Use the following code snippet for inspiration: 
+Additionally one can use the [ModelMerger](http://127.0.0.1:63320/node?ref=r%3Aa4055897-4d16-4474-96e9-a78cf2abfe5a%28de.itemis.model.merge.runtime.runtime%29%2F3370123198534290138) directly to control which root-nodes shall be provided for merging. Use the following code snippet for inspiration: 
 
 ```java
 private void mergeRoots(concept<> usingConcept)  { 

--- a/docs/extensions/utils/node-versioning.md
+++ b/docs/extensions/utils/node-versioning.md
@@ -3,13 +3,13 @@
 
 The node versioning extension gives support for storing different *states/versions* of a node inside of the model. It is **not** a replacement for version control systems like `git`.
 
-An example use case might be a model is used to describe an API and the users wants to detect changes between different releases of the API. This API has a version number that follows semVer associated with it. Now when users wants check what changes happened since the last release the information stored by this extension can be used to diff the current state against the last released one.
+An example use case might be a model is used to describe an API and the users want to detect changes between different releases of the API. This API has a version number that follows semVer associated with it. Now when users want to check what changes happened since the last release the information stored by this extension can be used to diff the current state against the last released one.
 
 The scope of this extension is to provide a way to store the versions of a node and do change detection. It does intentionally not provide ways how to semantically reason about a change as this is highly domain specific. It might be used in conjunction with the `nodecomparator` to do structural diffs between versions.
 
 State: *Incubating* 
 
-This extension is currently incubating and might under go substantial changes in the future. Currently it only supports storing of the version information and change detection. For future feature ideas see the [potential features](#potential-features) section.
+This extension is currently incubating and might undergo substantial changes in the future. Currently it only supports storing of the version information and change detection. For future feature ideas see the [potential features](#potential-features) section.
 
 ### What is a *Node* 
 When we speak of a node in this document we mean the node and **all** of its children but not of the referenced nodes. Sometimes this is also called *subtree*.


### PR DESCRIPTION
## Summary

Fix 20 typos, grammar slips and copy-paste errors in the extension documentation under `docs/`. Documentation only - no code or MPS models touched.

**docs/extensions/editor/tables.md**
- `- **disable right row end cells**: there's a special cell to the left of table rows` -> `to the right of table rows` (copy-paste from the "disable left row end cells" bullet directly above)
- `a function that initialized the shared variables` -> `initializes`
- `an even lower level form of declaration a table` -> `declaring a table`
- `setting the cells directely in the grid` -> `directly`

**docs/extensions/editor/math.md**
- `First you have to add some child cells. The need to have a name` -> `They need to have a name`
- `After settings some variables` -> `After setting`
- ``The `paint`method`` -> ``The `paint` method``
- `math.sum` and `math.product` had their link labels swapped: `math.product` now points at **pi notation** and `math.sum` at **sigma notation**. `math.sum` also had its URL corrected to `.../sigma-notation/` (verified 200) since it previously pointed at the pi-notation article.

**docs/extensions/editor/grammar-cells.md**
- `The editor cell of th child` -> `of the child`

**docs/extensions/editor/celllayout.md**
- `grow the cell to the with of the parent` -> `to the width of the parent`

**docs/extensions/editor/richtext.md**
- `there are can't be two consecutive Words` -> `there can't be`

**docs/extensions/utils/model-merger.md**
- `concepts wihtout policies otherwise an exception will be throw` -> `without policies ... will be thrown`
- `as described bellow` -> `as described below`
- `- **Right**: use the value of the right property, and discard the value of the right property.` -> `discard the value of the left property` (the Children and Reference sections below already use the correct left/right pattern)
- `and mde\`de.itemis.model.merge\` language` -> ``and the `de.itemis.model.merge` language``
- `defined in the configuraiton` -> `configuration`
- `Additonaly one can use` -> `Additionally`

**docs/extensions/utils/node-versioning.md**
- `the users wants to detect changes` -> `the users want`; `Now when users wants check` -> `Now when users want to check`
- `might under go substantial changes` -> `undergo`

### Deliberately not changed (verified, not typos)

- `README.md`: `Mbeddr2_Mbeddr_Gradle_MpsExtenstions` looks like a misspelling but it is the **real TeamCity build configuration id**. Requesting the status icon for that id returns a live build status, while the "corrected" spelling returns *no permission to get data*. Fixing it would break the badge.
- `math.md`: `side-tranformation-helper-cells` is the literal cell name in `code/math/languages/de.itemis.mps.editor.math/languageModels/editor.mps`, so the docs are correctly quoting the identifier.
- `node-versioning.md`: `` `nodecomparator` `` is left as-is - it reads as a reference to the comparator extension rather than prose.

### One thing you may want to look at

`docs/extensions/editor/celllayout.md` ends mid-sentence: the file's last line is *"...it is very likely that"* with nothing after it. It was left untouched because completing it would mean inventing content, but it looks like text was lost.